### PR TITLE
Add interactive codebase courses (general + image-generator/UI focus)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ supabase
 .dev.vars*
 .source
 .env
+._*

--- a/courses/general-course/_base.html
+++ b/courses/general-course/_base.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Inside a Real AI App</title>
+
+  <!-- Google Fonts: Bricolage Grotesque · DM Sans · JetBrains Mono -->
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:opsz,wght@12..96,400;12..96,600;12..96,700;12..96,800&family=DM+Sans:ital,opsz,wght@0,9..40,300;0,9..40,400;0,9..40,500;0,9..40,600;0,9..40,700;1,9..40,400;1,9..40,500&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+
+  <link rel="stylesheet" href="styles.css">
+
+  <!--
+    CUSTOMIZE PER COURSE — change only the three accent variables below.
+    Options:
+      vermillion  #D94F30 / #C4432A / #FDEEE9 / #E8836C  (default)
+      coral       #E06B56 / #C85A47 / #FDECEA / #E89585
+      teal        #2A7B9B / #1F6280 / #E4F2F7 / #5A9DB8
+      amber       #D4A843 / #BF9530 / #FDF5E0 / #E0C070
+      forest      #2D8B55 / #226B41 / #E8F5EE / #5AAD7A
+  -->
+  <style>
+    :root {
+      --color-accent:       #D94F30;
+      --color-accent-hover: #C4432A;
+      --color-accent-light: #FDEEE9;
+      --color-accent-muted: #E8836C;
+    }
+  </style>
+
+  <script src="main.js" defer></script>
+</head>
+<body>
+
+  <nav class="nav" id="nav">
+    <div class="progress-bar" id="progress-bar" role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100"></div>
+    <div class="nav-inner">
+      <span class="nav-title">Inside a Real AI App</span>
+      <div class="nav-dots" id="nav-dots" role="tablist">
+        <button class="nav-dot" data-target="module-1" data-tooltip="What Happens When You Click Generate" role="tab" aria-label="Module 1: What Happens When You Click Generate"></button>
+        <button class="nav-dot" data-target="module-2" data-tooltip="Meet the Cast" role="tab" aria-label="Module 2: Meet the Cast"></button>
+        <button class="nav-dot" data-target="module-3" data-tooltip="Who Are You?" role="tab" aria-label="Module 3: Who Are You?"></button>
+        <button class="nav-dot" data-target="module-4" data-tooltip="Following the Money" role="tab" aria-label="Module 4: Following the Money"></button>
+        <button class="nav-dot" data-target="module-5" data-tooltip="Memory and the Outside World" role="tab" aria-label="Module 5: Memory and the Outside World"></button>
+        <button class="nav-dot" data-target="module-6" data-tooltip="Every Language, Every Screen" role="tab" aria-label="Module 6: Every Language, Every Screen"></button>
+        <button class="nav-dot" data-target="module-7" data-tooltip="When It Breaks" role="tab" aria-label="Module 7: When It Breaks"></button>
+      </div>
+    </div>
+  </nav>
+
+  <main id="main">
+    <!-- modules/*.html content is assembled here by build.sh -->

--- a/courses/general-course/_footer.html
+++ b/courses/general-course/_footer.html
@@ -1,0 +1,4 @@
+  </main>
+
+</body>
+</html>

--- a/courses/general-course/briefs/01-the-click.md
+++ b/courses/general-course/briefs/01-the-click.md
@@ -1,0 +1,248 @@
+# Module 1: What Happens When You Click "Generate"
+
+> You are writing ONE module of a 7-module course about a real, live web app.
+> The app: **charlieandlola.net** — you upload a selfie, it turns it into a Charlie & Lola
+> children's-cartoon-style character using Google's Gemini AI. It's a real business:
+> free to try, sign in to download, buy credits for more.
+> Repo name in package.json: `charlie-and-lola-style-converter`, version 2.6.0.
+
+### Teaching Arc
+
+- **Metaphor:** **The one-hour photo lab drop-off envelope.** You slide your film into a paper
+  envelope, write your name and "matte finish, 4x6" on the outside, and post it through a slot
+  in the wall. You cannot see what happens back there. Someone develops it, someone files a copy,
+  and later an envelope of prints comes back out. The *envelope with the options written on it*
+  is the request. The slot in the wall is the API endpoint. The lab out back is the server.
+  Use this metaphor throughout — the "envelope", the "slot", the "back room", the "prints".
+- **Opening hook:** "You pick a photo of yourself, hit Generate, watch a spinner for about ten
+  seconds, and a cartoon version of you appears. Those ten seconds are the whole course in
+  miniature. Let's slow them down."
+- **Key insight:** Your browser and the server are two separate computers that can only pass
+  each other **messages**. Everything an app does is: package a message, send it, wait, unpack
+  the reply. The "magic" is just a very well-organized relay of messages.
+- **"Why should I care?":** When something in your app doesn't work, the very first useful
+  question is *"how far did the message get?"* Did it leave the browser? Did the server receive
+  it? Did the AI company answer? Being able to point at a step is the difference between
+  "it's broken, fix it" (which sends AI in circles) and "the request reaches the server but the
+  reply has no image in it" (which gets it fixed in one shot).
+
+### The Actual 7 Steps (this is the spine of the module)
+
+1. **You drop a photo in.** The browser turns the file into a long text string (base64) and keeps
+   it in memory + `localStorage`.
+2. **You click Generate.** The browser packs a `FormData` envelope: the image plus the options
+   (style, aspect ratio, output format).
+3. **`fetch('/api/generate-cyberpunk')`** — the envelope goes through the slot.
+4. **The server unpacks and checks it.** Valid aspect ratio? Is there an image? Under 10MB? Are you
+   signed in, and if so do you have ≥10 credits? Is an AI key free right now?
+5. **The server calls Google Gemini** with the prompt + your image bytes, and waits.
+6. **The reply comes back as raw image data.** The server uploads it to cloud storage (Cloudflare R2)
+   and gets a URL. If storage isn't configured, it falls back to embedding the whole image in the reply.
+7. **The server sends back one JSON object.** The browser reads `result.data.imageUrl`, sets it in
+   React state, and the picture appears. A little toast pops up.
+
+### Code Snippets (pre-extracted — use verbatim, do not edit)
+
+**Snippet A — the browser packs the envelope.**
+File: `src/components/blocks/imagen-wrapper/imagen-client.tsx` (lines 334–357)
+
+```js
+      const formData = new FormData();
+
+      formData.append('mode', 'image2image');
+      formData.append('style', 'charlie-lola'); // Fixed style for Charlie and Lola
+      formData.append('aspectRatio', aspectRatio);
+      formData.append('outputFormat', outputFormat);
+      formData.append('model', 'standard'); // Fixed model
+
+      if (customPrompt.trim()) {
+        formData.append('customPrompt', customPrompt);
+      }
+
+      for (let i = 0; i < uploadedImages.length; i++) {
+        const response = await fetch(uploadedImages[i]);
+        const blob = await response.blob();
+        formData.append(`image_${i}`, blob);
+      }
+
+      formData.append('imageCount', uploadedImages.length.toString());
+
+      const apiResponse = await fetch('/api/generate-cyberpunk', {
+        method: 'POST',
+        body: formData,
+      });
+```
+
+**Snippet B — the server unpacks the envelope.**
+File: `src/app/api/generate-cyberpunk/route.ts` (lines 9–18)
+
+```ts
+export async function POST(request: Request) {
+  try {
+    const formData = await request.formData();
+    const style = formData.get('style') as string || 'charlie-lola';
+    const mode = formData.get('mode') as string || 'image2image'; // Charlie and Lola style transformation
+    const customPrompt = formData.get('customPrompt') as string || '';
+    const aspectRatio = formData.get('aspectRatio') as string || '4:3';
+    const outputFormat = formData.get('outputFormat') as string || 'png';
+    const model = formData.get('model') as string || 'standard';
+    const imageCount = parseInt(formData.get('imageCount') as string || '0');
+```
+
+**Snippet C — the actual instruction sent to the AI (the prompt).**
+File: `src/app/api/generate-cyberpunk/route.ts` (lines 121–139)
+
+```ts
+    const imageEditPrompt = [
+      { text: charlieLolaPrompt },
+      {
+        inlineData: {
+          mimeType: mimeType,
+          data: base64Image,
+        },
+      },
+    ];
+
+    console.log("🔄 Generating Charlie and Lola style image...");
+
+    let response;
+    try {
+      // Generate edited image using Gemini 2.5 Flash Image Preview
+      response = await ai.models.generateContent({
+        model: "gemini-2.5-flash-image-preview",
+        contents: imageEditPrompt,
+      });
+```
+
+**Snippet D — the reply the browser gets back.**
+File: `src/app/api/generate-cyberpunk/route.ts` (lines 236–250)
+
+```ts
+    return respData({
+      imageUrl: responseImageUrl,
+      filename: storedFilename,
+      message: "Charlie and Lola style transformation completed successfully",
+      provider: "google.gemini",
+      model: "gemini-2.5-flash-image-preview",
+      creditsUsed: isRegisteredUser ? requiredCredits : 0,
+      aspectRatio,
+      outputFormat: fileExtension,
+      style: style,
+      storedLocally: hasStorageConfig && !finalImageUrl.startsWith('data:'),
+      requiresRegistration,
+      isPreview: !isRegisteredUser,
+      downloadUrl: isRegisteredUser ? responseImageUrl : null,
+    });
+```
+
+**Snippet E — the browser unpacks the reply.**
+File: `src/components/blocks/imagen-wrapper/imagen-client.tsx` (lines 363–378)
+
+```js
+      const result = await apiResponse.json();
+
+      if (result.code === 0 && result.data?.imageUrl) {
+        setGeneratedImage(result.data.imageUrl);
+
+        // Handle different response types
+        if (result.data.requiresRegistration && !session) {
+          toast.success("Image generated! Sign in to download full resolution image.");
+        } else if (result.msg === 'QUEUE_REQUIRED') {
+          toast.warning("🚧 Service is busy. You're in the queue. Upgrade to premium to skip the queue!");
+        } else {
+          toast.success(t.messages.success.generated);
+          if (session) {
+            refreshCredits();
+          }
+        }
+```
+
+### Facts You Can Use (all verified in the codebase)
+
+- The endpoint is literally called **`/api/generate-cyberpunk`** even though the app makes
+  Charlie & Lola cartoons. This is a leftover name from an earlier version of the product. It works
+  fine — but it's a great, true, real-world example of how names in code drift away from what the
+  code does. Worth an "aha" callout: *stale names are a normal fact of real codebases, and they're
+  why you should describe behaviour, not filenames, when instructing an AI.*
+- The AI model is `gemini-2.5-flash-image-preview` from Google.
+- The prompt is a long, very specific English paragraph including a "Negative Prompt" section
+  listing what NOT to do: *"No realistic shading, no detailed rendering, no anime or manga style,
+  no 3D modeling, no photographic textures!"* — the prompt is just text in a file. Anyone who can
+  edit that string can change the entire product. Good "aha" moment.
+- Uploaded images are capped at 5, and each must be under 10MB.
+- The reply is always shaped `{ code, message, data }` — `code: 0` means OK, `code: -1` means error.
+  This is a house convention defined in `src/lib/resp.ts`, not a web standard.
+
+### Interactive Elements (all required)
+
+- [x] **Code↔English translation** — Snippet A (browser packs envelope) and Snippet D or E
+      (the reply). At least two translation blocks in this module.
+- [x] **Data flow animation** — THE hero visual of this module. Actors, in order:
+      `Browser` → `API Route` → `Gemini AI` → `Cloud Storage` → `Browser`.
+      Steps: (1) Browser packs photo + options into FormData. (2) POST to /api/generate-cyberpunk.
+      (3) Server validates: aspect ratio, image present, size under 10MB, credits, free API key.
+      (4) Server sends prompt + image bytes to Gemini. (5) Gemini returns raw image data.
+      (6) Server uploads it to Cloudflare R2 and gets a URL back. (7) Server returns JSON with
+      `imageUrl`. (8) Browser puts the URL in an `<img>` and shows a toast.
+- [x] **Group chat animation** — a short one, three participants: **Browser**, **Server**,
+      **Gemini**. Give them personality. Browser: "Here's a photo and some options, make it
+      Charlie & Lola." Server: "Hold on — aspect ratio valid? image present? under 10MB? ok."
+      Server → Gemini: "Turn this person into a Charlie & Lola character. No 3D, no anime, no
+      photographic textures." Gemini: "...done, here's the raw pixels." Server: "Filing a copy in
+      storage. Here's your URL." Browser: "🎉". (The course needs at least one group chat overall;
+      Modules 1 and 4 both have one, which is good.)
+- [x] **Quiz** — 3 questions at the end, all scenario/debugging style:
+      1. A user says "I clicked Generate and nothing happened — the spinner just spins forever."
+         Where do you look FIRST, and why? (Options: rewrite the AI prompt / check whether the
+         request left the browser and what the server replied / change the button colour /
+         reinstall the app.) Correct: check the message journey — open the browser's Network tab
+         and see how far the envelope got.
+      2. You want to change the cartoon style so characters keep a *background* instead of a
+         transparent one. What actually has to change? (Correct: the prompt text — it's just an
+         English string in the API route. Wrong options teach that you don't need a new AI model
+         or a database change.)
+      3. Guests see the generated image but the download button asks them to sign in. Based on
+         the JSON reply, which field is the app checking? (Correct: `requiresRegistration` /
+         `downloadUrl` being null for guests.)
+- [x] **Glossary tooltips** — be aggressive. Tooltip at minimum: API, endpoint, request, response,
+      server, client/browser, JSON, base64, FormData, `fetch`, POST, state, React, prompt,
+      validate, MB, upload, URL, toast, cloud storage, model (AI sense), localStorage.
+- [x] **Callout boxes** — one "aha" on *the whole internet is just request → response*, and one on
+      *the endpoint name lies (generate-cyberpunk) — describe behaviour, not filenames, to AI*.
+
+### Screens (aim for 5)
+
+1. **What this app even is** — one short paragraph + an icon-label row or feature cards:
+   upload a photo → get a cartoon; free to try; sign in to download; credits to keep going.
+   Include what makes it *technically* interesting: it's a full commercial product — payments,
+   accounts, two languages, an AI model — in about 330 TypeScript files.
+2. **The photo lab metaphor** — set it up visually (numbered step cards or a flow diagram).
+3. **The envelope** — Snippet A as a code↔English block. One idea: a request is data + options.
+4. **The back room** — Snippet B, C. The prompt reveal. Then the flow animation as hero visual.
+5. **The prints come back** — Snippet D/E, the group chat, then the quiz.
+
+### Reference Files to Read
+
+- `references/content-philosophy.md` — all of it.
+- `references/gotchas.md` — all of it.
+- `references/interactive-elements.md` → "Code ↔ English Translation Blocks", "Multiple-Choice
+  Quizzes", "Group Chat Animation", "Message Flow / Data Flow Animation", "Callout Boxes",
+  "Numbered Step Cards", "Glossary Tooltips", "Icon-Label Rows".
+- `references/design-system.md` → "Module Structure", "Color Palette", "Typography".
+
+### Connections
+
+- **Previous module:** none — this is the opening. Open by explaining what the app does in plain
+  language before anything technical.
+- **Next module: "Meet the Cast"** — end by pointing forward: "We just watched a message travel
+  through five different pieces of code without ever asking *who* those pieces are, or why the
+  code is split up the way it is. That's next."
+- **Tone/style notes:** Accent colour is **vermillion** (`--color-accent`, a warm red-orange).
+  Warm developer-notebook feel. Zero jargon without a tooltip. Second person ("you"). Never say
+  "as you probably know". The learner is a "vibe coder" — they build software by instructing AI,
+  and have no CS background. Never use a restaurant/kitchen metaphor anywhere.
+  Actor naming convention used across the whole course: **Browser**, **Server**, **Gemini**,
+  **Database**, **Stripe**, **Storage** — capitalised, used consistently in every animation.
+  Your file must contain ONLY `<section class="module" id="module-1"> ... </section>` — no
+  `<html>`, `<head>`, `<body>`, `<style>` or `<script>` tags. Write it to
+  `courses/general-course/modules/01-the-click.html`.

--- a/courses/general-course/briefs/02-meet-the-cast.md
+++ b/courses/general-course/briefs/02-meet-the-cast.md
@@ -1,0 +1,237 @@
+# Module 2: Meet the Cast — How the Code Is Organised
+
+> You are writing ONE module of a 7-module course about a real, live web app.
+> The app: **charlieandlola.net** — you upload a selfie, it turns it into a Charlie & Lola
+> children's-cartoon-style character using Google's Gemini AI. Free to try, sign in to
+> download, buy credits for more. Built with Next.js 15 and TypeScript, ~330 code files.
+
+### Teaching Arc
+
+- **Metaphor:** **A film production.** The **cast** are the parts you see on screen (the buttons,
+  the upload box, the preview panel — the React components). The **crew** work behind the camera
+  and never appear in the shot (the server code — API routes, services, models). The **props
+  department** keeps a shelf of generic, reusable objects that any scene can borrow — a chair, a
+  mug, a lamp (the `ui/` folder: buttons, cards, dialogs). And there is a strict **chain of
+  command**: an actor doesn't wander into the accounts office to rewrite the budget; requests go
+  up the chain in order. Use "cast / crew / props / chain of command" throughout.
+- **Opening hook:** "In Module 1 a message travelled through five different pieces of code. Nobody
+  introduced them. Let's meet the cast — because the single most useful thing you can tell an AI
+  coding assistant is *where* a change belongs."
+- **Key insight:** This codebase is organised in **layers**, and each layer is only allowed to talk
+  to the one below it. Route → Service → Model → Database. Nobody skips a step. Layers exist so
+  that a rule (like "10 credits per image") is written down in exactly one place.
+- **"Why should I care?":** When you tell an AI "add a rule that Pro users get 3 free generations
+  a day", it has to put that rule *somewhere*. If it puts it in a button, you'll have the rule in
+  five places and four of them will be wrong within a month. Knowing the layers lets you say
+  "put that in the credit service, not in the component" — and that one sentence is often the
+  difference between a codebase that survives a year and one that doesn't.
+
+### The Map (this is the spine of the module)
+
+The real top-level structure of `src/`:
+
+| Folder | Who they are | What lives there |
+|---|---|---|
+| `src/app/` | **The stage** | Every page and every API endpoint. The folder path *is* the URL. |
+| `src/components/blocks/` | **The cast** | Big page sections: `hero`, `pricing`, `faq`, `footer`, `imagen-wrapper`. |
+| `src/components/ui/` | **The props department** | 37 small generic pieces: `button.tsx`, `card.tsx`, `dialog.tsx`, `tabs.tsx`. |
+| `src/services/` | **The crew chiefs** | Business rules: `credit.ts`, `order.ts`, `user.ts`, `stripe.ts`, `affiliate.ts`. |
+| `src/models/` | **The records office** | The only files allowed to touch the database: `user.ts`, `credit.ts`, `order.ts`, `post.ts`. |
+| `src/db/` | **The filing cabinet itself** | `schema.ts` (table shapes) + `index.ts` (the connection). |
+| `src/auth/` | **Security** | Who you are (covered in Module 3). |
+| `src/i18n/` | **Translation department** | English and Chinese text (Module 6). |
+| `src/lib/` | **The toolbox** | Small helpers used by everyone: `hash.ts`, `time.ts`, `resp.ts`, `storage.ts`. |
+| `src/aisdk/` | **The specialist rig** | A hand-built adapter for the Kling video-generation service. |
+
+**The routing trick worth its own screen:** in Next.js, folders under `src/app/` literally become
+web addresses. `src/app/[locale]/(default)/pricing/page.tsx` becomes `charlieandlola.net/en/pricing`.
+`src/app/api/checkout/route.ts` becomes `charlieandlola.net/api/checkout`. Two special notations:
+- `[locale]` — square brackets mean "anything goes here, and tell me what it was". That's how
+  `/en/pricing` and `/zh/pricing` are the same file.
+- `(default)`, `(admin)`, `(console)` — round brackets mean "this folder is for *organising* only,
+  it does NOT appear in the URL". `(admin)/admin/orders/page.tsx` is just `/admin/orders`.
+This is a genuinely confusing convention and worth a visual file tree.
+
+### The Other Big Divide: Server vs Client
+
+Some components run on the company's server before the page is even sent to you. Others run in
+your browser. The line is drawn by one line of text at the top of a file: `'use client'`.
+The clearest example in this codebase is a matched pair:
+
+- `imagen-wrapper/index.tsx` — **server**. It looks up the translated text and hands it down.
+- `imagen-wrapper/imagen-client.tsx` — **client**, marked `'use client'`. It handles clicks,
+  drag-and-drop, spinners — anything that reacts to a human.
+
+Why split? Server components can read secrets and databases; client components can't (anything in
+the browser can be read by the user). Client components can respond to clicks; server components
+can't. So this pair is a hand-off: server fetches, client interacts.
+
+### Code Snippets (pre-extracted — use verbatim, do not edit)
+
+**Snippet A — the chain of command, in three files.** Show these three as a stacked
+"route → service → model" sequence. This is the module's centrepiece.
+
+*Layer 1 — the route (takes the request, returns a reply). File: `src/app/api/generate-cyberpunk/route.ts` (lines 51–61)*
+
+```ts
+    // Get user info
+    const userUuid = await getUserUuid();
+    const isRegisteredUser = !!userUuid;
+
+    // Check credits for registered users
+    if (isRegisteredUser) {
+      const userCredits = await getUserCredits(userUuid);
+      if (userCredits.left_credits < CreditsAmount.ImageGeneration) {
+        return respErr(`Insufficient credits. You need ${CreditsAmount.ImageGeneration} credits but only have ${userCredits.left_credits}. Please recharge to continue.`, 'INSUFFICIENT_CREDITS');
+      }
+    }
+```
+
+*Layer 2 — the service (knows the business rules). File: `src/services/credit.ts` (lines 22–26)*
+
+```ts
+export enum CreditsAmount {
+  NewUserGet = 30,
+  PingCost = 1,
+  ImageGeneration = 10,
+}
+```
+
+*Layer 3 — the model (the only code that touches the database). File: `src/models/credit.ts` (lines 62–72)*
+
+```ts
+export async function getAllUserCredits(
+  user_uuid: string
+): Promise<(typeof credits.$inferSelect)[] | undefined> {
+  const data = await db()
+    .select()
+    .from(credits)
+    .where(eq(credits.user_uuid, user_uuid))
+    .orderBy(asc(credits.created_at));
+
+  return data;
+}
+```
+
+**Snippet B — the server half of the hand-off.**
+File: `src/components/blocks/imagen-wrapper/index.tsx` (lines 8–18)
+
+```tsx
+export default async function ImagenWrapper({ locale = 'en' }: ImagenWrapperProps = {}) {
+  // Set the request locale for server-side translations
+  setRequestLocale(locale);
+
+  // Get the translations on the server side with explicit locale
+  const t = await getTranslations({ locale, namespace: 'imagen' });
+
+  // Pass translations as props to the client component
+  const translations = {
+    badge: { text: t('badge.text') },
+    title: { main: t('title.main'), subtitle: t('title.subtitle') },
+```
+
+**Snippet C — the client half. Note the very first line.**
+File: `src/components/blocks/imagen-wrapper/imagen-client.tsx` (lines 1–12)
+
+```tsx
+'use client';
+
+import React, { useState, useRef, useEffect } from 'react';
+import { useSession } from 'next-auth/react';
+import { Card, CardContent } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+import { useUserCredits } from '@/hooks/useUserCredits';
+import CreditDisplay from '@/components/blocks/credits-display';
+import { toast } from 'sonner';
+import { convertToCdnUrl } from '@/lib/cdn-url';
+import { useTheme } from '@/contexts/theme-context';
+```
+
+**Snippet D — the landing page as an assembly of cast members.** Notice that the page barely
+contains any content of its own; it's a list of sections, each fed a slice of data.
+File: `src/app/[locale]/(default)/page.tsx` (lines 233–243)
+
+```tsx
+      <ImagenWrapper locale={locale} />
+      {page.introduce && <Feature1 section={page.introduce} />}
+      {page.benefit && <Feature2 section={page.benefit} />}
+      {page.usage && <Feature3 section={page.usage} />}
+      {page.feature && <Feature section={page.feature} />}
+      {page.showcase && <Showcase section={page.showcase} />}
+      {page.stats && <Stats section={page.stats} />}
+      {page.pricing && <Pricing pricing={page.pricing} />}
+      {page.testimonial && <Testimonial section={page.testimonial} />}
+      {page.faq && <FAQ section={page.faq} />}
+      {page.cta && <CTA section={page.cta} />}
+```
+
+The `&&` here means "only draw this section if there's content for it" — the whole landing page
+is switched on and off by a data file. That's worth an "aha": *the page is a template; the content
+is data.* (Module 6 shows where that data lives.)
+
+### Interactive Elements (all required)
+
+- [x] **Code↔English translation** — at least two. Snippet A's three layers (present as three
+      small stacked translation blocks, or one with clear separation) and Snippet C or D.
+- [x] **Visual file tree** — the `src/` map above, annotated with the film-crew roles. This is the
+      module's hero visual. Include the `[locale]` and `(default)` notation explanation as
+      annotations or a small side-by-side "folder path → real URL" comparison.
+- [x] **Layer toggle demo OR interactive architecture diagram** — show the four layers
+      (Route / Service / Model / Database) and let the learner click through them. Emphasise the
+      rule: each layer talks only to the one below.
+- [x] **Quiz** — 3–4 questions, scenario style:
+      1. "You want to change the cost of generating an image from 10 credits to 5. Which file?"
+         (Correct: `src/services/credit.ts`, the `CreditsAmount` list — one place, everywhere gets it.
+         Wrong options: the button component / the database / every API route.)
+      2. "An AI assistant writes database queries directly inside a page component. Why should you
+         push back?" (Correct: it skips two layers, so the rule now lives in two places and the
+         page can't run on the server safely / duplicated logic drifts.)
+      3. "You need a component that shows a live countdown timer that updates every second. Server
+         component or client component, and how do you tell the AI?" (Correct: client — it reacts
+         to time/interaction; say "mark it `'use client'`".)
+      4. "Where in the URL does the folder `(console)` show up?" (Correct: nowhere — round brackets
+         are organisation only.)
+- [x] **Glossary tooltips** — aggressive. At minimum: component, React, TypeScript, Next.js,
+      route, folder/directory, import, function, `props`, service layer, model, schema, database,
+      business logic, server-side, client-side, render, framework, enum, hook, URL path, deploy.
+- [x] **Callout boxes** — one "aha" on *a rule should live in exactly one place* (this is the
+      single most transferable idea in the module); one on *the page is a template, the content is
+      data*.
+
+### Screens (aim for 5)
+
+1. **The film production metaphor** + why organisation is a survival skill for a codebase.
+2. **The map** — the visual file tree, annotated. Hero visual.
+3. **Folders become URLs** — `[locale]` and `(default)` explained side by side with real examples.
+4. **The chain of command** — Snippet A's three layers, the layer toggle/diagram, the "one place"
+   callout.
+5. **Cast vs crew** — `'use client'`, Snippets B and C as the hand-off pair, Snippet D as the
+   assembled page. Then the quiz.
+
+### Reference Files to Read
+
+- `references/content-philosophy.md` — all of it.
+- `references/gotchas.md` — all of it.
+- `references/interactive-elements.md` → "Code ↔ English Translation Blocks", "Multiple-Choice
+  Quizzes", "Visual File Tree", "Interactive Architecture Diagram", "Layer Toggle Demo",
+  "Callout Boxes", "Glossary Tooltips", "Icon-Label Rows", "Pattern/Feature Cards".
+- `references/design-system.md` → "Module Structure", "Color Palette", "Typography".
+
+### Connections
+
+- **Previous module: "What Happens When You Click Generate"** — traced one message from the
+  browser through the API route to Google's Gemini AI and back. It used the terms Browser, Server,
+  Gemini. It already showed `src/app/api/generate-cyberpunk/route.ts` and
+  `imagen-client.tsx`, so you can refer back to them as familiar faces.
+- **Next module: "Who Are You?"** — sign-in, sessions, and how the server knows which account a
+  request belongs to. End by pointing forward: the route in Snippet A called `getUserUuid()` and
+  we just accepted that it works. Next module opens that box.
+- **Tone/style notes:** Accent colour is **vermillion** (warm red-orange). Warm developer-notebook
+  feel. Zero jargon without a tooltip. Second person. The learner is a "vibe coder" — builds
+  software by instructing AI, no CS background. **Never use a restaurant/kitchen metaphor.**
+  Module 1 used the photo-lab metaphor; don't reuse it. Actor naming across the course:
+  **Browser, Server, Gemini, Database, Stripe, Storage** — capitalised, consistent.
+  Your file must contain ONLY `<section class="module" id="module-2"> ... </section>` — no
+  `<html>`, `<head>`, `<body>`, `<style>` or `<script>` tags. Write it to
+  `courses/general-course/modules/02-meet-the-cast.html`.

--- a/courses/general-course/briefs/03-who-are-you.md
+++ b/courses/general-course/briefs/03-who-are-you.md
@@ -1,0 +1,264 @@
+# Module 3: Who Are You? — Sign-In, Sessions, and Trust
+
+> You are writing ONE module of a 7-module course about a real, live web app.
+> The app: **charlieandlola.net** — upload a selfie, get a Charlie & Lola cartoon character
+> from Google's Gemini AI. Free to try, sign in to download, buy credits for more.
+> Next.js 15 + TypeScript. Sign-in is handled by a library called NextAuth.
+
+### Teaching Arc
+
+- **Metaphor:** **The music-festival wristband.** At the gate you queue up once and prove who you
+  are the hard way — passport, booking reference, a good look at your face. In exchange you get a
+  paper wristband. After that, nobody at any stage, bar or backstage door checks your passport
+  again; they glance at the wristband. The wristband is **tamper-evident** — you can't peel it off
+  and pass it to a friend without it showing. And it **expires** at the end of the weekend.
+  The gate = the sign-in flow. The wristband = the session cookie holding a signed token.
+  "Show me your wristband" = `getUserUuid()`. Use gate/wristband/stages throughout.
+- **Opening hook:** "You can use this app without signing in. You just can't *download*. The moment
+  the app cares about who you are is the moment all of this machinery switches on — and it's the
+  same machinery in almost every app you've ever used."
+- **Key insight:** Proving who you are is **expensive and happens once**; *remembering* who you are
+  is **cheap and happens on every single request**. Those are two different jobs, and confusing
+  them is where most auth bugs come from. Also: this app never stores your Google password. It
+  never sees it.
+- **"Why should I care?":** Auth is the #1 thing AI assistants get subtly wrong, because it's the
+  one place where "it works on my machine" and "it's secure" are different questions. If you can
+  read a sign-in flow, you can spot the classic disasters: trusting data the browser sent you,
+  checking permissions in the browser instead of the server, or storing passwords in plain text.
+
+### The Story of a Sign-In (spine of the module)
+
+1. You click "Sign in with Google". Your browser goes **to Google**, not to this app.
+2. You log in *at Google*. This app never sees your password. Google asks "do you want to share
+   your email and name with charlieandlola.net?"
+3. Google sends your browser back to the app with a signed slip of paper proving "this is
+   ruoyu@example.com, and I, Google, vouch for it."
+4. NextAuth's `jwt` callback fires. This is the app's one chance to do something with that fact.
+5. It calls `handleSignInUser()`, which builds a user record and calls `saveUser()`.
+6. `saveUser()` checks the database. **New email? Create the account and give them 30 free credits,
+   expiring in one year.** Existing email? Just load the existing record.
+7. The user's `uuid`, email, nickname and avatar get packed into the **token** — the wristband.
+8. That token is stored in a cookie in your browser. Every future request carries it automatically.
+9. On any later request, `getUserUuid()` reads the wristband and returns your id — or an empty
+   string, which is how the app knows you're a guest.
+
+### Three Doors Into the Same Building
+
+The app supports several sign-in methods, and every one of them lands in the same place (step 4
+above). Present these as cards:
+- **Google** (standard OAuth redirect)
+- **GitHub** (standard OAuth redirect)
+- **Google One Tap** (the little "Continue as…" bubble that appears top-right — it hands over a
+  token which the server verifies by calling Google's `tokeninfo` endpoint)
+- **Email + password** (only if switched on) — the app *does* store a password here, but as a
+  **hash**, never the password itself.
+- **API key** — for developers calling the app programmatically. A key starting with `sk-`.
+
+The clever bit: none of these providers are hard-coded on. Each one only exists if the matching
+environment variables are set. Look at the `if` around each provider — the list of sign-in buttons
+on the page is literally computed from the server's configuration at startup.
+
+### Code Snippets (pre-extracted — use verbatim, do not edit)
+
+**Snippet A — a sign-in method only exists if it's configured.**
+File: `src/auth/config.ts` (lines 132–144)
+
+```ts
+// Google Auth
+if (
+  process.env.NEXT_PUBLIC_AUTH_GOOGLE_ENABLED === "true" &&
+  process.env.AUTH_GOOGLE_ID &&
+  process.env.AUTH_GOOGLE_SECRET
+) {
+  providers.push(
+    GoogleProvider({
+      clientId: process.env.AUTH_GOOGLE_ID,
+      clientSecret: process.env.AUTH_GOOGLE_SECRET,
+    })
+  );
+}
+```
+
+**Snippet B — the wristband gets printed. This is the hinge of the whole module.**
+File: `src/auth/config.ts` (lines 208–228)
+
+```ts
+    async jwt({ token, user, account }) {
+      // Persist the OAuth access_token and or the user id to the token right after signin
+      try {
+        if (!user || !account) {
+          return token;
+        }
+
+        const userInfo = await handleSignInUser(user, account);
+        if (!userInfo) {
+          throw new Error("save user failed");
+        }
+
+        token.user = {
+          uuid: userInfo.uuid,
+          email: userInfo.email,
+          nickname: userInfo.nickname,
+          avatar_url: userInfo.avatar_url,
+          created_at: userInfo.created_at,
+        };
+
+        return token;
+      } catch (e) {
+```
+
+**Snippet C — new account? Here's 30 free credits.**
+File: `src/services/user.ts` (lines 20–38)
+
+```ts
+    const existUser = await findUserByEmail(user.email);
+
+    if (!existUser) {
+      // user not exist, create a new user
+      if (!user.uuid) {
+        user.uuid = getUuid();
+      }
+
+      console.log("user to be inserted:", user);
+
+      const dbUser = await insertUser(user as typeof users.$inferInsert);
+
+      // increase credits for new user, expire in one year
+      await increaseCredits({
+        user_uuid: user.uuid,
+        trans_type: CreditsTransType.NewUser,
+        credits: CreditsAmount.NewUserGet,
+        expired_at: getOneYearLaterTimestr(),
+      });
+```
+
+**Snippet D — "show me your wristband". Every protected action starts here.**
+File: `src/services/user.ts` (lines 57–77)
+
+```ts
+export async function getUserUuid() {
+  let user_uuid = "";
+
+  const token = await getBearerToken();
+
+  if (token) {
+    // api key
+    if (token.startsWith("sk-")) {
+      const user_uuid = await getUserUuidByApiKey(token);
+
+      return user_uuid || "";
+    }
+  }
+
+  const session = await auth();
+  if (session && session.user && session.user.uuid) {
+    user_uuid = session.user.uuid;
+  }
+
+  return user_uuid;
+}
+```
+
+Point out the design decision hidden in that empty string: `getUserUuid()` never throws and never
+says "unauthorised". It just returns `""` for a guest. That's *why* the app can offer free
+generation to logged-out visitors — being a guest isn't an error, it's a state.
+
+**Snippet E — passwords are never stored, only hashes.**
+File: `src/auth/config.ts` (lines 41–50)
+
+```ts
+          if (!user || !user.password_hash) {
+            return null;
+          }
+
+          // Verify password
+          const isValidPassword = await verifyPassword(password, user.password_hash);
+
+          if (!isValidPassword) {
+            return null;
+          }
+```
+
+A hash is a one-way blender: you can turn "hunter2" into a fingerprint, but you can't turn the
+fingerprint back into "hunter2". When you log in, the app blends what you typed and compares
+fingerprints. Notice too that a wrong password and a non-existent account both `return null` —
+the app doesn't tell an attacker which one it was.
+
+### The Real Gotcha Worth Teaching
+
+`getUserUuid()` reads the session **on the server**. The browser sends the cookie; the server
+verifies its signature before believing a single word of it. Contrast this with the tempting
+mistake an AI assistant will happily make: reading `session.user.uuid` in a client component and
+sending it to the server as a parameter. That means anyone can type someone else's user id into
+the request. **Rule: the server never takes the browser's word for who you are.** Make this a
+prominent callout — it's the single most valuable security instinct in this module.
+
+### Interactive Elements (all required)
+
+- [x] **Code↔English translation** — at least two: Snippet B (the wristband being printed) and
+      Snippet D (the wristband being checked). Snippet C is a strong third.
+- [x] **Data flow animation** — the hero visual. Actors: `Browser` → `Google` → `Server` →
+      `Database` → `Browser`. Steps: (1) You click "Sign in with Google". (2) Browser is redirected
+      to Google — the app never sees your password. (3) Google verifies you and sends the browser
+      back with a signed proof. (4) The server's `jwt` callback fires. (5) Server asks the Database:
+      "seen this email before?" (6) New user → create record + grant 30 credits. (7) Server packs
+      uuid + email + nickname into a signed token. (8) Token is stored as a cookie in your browser.
+      Every later request carries it automatically.
+- [x] **Quiz** — 3–4 questions, scenario/debugging style:
+      1. "Users report they get signed out every time they refresh. Where do you look?" (Correct:
+         the cookie/token — is it being set, is it expiring immediately, is `useSecureCookies` on
+         over plain HTTP. Wrong: the Google account settings / the database.)
+      2. "An AI assistant writes code that reads the user's id in the browser and sends it to the
+         server with the request. What's wrong with that?" (Correct: the browser can be edited by
+         anyone — you'd be letting a user claim to be someone else. The server must read identity
+         from the verified session, not from the request body.) **This is the money question.**
+      3. "You add a 'Sign in with GitHub' button but nothing happens in production, though it works
+         locally. What's the most likely cause?" (Correct: the environment variables gating that
+         provider aren't set on the production server, so the provider was never added to the list.)
+      4. "New signups aren't receiving their 30 free credits, but they *can* sign in. Which step of
+         the sign-in story failed?" (Correct: the branch inside `saveUser` that runs only for brand
+         new emails — e.g. the user already existed under a different provider.)
+- [x] **Glossary tooltips** — aggressive. At minimum: authentication, authorisation, OAuth, session,
+      cookie, token, JWT, callback, provider, environment variable, hash, `uuid`, redirect,
+      endpoint, HTTPS, API key, bearer token, credentials, database record, server-side,
+      client-side, plain text.
+- [x] **Callout boxes** — one "aha" on *prove once, remember cheaply*; one warning on *the server
+      never takes the browser's word for who you are*.
+- [x] **Optional if it fits**: a "Spot the Bug" challenge using the client-sends-its-own-user-id
+      anti-pattern, or config badges showing which sign-in methods switch on with which env vars.
+
+### Screens (aim for 5)
+
+1. **The wristband metaphor** + the two different jobs (proving vs remembering).
+2. **Three doors into the same building** — provider cards + Snippet A (providers are conditional).
+3. **The gate** — the sign-in flow animation as hero visual, then Snippet B.
+4. **Your first 30 credits** — Snippet C. Sets up Module 4.
+5. **Showing the wristband** — Snippet D, the empty-string-means-guest insight, the security
+   callout, Snippet E on hashes, then the quiz.
+
+### Reference Files to Read
+
+- `references/content-philosophy.md` — all of it.
+- `references/gotchas.md` — all of it.
+- `references/interactive-elements.md` → "Code ↔ English Translation Blocks", "Multiple-Choice
+  Quizzes", "Message Flow / Data Flow Animation", "Callout Boxes", "Glossary Tooltips",
+  "Pattern/Feature Cards", "Permission/Config Badges", "Spot the Bug Challenge".
+- `references/design-system.md` → "Module Structure", "Color Palette", "Typography".
+
+### Connections
+
+- **Previous module: "Meet the Cast"** — the folder map, the layer rule (Route → Service → Model →
+  Database), and the `'use client'` server/client divide. It ended by noting that the image route
+  calls `getUserUuid()` and promised this module would open that box. Open by delivering on that.
+- **Next module: "Following the Money"** — credits, Stripe checkout, and the ledger. End by
+  pointing forward: "New users get 30 credits. An image costs 10. So what happens on the fourth
+  one? That's a payment question — and payments have a plot twist."
+- **Tone/style notes:** Accent colour is **vermillion** (warm red-orange). Warm developer-notebook
+  feel. Zero jargon without a tooltip. Second person. The learner is a "vibe coder" — builds
+  software by instructing AI, no CS background. **Never use a restaurant/kitchen metaphor.**
+  Already used elsewhere in the course and off-limits here: photo lab (M1), film production (M2).
+  Actor naming across the course: **Browser, Server, Google, Database, Stripe, Storage** —
+  capitalised, consistent.
+  Your file must contain ONLY `<section class="module" id="module-3"> ... </section>` — no
+  `<html>`, `<head>`, `<body>`, `<style>` or `<script>` tags. Write it to
+  `courses/general-course/modules/03-who-are-you.html`.

--- a/courses/general-course/briefs/04-following-the-money.md
+++ b/courses/general-course/briefs/04-following-the-money.md
@@ -1,0 +1,297 @@
+# Module 4: Following the Money — Credits, Stripe, and the Ledger
+
+> You are writing ONE module of a 7-module course about a real, live web app.
+> The app: **charlieandlola.net** — upload a selfie, get a Charlie & Lola cartoon character
+> from Google's Gemini AI. Free to try, sign in to download, buy credits for more.
+> Next.js 15 + TypeScript + a PostgreSQL database. Payments run through **Stripe**.
+
+### Teaching Arc
+
+- **Metaphor:** **The chequebook register** — that little paper stub in the back of a chequebook
+  where you write one line per transaction: *date, description, +£200 / −£35*. The crucial rule:
+  **you never rub out the balance and write a new one.** You only ever add a line. The balance
+  isn't stored anywhere — it's *calculated* by adding up the lines. That's exactly how credits
+  work in this app, and it's why you can always answer "where did my 20 credits go?"
+  Secondary metaphor for webhooks (keep it small and separate): **the delivery firm phoning you
+  back.** You don't stand at the door guessing; they call when the parcel is actually delivered.
+- **Opening hook:** "New accounts get 30 free credits. An image costs 10. So the fourth image is
+  where this app has to become a business — and the way it handles money is quietly the most
+  carefully-built part of the whole codebase."
+- **Key insight:** The credits table is an **append-only ledger**, not a balance. Every grant is a
+  positive row, every spend is a negative row, and your balance is the sum. And the moment money
+  is actually confirmed is not when you click Pay — it's when **Stripe calls the server back**.
+- **"Why should I care?":** Money bugs are the ones that cost real money and real trust. If you ask
+  an AI to "add credits", it will almost certainly reach for `UPDATE users SET credits = credits - 10`
+  — a single number it overwrites. That works right up until two requests land at the same time,
+  or a customer disputes a charge, and then you have no way to reconstruct what happened. Knowing
+  to say *"use an append-only ledger, don't overwrite a balance"* is a genuinely senior instruction.
+
+### The Money Story (spine of the module)
+
+**Part 1 — buying.**
+1. You click a plan on the pricing page. The browser POSTs `{ product_id, currency, locale }` to
+   `/api/checkout`. **Note what it does NOT send: the price.**
+2. The server looks the product up in its own pricing file and reads the real price from there.
+   (Screen-worthy: if the price came from the browser, anyone could buy the $99 plan for $0.01.)
+3. The server creates an **order** row with status `created` and its own order number.
+4. The server asks Stripe for a checkout session and gets back a URL. Your browser goes to
+   Stripe's page. **Your card details never touch this app's servers.**
+5. You pay on Stripe's page.
+
+**Part 2 — the callback (the plot twist).**
+6. Stripe redirects your browser back to the app. **This is not proof of payment.** Anyone could
+   type that return URL into their address bar.
+7. Separately, Stripe's servers send a **webhook** — a POST to `/api/pay/notify/stripe` — saying
+   `checkout.session.completed`. That message is cryptographically signed.
+8. The server verifies the signature with `constructEventAsync`. If it doesn't verify, it's ignored.
+9. `updateOrder()` flips the order from `created` to `paid`… but only if it was `created`.
+10. `updateCreditForOrder()` adds a positive ledger row for that order number.
+
+**Part 3 — spending.**
+11. Generating an image calls `decreaseCredits()`, which writes a **negative** row.
+12. `getUserCredits()` adds every unexpired row together to produce your balance.
+
+### The Two Safety Nets (give these their own screen — this is the best material in the module)
+
+**1. Idempotency.** Stripe may send the same webhook more than once — that's by design, so a
+network blip doesn't lose your payment. So the code has to be safe to run twice. It has two guards:
+
+```ts
+    // order already paied
+    if (order.status === OrderStatus.Paid) {
+      return;
+    }
+```
+and, in the credit service:
+```ts
+    const credit = await findCreditByOrderNo(order.order_no);
+    if (credit) {
+      // order already increased credit
+      return;
+    }
+```
+"Idempotent" is a word worth teaching explicitly: *doing it twice has the same result as doing it
+once*. It's a term that will make an AI assistant immediately write better payment code.
+
+**2. Credits expire.** Every credit row has an `expired_at` date, and the balance query only counts
+rows that haven't expired yet. New-user credits expire in one year; purchased credits expire at the
+end of the billing period. Notice the ordering — `orderBy(asc(credits.expired_at))` — the code
+spends the *soonest-to-expire* credits first. That's a deliberate business decision living in code.
+
+### Code Snippets (pre-extracted — use verbatim, do not edit)
+
+**Snippet A — the price comes from the server, never from the browser.**
+File: `src/app/api/checkout/route.ts` (lines 31–42)
+
+```ts
+    // validate checkout params
+    const page = await getPricingPage(locale);
+    if (!page || !page.pricing || !page.pricing.items) {
+      return respErr("invalid pricing table");
+    }
+
+    const item = page.pricing.items.find(
+      (item: PricingItem) => item.product_id === product_id
+    );
+
+    if (!item || !item.amount || !item.interval || !item.currency) {
+      return respErr("invalid checkout params");
+    }
+```
+
+**Snippet B — verifying that a webhook really came from Stripe.**
+File: `src/app/api/pay/notify/stripe/route.ts` (lines 19–37)
+
+```ts
+    const sign = req.headers.get("stripe-signature") as string;
+    const body = await req.text();
+    if (!sign || !body) {
+      throw new Error("invalid notify data");
+    }
+
+    const event = await stripe.webhooks.constructEventAsync(
+      body,
+      sign,
+      stripeWebhookSecret
+    );
+
+    console.log("stripe notify event: ", event);
+
+    switch (event.type) {
+      case "checkout.session.completed": {
+        // get checkout session
+        const session = event.data.object;
+        await handleCheckoutSession(stripe, session);
+        break;
+      }
+```
+
+**Snippet C — the double guard against paying twice.**
+File: `src/services/order.ts` (lines 36–59)
+
+```ts
+    // order already paied
+    if (order.status === OrderStatus.Paid) {
+      return;
+    }
+
+    // only update order status from created to paid
+    if (order.status !== OrderStatus.Created) {
+      throw new Error("invalid order status");
+    }
+
+    const paid_at = getIsoTimestr();
+    await updateOrderStatus(
+      order_no,
+      OrderStatus.Paid,
+      paid_at,
+      paid_email,
+      paid_detail
+    );
+
+    if (order.user_uuid) {
+      if (order.credits > 0) {
+        // increase credits for paied order
+        await updateCreditForOrder(order as unknown as Order);
+      }
+```
+
+**Snippet D — spending is just writing a negative line.** This is the heart of the ledger idea.
+File: `src/services/credit.ts` (lines 111–120)
+
+```ts
+    const new_credit: typeof creditsTable.$inferInsert = {
+      trans_no: getSnowId(),
+      created_at: new Date(getIsoTimestr()),
+      expired_at: new Date(expired_at),
+      user_uuid: user_uuid,
+      trans_type: trans_type,
+      credits: 0 - credits,
+      order_no: order_no,
+    };
+    await insertCredit(new_credit);
+```
+
+Draw attention to `credits: 0 - credits` — that minus sign *is* the entire spend mechanism.
+
+**Snippet E — the balance is calculated, not stored.**
+File: `src/services/credit.ts` (lines 54–60)
+
+```ts
+    // Get only valid credits for current balance
+    const validCredits = await getUserValidCredits(user_uuid);
+    if (validCredits) {
+      validCredits.forEach((v) => {
+        user_credits.left_credits += v.credits || 0;
+      });
+    }
+```
+
+**Snippet F — the five kinds of ledger entry, and the price list, in one place.**
+File: `src/services/credit.ts` (lines 14–26)
+
+```ts
+export enum CreditsTransType {
+  NewUser = "new_user", // initial credits for new user
+  OrderPay = "order_pay", // user pay for credits
+  SystemAdd = "system_add", // system add credits
+  Ping = "ping", // cost for ping api
+  ImageGeneration = "image_generation", // cost for image generation
+}
+
+export enum CreditsAmount {
+  NewUserGet = 30,
+  PingCost = 1,
+  ImageGeneration = 10,
+}
+```
+
+### Real Facts You Can Use
+
+- Real prices from the live pricing file: the featured plan is **Premium, $0.99/month** (`amount: 99`
+  — note prices are stored in **cents**, a near-universal convention that avoids decimal rounding
+  errors). There are 8 plans in total.
+- The pricing page isn't a database table — it's a JSON file per language:
+  `src/i18n/pages/pricing/en.json`. Changing a price is editing a text file.
+- The app supports two payment companies (Stripe and Creem), chosen by an environment variable
+  `PAY_PROVIDER`. Chinese customers get WeChat Pay and Alipay added as payment methods.
+- There's also an **affiliate** system: paid orders trigger `updateAffiliateForOrder()` which pays
+  a percentage to whoever invited that user.
+
+### Interactive Elements (all required)
+
+- [x] **Code↔English translation** — at least three: Snippet A (price from server), Snippet D
+      (the minus sign), and Snippet B or C.
+- [x] **Group chat animation** — the hero interaction. Participants: **Browser**, **Server**,
+      **Stripe**. Script roughly:
+      Browser: "I'd like the Premium plan." Server: "Let me look up what that actually costs — I'm
+      not taking your word for it. $0.99. Creating order #7429, status: created."
+      Server → Stripe: "Set me up a checkout for $0.99, and tag it with order 7429."
+      Stripe: "Here's a payment page. Send them over." Browser: *pays on Stripe's page*
+      Stripe → Server (later, unprompted): "📩 checkout.session.completed for order 7429. Signed."
+      Server: "Signature checks out. Order was 'created' → now 'paid'. Adding +1000 credits."
+      Stripe: "📩 checkout.session.completed for order 7429." (again!)
+      Server: "Already paid. Ignoring." ← land the idempotency punchline here.
+- [x] **Data flow animation** — the credits ledger: show rows accumulating
+      (`+30 new_user`, `−10 image_generation`, `−10 image_generation`, `+1000 order_pay`,
+      `−10 image_generation`) and the balance being computed by summing them, not stored.
+- [x] **Quiz** — 4 questions, scenario style:
+      1. "A customer pays, then closes the tab before the page redirects back. Do they get their
+         credits?" (Correct: yes — the webhook is a separate message from Stripe's servers to
+         yours and doesn't depend on the customer's browser at all.)
+      2. "Stripe accidentally sends the same 'payment complete' message twice. What stops the
+         customer getting double credits?" (Correct: the order status guard and the
+         `findCreditByOrderNo` check — the operation is idempotent.)
+      3. "An AI assistant suggests storing a single `credits` number on the users table and
+         subtracting from it. Name one thing that gets worse." (Correct: you lose the history — you
+         can't answer 'where did my credits go?', can't expire credits selectively, and two
+         simultaneous requests can overwrite each other.)
+      4. "Someone edits the request in their browser to send `amount: 1` instead of the real price.
+         What happens?" (Correct: nothing — the browser never sends the price; the server looks it
+         up. Use the wrong answers to teach *never trust the client with anything that matters*.)
+- [x] **Glossary tooltips** — aggressive. At minimum: webhook, Stripe, checkout session, ledger,
+      idempotent, transaction, row, table, signature/cryptographic signature, environment variable,
+      subscription, one-time payment, `POST`, JSON, cents, metadata, redirect, status, enum,
+      affiliate, expire, database query.
+- [x] **Callout boxes** — one "aha" on *never overwrite a balance, always append a line*; one
+      warning on *the redirect back to your site is not proof of payment — the webhook is*.
+
+### Screens (aim for 6)
+
+1. **The chequebook register** — the metaphor, and the reveal that there is no balance column.
+2. **Buying: the price does not come from the browser** — Snippet A + the "never trust the client"
+   callout.
+3. **The plot twist: webhooks** — the delivery-firm-calls-you-back idea, Snippet B, and the group
+   chat animation as hero.
+4. **Doing it twice safely** — idempotency, Snippet C, the punchline from the chat.
+5. **Spending** — Snippet D, Snippet E, the ledger animation, expiry and spend-soonest-first.
+6. **The whole picture** — Snippet F (all five entry types, the price list in one place), quiz.
+
+### Reference Files to Read
+
+- `references/content-philosophy.md` — all of it.
+- `references/gotchas.md` — all of it.
+- `references/interactive-elements.md` → "Code ↔ English Translation Blocks", "Multiple-Choice
+  Quizzes", "Group Chat Animation", "Message Flow / Data Flow Animation", "Callout Boxes",
+  "Glossary Tooltips", "Numbered Step Cards", "Pattern/Feature Cards".
+- `references/design-system.md` → "Module Structure", "Color Palette", "Typography".
+
+### Connections
+
+- **Previous module: "Who Are You?"** — sign-in, the session "wristband", `getUserUuid()`, and the
+  fact that brand-new accounts are granted 30 credits expiring in a year. It ended by asking what
+  happens on the fourth image. Open by answering that.
+- **Next module: "Memory and the Outside World"** — the database itself (tables, schema,
+  migrations), plus the outside services the app depends on: Google's AI, cloud storage, and the
+  key-rotation pool. End by pointing forward: "We've written a lot of rows to a database this
+  module without once asking what a database actually *is*, or what happens when it disappears.
+  It disappeared. Really. Next module."
+- **Tone/style notes:** Accent colour is **vermillion** (warm red-orange). Warm developer-notebook
+  feel. Zero jargon without a tooltip. Second person. The learner is a "vibe coder" — builds
+  software by instructing AI, no CS background. **Never use a restaurant/kitchen metaphor.**
+  Already used elsewhere and off-limits here: photo lab (M1), film production (M2), festival
+  wristband (M3). Actor naming across the course: **Browser, Server, Google, Database, Stripe,
+  Storage** — capitalised, consistent.
+  Your file must contain ONLY `<section class="module" id="module-4"> ... </section>` — no
+  `<html>`, `<head>`, `<body>`, `<style>` or `<script>` tags. Write it to
+  `courses/general-course/modules/04-following-the-money.html`.

--- a/courses/general-course/briefs/05-memory-and-the-outside-world.md
+++ b/courses/general-course/briefs/05-memory-and-the-outside-world.md
@@ -1,0 +1,272 @@
+# Module 5: Memory and the Outside World
+
+> You are writing ONE module of a 7-module course about a real, live web app.
+> The app: **charlieandlola.net** — upload a selfie, get a Charlie & Lola cartoon character
+> from Google's Gemini AI. Free to try, sign in to download, buy credits for more.
+> Next.js 15 + TypeScript. Data lives in a PostgreSQL database (hosted on Supabase),
+> images live in Cloudflare R2 object storage, the AI comes from Google.
+
+### Teaching Arc
+
+- **Metaphor:** **Building blueprints and renovation permits.** `schema.ts` is the blueprint — it
+  says this building has a Users room with these dimensions, an Orders room with those. But you
+  can't just hand a builder a new blueprint for a building people are already living in. You issue
+  numbered, dated **permits**: *#0003 — add a category column to Posts. #0004 — add a password_hash
+  column to Users.* Applied in order, they take any building from empty lot to current state. That's
+  a **migration**. Anyone with the permit stack can rebuild the exact same building.
+  Secondary metaphor, kept separate and small: the API key pool as **a bank of phone lines** — when
+  one line is engaged, the switchboard rotates to the next.
+- **Opening hook:** "Every module so far has said 'and then it saves it to the database' as if that
+  were one word. It's about six ideas — and the most useful thing about this particular database is
+  that, when we went looking for it while making this course, **it was gone**."
+- **Key insight:** Your app's data lives on *someone else's computer*, and so do the AI, the image
+  storage, and the payments. Your app is mostly a **coordinator of services it doesn't control**.
+  Every one of those services can be slow, rate-limited, expensive, or simply deleted.
+- **"Why should I care?":** Three practical superpowers. (1) You'll recognise a schema change as a
+  schema change, and know to ask AI for a *migration* rather than letting it silently edit tables.
+  (2) You'll know that "the app is broken" often means "an external service said no", and you'll
+  check that first. (3) You'll spot the cost and rate-limit questions *before* you launch, not after
+  the bill arrives.
+
+### The Database Half
+
+**Tables in this app (all 8, real).** Present as cards or an annotated list — this is a great
+visual and it summarises the whole product:
+
+| Table | What it holds |
+|---|---|
+| `users` | one row per account: uuid, email, nickname, avatar, which provider they signed in with, invite code |
+| `orders` | one row per purchase attempt: order number, amount, status, Stripe session id, credits bought |
+| `credits` | the ledger from Module 4: one row per grant or spend |
+| `apikeys` | developer keys (the ones starting `sk-`) |
+| `posts` | blog articles |
+| `categories` | blog categories |
+| `affiliates` | referral rewards |
+| `feedbacks` | user feedback and ratings |
+
+**The schema is TypeScript, not SQL.** Worth its own screen: developers describe the tables in a
+normal code file, and a tool called **Drizzle** generates the actual database instructions. The
+payoff is that the *editor* then knows the shape of your data — misspell `left_credits` and you're
+told immediately, before the code ever runs.
+
+**Migrations.** There are five in `src/db/migrations/`, with names auto-generated from a word list
+(`0003_steady_toad.sql`, `0004_striped_colossus.sql`). They're plain, tiny, and readable — show
+0004, it's literally one line. The lesson: a schema change is a *file you can review*, not an
+invisible act.
+
+**Connection pooling.** Opening a connection to a database is slow, so the app opens a handful and
+reuses them (`max: 10`). In Cloudflare's environment it opens exactly one, because that environment
+charges differently. Metaphor-adjacent framing: it's a small set of open phone lines held ready,
+not a new call placed every time anyone asks a question.
+
+### The Two Real Gotchas (both true, both from this codebase — this is the best material here)
+
+**Gotcha 1 — the database vanished.** This app's `DATABASE_URL` points at a Supabase-hosted
+Postgres database. While building this course we tried to connect to it and got **"tenant or user
+not found"** — the project had been deleted, most likely purged as an inactive free-tier project.
+Nothing in the code is wrong. The code is fine. The *thing the code depends on* stopped existing.
+Teach the debugging shape of this: an error that says "not found" at the *connection* stage, before
+any of your queries run, is almost never your code — it's the address, the credentials, or the
+service itself. Two things that would have caught it earlier: a health check that actually touches
+the database, and knowing that free tiers reclaim idle projects.
+
+**Gotcha 2 — the hardcoded password.** `src/db/index.ts` contains a real database password written
+directly into the source code, as a patch for a `/` character breaking URL parsing. Show it
+**with the password masked** (write `[REDACTED]` where the password is, and tell the reader you've
+masked it — the real file does not). Two lessons, both valuable:
+  - Secrets belong in environment variables, never in code. Code gets committed, shared, screenshotted.
+  - The *actual* fix for "my password has a special character in it" is URL-encoding the value in
+    the environment variable — not a string-replace on one specific password inside the app.
+  This is exactly the kind of well-intentioned "just make it work" patch an AI assistant will write
+  when you say "the database URL is failing" — and exactly the kind you should catch.
+
+### The Outside World Half
+
+**Three outside services, three different failure modes.** Cards:
+- **Google Gemini** — the AI. Fails with *quota exceeded* (HTTP 429) when you've used too much.
+- **Cloudflare R2** — object storage for finished images. Fails by being unreachable.
+- **Stripe** — payments (Module 4).
+
+**The API key pool** is a lovely, teachable pattern. The app reads up to six Gemini keys from
+environment variables, hands them out in rotation, counts requests against a daily limit, and
+**benches a key that errors** so the next request tries a different one. When every key is benched,
+the user gets an honest "we're at capacity" message rather than a crash. Point out the deliberate
+product decision inside the error handling: a quota failure is turned into *"Too many users online!
+VIP users get priority access"* — a technical limit reframed as an upsell.
+
+**Graceful degradation.** If storage isn't configured or the upload fails, the app doesn't error —
+it falls back to sending the whole image back inside the reply as a giant text string (a base64
+data URL). Worse, but working. Name the pattern: **graceful degradation**, and note the trade-off
+(the reply gets megabytes bigger and the image isn't saved anywhere).
+
+### Code Snippets (pre-extracted — use verbatim, do not edit, EXCEPT the masking noted in Snippet C)
+
+**Snippet A — a table described in TypeScript.**
+File: `src/db/schema.ts` (lines 82–91)
+
+```ts
+export const credits = pgTable("credits", {
+  id: integer().primaryKey().generatedAlwaysAsIdentity(),
+  trans_no: varchar({ length: 255 }).notNull().unique(),
+  created_at: timestamp({ withTimezone: true }),
+  user_uuid: varchar({ length: 255 }).notNull(),
+  trans_type: varchar({ length: 50 }).notNull(),
+  credits: integer().notNull(),
+  order_no: varchar({ length: 255 }),
+  expired_at: timestamp({ withTimezone: true }),
+});
+```
+
+**Snippet B — an entire migration.** Show it as a one-liner; the brevity IS the point.
+File: `src/db/migrations/0004_striped_colossus.sql` (whole file)
+
+```sql
+ALTER TABLE "users" ADD COLUMN "password_hash" varchar(255);
+```
+
+**Snippet C — the hardcoded-password patch. MASK THE PASSWORD.**
+File: `src/db/index.ts` (lines 34–39) — *password replaced with `[REDACTED]` for this course; the
+real file has it in plain text.*
+
+```ts
+  // Apply URL encoding for the specific password issue we're seeing
+  if (databaseUrl.includes(':[REDACTED]@')) {
+    databaseUrl = databaseUrl.replace(':[REDACTED]@', ':[REDACTED-ENCODED]@');
+    console.log('Applied URL encoding for database password special character');
+  }
+```
+
+State plainly in the surrounding text that you have masked the password and that the real file
+contains it verbatim — that honesty is part of the lesson.
+
+**Snippet D — a handful of connections, reused.**
+File: `src/db/index.ts` (lines 74–83)
+
+```ts
+  // Node.js environment with connection pool configuration
+  const client = postgres(databaseUrl, {
+    prepare: false,
+    max: 10, // Maximum connections in pool
+    idle_timeout: 30, // Idle connection timeout (seconds)
+    connect_timeout: 10, // Connection timeout (seconds)
+  });
+  dbInstance = drizzle({ client });
+
+  return dbInstance;
+```
+
+**Snippet E — six keys, taken in rotation.**
+File: `src/lib/gemini-api-pool.ts` (lines 19–27)
+
+```ts
+    // Get all Gemini API keys from environment variables
+    const geminiKeys = [
+      process.env.GEMINI_API_KEY,
+      process.env.GEMINI_API_KEY_1,
+      process.env.GEMINI_API_KEY_2, 
+      process.env.GEMINI_API_KEY_3,
+      process.env.GEMINI_API_KEY_4,
+      process.env.GEMINI_API_KEY_5,
+    ].filter(key => key && key.trim() !== '');
+```
+
+**Snippet F — benching a key that just failed, and turning a limit into an upsell.**
+File: `src/app/api/generate-cyberpunk/route.ts` (lines 143–147)
+
+```ts
+      // Check if it's a quota/limit error
+      if (error.message?.includes('quota') || error.message?.includes('limit') || error.status === 429) {
+        geminiApiPool.markKeyAsUnavailable(geminiApiKey, 'Quota exceeded');
+        return respErr("Too many users online! VIP users get priority access. You're in queue, please wait a moment or upgrade to VIP for instant access.", 'QUEUE_REQUIRED');
+      }
+```
+
+**Snippet G — graceful degradation: no storage? send the image inline.**
+File: `src/app/api/generate-cyberpunk/route.ts` (lines 178–186)
+
+```ts
+    let finalImageUrl = `data:${generatedImageMimeType};base64,${generatedImageData}`;
+    let storedFilename = filename;
+
+    // Store image if storage is configured
+    const hasStorageConfig = process.env.STORAGE_ENDPOINT && 
+                            process.env.STORAGE_ACCESS_KEY && 
+                            process.env.STORAGE_SECRET_KEY && 
+                            process.env.STORAGE_BUCKET;
+```
+
+### Interactive Elements (all required)
+
+- [x] **Code↔English translation** — at least three: Snippet A (a table in TypeScript), Snippet E
+      or F (the key pool), and Snippet C (the masked password patch — translate it into English
+      including *why this is the wrong fix*).
+- [x] **Data flow animation** — the hero visual: the API key pool in action. Actors:
+      `Request 1` … `Request 4` and `Key A`, `Key B`, `Key C`. Steps: Request 1 → Key A. Request 2 →
+      Key B (rotation). Request 3 → Key C. Key C returns "429 quota exceeded" → Key C is benched.
+      Request 4 → skips C, goes to Key A. When all keys are benched → user sees "at capacity".
+- [x] **Spot the Bug challenge** — Snippet C is the perfect candidate. Ask the learner what's wrong
+      with it before revealing (a live password in source code; and the real fix is URL-encoding
+      the environment variable, not a hardcoded string replace).
+- [x] **Quiz** — 4 questions, scenario/debugging style:
+      1. "Your app suddenly returns errors on every page, and the log says 'tenant or user not
+         found' before any query runs. What's the most likely cause?" (Correct: the database itself
+         is gone/unreachable or the connection string is wrong — not your application code.
+         Real story from this codebase.)
+      2. "You ask an AI to 'add a phone number field to users'. What should you insist it produces
+         alongside the schema change?" (Correct: a migration file, so the change is reviewable and
+         repeatable on every environment.)
+      3. "Image generation works for the first few users each morning and then everyone gets
+         'we're at capacity'. What's the likely cause and what's one lever you could pull?"
+         (Correct: daily quota on the AI keys is exhausted — add more keys / raise the paid quota /
+         queue requests.)
+      4. "Storage credentials are missing in production. What does a user actually experience?"
+         (Correct: generation still works, but the image comes back embedded in the response and
+         isn't saved anywhere — slower and unsharable. Teaches graceful degradation.)
+- [x] **Glossary tooltips** — aggressive. At minimum: database, PostgreSQL, table, row, column,
+      schema, migration, SQL, ORM, Drizzle, Supabase, connection pool, query, primary key, index,
+      timestamp, environment variable, API key, rate limit, quota, HTTP 429, object storage,
+      Cloudflare R2, base64, data URL, free tier, credentials, hardcode, graceful degradation, uuid.
+- [x] **Callout boxes** — one "aha" on *your app is mostly a coordinator of services you don't
+      control*; one warning on *secrets never go in code*; one on *free tiers reclaim idle projects*.
+
+### Screens (aim for 6)
+
+1. **Blueprints and permits** — the metaphor; what a database actually is in one sentence.
+2. **The eight tables** — annotated cards. Snippet A as a code↔English block.
+3. **Permits** — Snippet B (the one-line migration), why migrations exist, what to ask AI for.
+4. **The day the database vanished** — the true story, the debugging shape of connection-stage
+   errors, plus Snippet D (pooling) as the "how it normally connects" grounding.
+5. **The password in the code** — Snippet C, spot-the-bug, the secrets callout.
+6. **The outside world** — the three services, the key pool animation, Snippets E/F/G, graceful
+   degradation, then the quiz.
+
+### Reference Files to Read
+
+- `references/content-philosophy.md` — all of it.
+- `references/gotchas.md` — all of it.
+- `references/interactive-elements.md` → "Code ↔ English Translation Blocks", "Multiple-Choice
+  Quizzes", "Message Flow / Data Flow Animation", "Spot the Bug Challenge", "Callout Boxes",
+  "Glossary Tooltips", "Pattern/Feature Cards", "Visual File Tree", "Icon-Label Rows".
+- `references/design-system.md` → "Module Structure", "Color Palette", "Typography".
+
+### Connections
+
+- **Previous module: "Following the Money"** — Stripe checkout, webhooks, idempotency, and the
+  append-only credits ledger. It ended by saying "we've written a lot of rows to a database without
+  asking what a database actually is, or what happens when it disappears — it disappeared, really."
+  Open by delivering on that hook.
+- **Next module: "Every Language, Every Screen"** — how the same app serves English and Chinese,
+  and how the interface is assembled from reusable pieces. End by pointing forward: every piece of
+  text the learner has seen quoted in error messages so far was in English — but this app runs in
+  two languages, and none of that text lives in the components.
+- **Tone/style notes:** Accent colour is **vermillion** (warm red-orange). Warm developer-notebook
+  feel. Zero jargon without a tooltip. Second person. The learner is a "vibe coder" — builds
+  software by instructing AI, no CS background. **Never use a restaurant/kitchen metaphor.**
+  Already used elsewhere and off-limits here: photo lab (M1), film production (M2), festival
+  wristband (M3), chequebook register (M4). Actor naming across the course: **Browser, Server,
+  Gemini, Database, Stripe, Storage** — capitalised, consistent. Be matter-of-fact and kind about
+  the two gotchas — the goal is "this is normal and here's how you catch it", never mockery of
+  whoever wrote it.
+  Your file must contain ONLY `<section class="module" id="module-5"> ... </section>` — no
+  `<html>`, `<head>`, `<body>`, `<style>` or `<script>` tags. Write it to
+  `courses/general-course/modules/05-memory-and-the-outside-world.html`.

--- a/courses/general-course/briefs/06-every-language-every-screen.md
+++ b/courses/general-course/briefs/06-every-language-every-screen.md
@@ -1,0 +1,270 @@
+# Module 6: Every Language, Every Screen
+
+> You are writing ONE module of a 7-module course about a real, live web app.
+> The app: **charlieandlola.net** — upload a selfie, get a Charlie & Lola cartoon character
+> from Google's Gemini AI. Free to try, sign in to download, buy credits for more.
+> Next.js 15 + TypeScript + Tailwind CSS + Shadcn UI. It runs in English and Chinese.
+
+### Teaching Arc
+
+- **Metaphor:** **The museum audio guide.** The museum is built once. The paintings hang where they
+  hang, the corridors run where they run. At the door you pick a language and get a handset, and
+  from then on every plaque you stand in front of is narrated in *your* language. Nobody built a
+  second museum for Mandarin speakers. The building is the **structure** (components and layout);
+  the narration is the **content** (translation files); the handset you pick up at the door is the
+  **locale**. Use museum / handset / narration / plaques throughout.
+- **Opening hook:** "Every error message we've quoted so far has been in English. Add `/zh` to the
+  address bar of this app and the entire thing becomes Chinese — same buttons, same layout, same
+  code. Not one component was duplicated to make that happen."
+- **Key insight:** **Separate structure from content.** The moment text stops living inside your
+  components and starts living in data files, you get translations, A/B tests, and non-developers
+  editing marketing copy — all for free. It's the same principle as Module 2's "the page is a
+  template, the content is data", now applied to every word on the site.
+- **"Why should I care?":** Two things. (1) Retro-fitting translation into an app where text is
+  scattered across 200 components is a brutal, expensive job — knowing to say *"put user-facing
+  strings in the translation files, not inline"* on day one saves weeks. (2) The same discipline
+  applies to design: this app has 37 tiny reusable interface pieces and a colour palette defined in
+  exactly one file, which is why "make the whole site more orange" is a one-line change.
+
+### Half One: Two Languages, One App
+
+**The doorman.** A file called `middleware.ts` runs *before every single page request*. It looks at
+the address, works out which language you want (from the URL, or your browser's settings), and
+routes you accordingly. It's twelve lines long and it is the reason `/zh/pricing` works at all.
+
+**Two kinds of text, two different homes.** This is the screen most worth getting right:
+
+| Kind | Where it lives | Example |
+|---|---|---|
+| **Interface labels** — buttons, errors, form hints | `src/i18n/messages/en.json` and `zh.json` | `"sign_in": "Sign In"` |
+| **Page content** — the whole marketing page, section by section | `src/i18n/pages/landing/en.json` and `zh.json` | the hero headline, the FAQ list, all 8 pricing plans |
+
+The second one is the surprising one. The entire landing page — hero, features, testimonials, FAQ,
+pricing — is a JSON file with keys named `hero`, `introduce`, `benefit`, `usage`, `feature`,
+`stats`, `testimonial`, `faq`, `cta`, `footer`. Module 2 showed the page component drawing each
+section only if the data exists. **This is where that data comes from.** You can rewrite the entire
+marketing site without touching a single line of code.
+
+**The fallback chain** is a small, elegant thing worth showing: unknown language → try to load its
+file → if that fails for any reason, quietly serve English. Users see a page in the wrong language
+rather than an error page. Same idea as Module 5's graceful degradation, in a new costume.
+
+**Prices are localised too, not just words.** The Chinese pricing file carries a `cn_amount`, and
+Chinese checkouts add WeChat Pay and Alipay. Localisation isn't translation — it's *adaptation*.
+
+### Half Two: Building the Interface Out of Standard Parts
+
+**Three layers of interface**, from smallest to largest — present as a diagram or step cards:
+1. **Tailwind CSS** — instead of writing style rules in a separate file, you write tiny class names
+   directly on the element: `className="flex items-center gap-2 rounded-md"`. Divisive, but very
+   fast, and there's no such thing as "which stylesheet is this coming from?"
+2. **`src/components/ui/` (Shadcn UI)** — 37 generic parts: button, card, dialog, tabs, tooltip,
+   table. Crucially, these are **not** an installed library — the code was copied *into* the
+   project, so it can be edited. That's the whole idea of Shadcn: you own the parts.
+3. **`src/components/blocks/`** — whole page sections assembled from the parts: `hero`, `pricing`,
+   `faq`, `footer`, `showcase`.
+
+**Variants.** A button isn't one button — it's a small menu of options (`variant`: default,
+destructive, outline, secondary, ghost, link; `size`: default, sm, lg, icon). One file defines every
+button that will ever appear on the site. Worth naming out loud: this is *why* the site looks
+consistent, and it's what "design system" actually means in practice.
+
+**One palette, one file.** All colours are defined once as CSS custom properties in
+`src/app/theme.css`, in a colour format called `oklch`. The brand palette is named after the
+cartoon: `--cl-yellow`, `--cl-orange`, `--cl-blue`, `--cl-pink`, `--cl-green`, `--cl-red`,
+`--cl-brown`. Dark mode is the same variable names redefined. Nothing hardcodes a hex code.
+
+### Code Snippets (pre-extracted — use verbatim, do not edit)
+
+**Snippet A — the doorman. The whole file is twelve lines.**
+File: `src/middleware.ts` (whole file)
+
+```ts
+import createMiddleware from "next-intl/middleware";
+import { routing } from "./i18n/routing";
+
+export default createMiddleware(routing);
+
+export const config = {
+  matcher: [
+    "/",
+    "/(en|en-US|zh|zh-CN|zh-TW|zh-HK|zh-MO|ja|ko|ru|fr|de|ar|es|it)/:path*",
+    "/((?!privacy-policy|terms-of-service|api/|_next|_vercel|.*\\..*).*)",
+  ],
+};
+```
+
+Worth pointing out: the list of languages the doorman *recognises* is much longer than the two the
+app actually *supports*. Also note `api/` is deliberately excluded — API endpoints don't need a
+language prefix. That third pattern is a **regular expression**, a compact notation for "match
+these addresses but not those" — tooltip it, don't explain it in depth.
+
+**Snippet B — only two languages are real.**
+File: `src/i18n/locale.ts` (lines 3–12)
+
+```ts
+export const locales = ["en", "zh"];
+
+export const localeNames: any = {
+  en: "English",
+  zh: "中文",
+};
+
+export const defaultLocale = "en";
+
+export const localePrefix = "as-needed";
+```
+
+`"as-needed"` is a small, real product decision: English is the default, so it gets the clean URL
+(`/pricing`), and only other languages get a prefix (`/zh/pricing`).
+
+**Snippet C — the fallback chain.**
+File: `src/i18n/request.ts` (lines 18–30)
+
+```ts
+  try {
+    const messages = (await import(`./messages/${locale.toLowerCase()}.json`))
+      .default;
+    return {
+      locale: locale,
+      messages: messages,
+    };
+  } catch (e) {
+    return {
+      locale: "en",
+      messages: (await import(`./messages/en.json`)).default,
+    };
+  }
+```
+
+**Snippet D — the whole marketing page is a data file, loaded by language.**
+File: `src/services/page.ts` (lines 15–33)
+
+```ts
+export async function getPage(
+  name: string,
+  locale: string
+): Promise<LandingPage | PricingPage | ShowcasePage> {
+  try {
+    if (locale === "zh-CN") {
+      locale = "zh";
+    }
+
+    return await import(
+      `@/i18n/pages/${name}/${locale.toLowerCase()}.json`
+    ).then((module) => module.default);
+  } catch (error) {
+    console.warn(`Failed to load ${locale}.json, falling back to en.json`);
+
+    return await import(`@/i18n/pages/${name}/en.json`).then(
+      (module) => module.default
+    );
+  }
+}
+```
+
+**Snippet E — one button, six looks.**
+File: `src/components/ui/button.tsx` (lines 12–27)
+
+```tsx
+      variant: {
+        default:
+          "bg-primary text-primary-foreground shadow-xs hover:bg-primary/90",
+        destructive:
+          "bg-destructive text-white shadow-xs hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
+        outline:
+          "border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50",
+        secondary:
+          "bg-secondary text-secondary-foreground shadow-xs hover:bg-secondary/80",
+        ghost:
+          "hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50",
+        link: "text-primary underline-offset-4 hover:underline",
+      },
+```
+
+**Snippet F — the whole brand, in one place.**
+File: `src/app/theme.css` (lines 25–31)
+
+```css
+  --cl-yellow: oklch(0.9 0.15 85);
+  --cl-orange: oklch(0.8 0.15 60);
+  --cl-blue: oklch(0.8 0.08 200);
+  --cl-pink: oklch(0.8 0.1 340);
+  --cl-green: oklch(0.85 0.15 140);
+  --cl-red: oklch(0.7 0.2 25);
+  --cl-brown: oklch(0.6 0.1 60);
+```
+
+### Interactive Elements (all required)
+
+- [x] **Code↔English translation** — at least three: Snippet A (the doorman), Snippet D (page
+      content as data), and Snippet E (button variants) or Snippet C (the fallback).
+- [x] **Data flow animation** — the hero visual. Actors: `Browser` → `Middleware` → `Page` →
+      `Translation Files` → `Browser`. Steps: (1) Someone requests `/zh/pricing`. (2) The doorman
+      middleware reads `zh` out of the address. (3) The page component is told "this request is
+      Chinese". (4) It loads `messages/zh.json` for labels and `pages/pricing/zh.json` for content.
+      (5) The *same* components render, filled with Chinese text and CNY prices. (6) Show the
+      fallback branch: an unsupported language quietly gets English instead of an error.
+- [x] **Side-by-side comparison** — the same interface rendered in English and Chinese from the same
+      component, with the JSON key shown in the middle. E.g. `"sign_in"` → "Sign In" / "登录".
+      This is the visual that makes the whole idea click; make it prominent.
+- [x] **Pattern/feature cards** — the three interface layers (Tailwind → ui/ parts → blocks), and/or
+      the button variants shown as actual styled chips.
+- [x] **Quiz** — 3–4 questions, scenario style:
+      1. "The marketing team wants to change the headline on the home page. Do they need a
+         developer?" (Correct: no — it's a text field in a JSON data file. Wrong options teach that
+         it's not in the component and not in the database.)
+      2. "You add a French version. What do you have to create, and what do you *not* have to
+         touch?" (Correct: add `fr` to the locale list and add the JSON files; you don't duplicate
+         a single component.)
+      3. "A user in Germany visits and the app has no German. What do they see?" (Correct: English —
+         the fallback. Not an error page, not a blank page.)
+      4. "You ask an AI to add a new 'Danger' button style. Where should it go, and why does that
+         matter?" (Correct: as a new variant in the one button file — so every Danger button on the
+         site stays identical and can be changed in one place.)
+- [x] **Glossary tooltips** — aggressive. At minimum: internationalisation/i18n, locale, middleware,
+      JSON, key/value, fallback, hardcode, CSS, Tailwind, class name, component library, Shadcn,
+      variant, CSS custom property/variable, dark mode, hex code, `oklch`, regular expression, URL
+      prefix, render, prop, design system, currency code, CNY.
+- [x] **Callout boxes** — one "aha" on *separate structure from content and you get translation,
+      experiments and non-developer edits for free*; one on *localisation is adaptation, not just
+      translation* (the WeChat Pay / Alipay / `cn_amount` example).
+
+### Screens (aim for 5–6)
+
+1. **The audio guide** — metaphor; the `/zh` reveal.
+2. **The doorman** — Snippet A + B, the flow animation as hero visual.
+3. **Two kinds of text** — the table above, the side-by-side English/Chinese comparison, Snippet D.
+4. **When there's no translation** — Snippet C, the fallback, localisation-as-adaptation callout.
+5. **Building from standard parts** — the three layers, Snippet E, variants as visual chips.
+6. **One palette** — Snippet F, dark mode, then the quiz.
+
+### Reference Files to Read
+
+- `references/content-philosophy.md` — all of it.
+- `references/gotchas.md` — all of it.
+- `references/interactive-elements.md` → "Code ↔ English Translation Blocks", "Multiple-Choice
+  Quizzes", "Message Flow / Data Flow Animation", "Pattern/Feature Cards", "Callout Boxes",
+  "Glossary Tooltips", "Layer Toggle Demo", "Icon-Label Rows", "Flow Diagrams".
+- `references/design-system.md` → "Module Structure", "Color Palette", "Typography".
+
+### Connections
+
+- **Previous module: "Memory and the Outside World"** — the eight database tables, schema and
+  migrations, connection pooling, the Gemini API key pool, graceful degradation, and two real
+  gotchas (a Supabase database that had been deleted, and a password hardcoded into
+  `src/db/index.ts`). It ended by noting that every error message quoted so far was in English,
+  but the app runs in two languages and none of that text lives in the components. Open on that.
+- **Next module: "When It Breaks"** — debugging intuition and how the app actually gets onto the
+  internet (Vercel, Cloudflare, Docker) — the final module, which also recaps the whole course.
+  End by pointing forward: everything so far has been *how it works*. The last module is *what to
+  do when it doesn't*, and how all of this gets from a laptop onto the real internet.
+- **Tone/style notes:** Accent colour is **vermillion** (warm red-orange). Warm developer-notebook
+  feel. Zero jargon without a tooltip. Second person. The learner is a "vibe coder" — builds
+  software by instructing AI, no CS background. **Never use a restaurant/kitchen metaphor.**
+  Already used elsewhere and off-limits here: photo lab (M1), film production (M2), festival
+  wristband (M3), chequebook register (M4), blueprints-and-permits (M5). Actor naming across the
+  course: **Browser, Server, Gemini, Database, Stripe, Storage** — capitalised, consistent.
+  Your file must contain ONLY `<section class="module" id="module-6"> ... </section>` — no
+  `<html>`, `<head>`, `<body>`, `<style>` or `<script>` tags. Write it to
+  `courses/general-course/modules/06-every-language-every-screen.html`.

--- a/courses/general-course/briefs/07-when-it-breaks.md
+++ b/courses/general-course/briefs/07-when-it-breaks.md
@@ -1,0 +1,292 @@
+# Module 7: When It Breaks — Debugging, Shipping, and the Whole Picture
+
+> You are writing the FINAL module of a 7-module course about a real, live web app.
+> The app: **charlieandlola.net** — upload a selfie, get a Charlie & Lola cartoon character
+> from Google's Gemini AI. Free to try, sign in to download, buy credits for more.
+> Next.js 15 + TypeScript, PostgreSQL, Stripe, Google Gemini, Cloudflare R2, two languages.
+> This module has two jobs: build debugging intuition, and send the learner off with the whole
+> architecture in one picture.
+
+### Teaching Arc
+
+- **Metaphor:** **Aviation.** Two halves, one world. Before every flight there's a **pre-flight
+  checklist** — the same items, every time, read aloud, because "I'm sure it's fine" is how planes
+  crash. That's deployment. And when something *does* go wrong, investigators don't guess; they
+  pull the **flight recorder** and read what the aircraft was actually doing, second by second.
+  That's logging and debugging. Use checklist / flight recorder / instruments throughout. Note the
+  key aviation idea explicitly: you don't debug by *thinking harder*, you debug by *getting more
+  instrument readings*.
+- **Opening hook:** "Six modules of how it works. Here's the part nobody writes down: what to do at
+  11pm when a user emails 'it's broken' and you have no idea where to start."
+- **Key insight:** Debugging is **binary search on a pipeline**. You know the message travels
+  Browser → Server → outside service → Database → back. Every observation cuts the search space in
+  half. The goal of any debugging session is never "fix it" — it's "find the first step where
+  reality stopped matching expectation."
+- **"Why should I care?":** This is the single most valuable module for someone who directs AI.
+  AI assistants are excellent at fixing a problem you can *describe precisely* and terrible at
+  finding one you can only describe as "it doesn't work". A vague report sends AI into a loop of
+  speculative rewrites, each one making the codebase worse. One precise sentence — *"the POST to
+  /api/generate-cyberpunk returns 200 with code -1 and message 'Insufficient credits' even though
+  the balance shows 40"* — usually gets fixed on the first try.
+
+### Half One: When It Breaks
+
+**The five-question ladder** (the module's central visual — numbered step cards or a flow diagram).
+For any bug, ask in this order:
+1. **Did the request even leave the browser?** (Browser dev tools → Network tab. No request = the
+   bug is in your click handler, not on the server.)
+2. **Did the server receive it, and what did it answer?** (Status code + the response body. This
+   app always replies `{ code, message, data }` — `code: 0` is fine, `code: -1` is an error with a
+   human-readable message right there.)
+3. **Did an outside service refuse?** (Gemini quota, Stripe signature, storage credentials. These
+   show up in server logs, not in the browser.)
+4. **Is the data actually what you think it is?** (Is the credits row there? Is the order status
+   still `created`?)
+5. **Is it the environment, not the code?** (Works locally, fails in production ⇒ suspect
+   environment variables first, every time. Module 3's GitHub-sign-in-button example is exactly
+   this.)
+
+**Three real bug shapes from this exact codebase.** Present these as cards or a spot-the-bug —
+they're concrete, they're true, and each teaches a different instinct:
+
+- **The silent zero.** `getUserCredits()` wraps everything in a `try/catch`, and on *any* failure
+  it logs a line and returns a balance of **zero**. So if the database is unreachable, a paying
+  customer doesn't see "something went wrong" — they see "0 credits" and assume they've been
+  robbed. Lesson: **a catch block that swallows an error turns a loud problem into a quiet lie.**
+  When you ask AI to "add error handling", say what should happen on failure, or you'll get this.
+- **The environment gap.** A feature that works on a laptop and not in production is nearly always
+  a missing environment variable, not broken code. In this app whole sign-in providers, the entire
+  storage upload, and the payment provider choice are all switched on and off by env vars.
+- **The name that lies.** The image endpoint is still called `/api/generate-cyberpunk` from a
+  previous version of the product (Module 1 flagged this). There are also `.backup` copies of route
+  files sitting in the repo. Lesson: in a real codebase, names and leftovers drift. Describe
+  *behaviour* to an AI, not filenames.
+
+**Reading the flight recorder.** The generation route logs a block of context before every AI call —
+mode, model, aspect ratio, whether the user was registered, their uuid. Show it: this is somebody
+deliberately deciding what they'd want to know at 3am. Teach the principle: **log the inputs you'd
+need to reproduce the problem**, and never log secrets.
+
+**The 60-second cliff.** `vercel.json` gives API endpoints a hard 60-second limit. Image generation
+takes ~10 seconds, so there's headroom — but this is exactly the kind of invisible ceiling that
+makes a feature work in testing and fail under load. Name the class of problem: *limits you didn't
+choose and can't see*.
+
+### Half Two: Getting It Onto the Internet
+
+**Three ways to ship the same app** — cards, with the trade-off named for each:
+- **Vercel** — the default. Push to git, it builds and deploys. Easiest; you're on their terms.
+- **Cloudflare Workers** — a separate branch, runs at the edge, needs a special database
+  connection (Hyperdrive) because the environment is more restricted. Cheap and fast; more
+  constraints. The database file literally has a branch for it: `if (isCloudflareWorker)` opens
+  exactly one connection instead of a pool.
+- **Docker** — a recipe that builds a self-contained box you can run anywhere. Most portable;
+  most work.
+
+**The build step.** Worth one clear screen: the code you write is not the code that runs. `pnpm build`
+turns TypeScript into JavaScript, pre-renders pages, and bundles everything. `output: "standalone"`
+in the config means "produce one folder that contains everything needed to run" — which is what
+makes the Docker image small. Note the multi-stage Dockerfile: install → build → copy only the
+result into a fresh image, and run as a non-root user (`USER nextjs`) so a compromise can't take
+the whole machine.
+
+**The checklist.** Give the learner an actual pre-flight checklist they can reuse for any project:
+environment variables set in production? database reachable *from production*, not just locally?
+webhook URL registered with the payment provider and pointing at the live domain? secrets not in
+the code? external service quotas high enough for launch day? a way to see the logs?
+
+### Half Three: The Whole Picture (close the course here)
+
+One full architecture diagram tying all seven modules together, then a short send-off. The diagram
+should show: Browser (React components, `ui/` + `blocks/`) → Middleware (language) → Pages & API
+Routes → Services (business rules) → Models → PostgreSQL; with Auth, Stripe, Gemini and R2 hanging
+off the side as outside services. Label each region with the module that covered it.
+
+Then a genuinely useful closing list: **the vocabulary you now own** — request/response, endpoint,
+session, token, webhook, idempotent, ledger, schema, migration, connection pool, rate limit,
+environment variable, graceful degradation, locale, component, server vs client, variant, middleware.
+Frame it exactly as the payoff promised: these are the words that let you tell an AI assistant
+precisely what you want.
+
+### Code Snippets (pre-extracted — use verbatim, do not edit)
+
+**Snippet A — the silent zero.** The most teachable seven lines in the codebase.
+File: `src/services/credit.ts` (lines 65–77)
+
+```ts
+    if (user_credits.left_credits < 0) {
+      user_credits.left_credits = 0;
+    }
+
+    if (user_credits.left_credits > 0) {
+      user_credits.is_pro = true;
+    }
+
+    return user_credits;
+  } catch (e) {
+    console.log("get user credits failed: ", e);
+    return user_credits;
+  }
+```
+
+The `user_credits` returned from the catch block is the one initialised at the top of the function
+with all zeros. A database outage and "you have no credits" look identical to the user.
+
+**Snippet B — deliberately logging the context you'd want at 3am.**
+File: `src/app/api/generate-cyberpunk/route.ts` (lines 95–105)
+
+```ts
+    console.log("=== Charlie and Lola API Request Details ===");
+    console.log("Mode:", mode);
+    console.log("Model:", model);
+    console.log("Aspect Ratio:", aspectRatio);
+    console.log("Output Format:", outputFormat);
+    console.log("Style:", style);
+    console.log("Custom Prompt:", customPrompt ? "Yes" : "No");
+    console.log("Images uploaded:", images.length);
+    console.log("User Registered:", isRegisteredUser);
+    console.log("User UUID:", userUuid || "Guest user");
+    console.log("===========================================");
+```
+
+**Snippet C — the invisible ceiling.**
+File: `vercel.json` (whole file)
+
+```json
+{
+  "functions": {
+    "app/api/**/*": {
+      "maxDuration": 60,
+      "memory": 1024
+    }
+  }
+}
+```
+
+**Snippet D — the same code, two environments.**
+File: `src/db/index.ts` (lines 55–67)
+
+```ts
+  // In Cloudflare Workers, create new connection each time
+  if (isCloudflareWorker) {
+    console.log("in Cloudflare Workers environment");
+    // Workers environment uses minimal configuration
+    const client = postgres(databaseUrl, {
+      prepare: false,
+      max: 1, // Limit to 1 connection in Workers
+      idle_timeout: 10, // Shorter timeout for Workers
+      connect_timeout: 5,
+    });
+
+    return drizzle(client);
+  }
+```
+
+**Snippet E — building a shippable box, and dropping privileges.**
+File: `Dockerfile` (lines 22–33)
+
+```dockerfile
+FROM base AS runner
+WORKDIR /app
+
+RUN addgroup --system --gid 1001 nodejs && \
+    adduser --system --uid 1001 nextjs && \
+    mkdir .next && \
+    chown nextjs:nodejs .next
+
+COPY --from=builder /app/public ./public
+COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
+COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
+
+USER nextjs
+```
+
+### Interactive Elements (all required)
+
+- [x] **Code↔English translation** — at least three: Snippet A (the silent zero — translate the
+      catch block into what the *user* experiences), Snippet C (the invisible ceiling), and
+      Snippet D or E.
+- [x] **Interactive architecture diagram** — the whole-app picture described above. This is the
+      module's hero visual and the course's closing image. Label regions with module numbers.
+- [x] **Data flow animation** — a *debugging* flow rather than a success flow: walk the five-question
+      ladder as a pipeline with a red X appearing at a different stage each step, showing what you'd
+      observe at each point. (Or: animate one concrete bug — "user says image never appears" — being
+      narrowed down step by step.)
+- [x] **Spot the Bug challenge** — Snippet A. Show it, ask what a user experiences when the database
+      is down, then reveal.
+- [x] **Quiz** — 4–5 questions, all scenario/debugging. This is the course's final quiz, so make it
+      a genuine test of everything:
+      1. "A customer says they paid but have no credits. Walk the ladder: what do you check, in what
+         order?" (Correct answer should involve: did Stripe send the webhook / did it verify / is
+         the order status `paid` / is there a credits row for that order number.)
+      2. "Everything works locally; in production sign-in with GitHub does nothing. Best first
+         guess?" (Correct: missing environment variables in production.)
+      3. "An AI assistant offers to 'add error handling' to a data-fetching function. What should
+         you specify?" (Correct: what should happen on failure — surface the error, don't return a
+         default that looks like real data.)
+      4. "You want to add a feature where users can save favourites. Based on the whole course,
+         name the layers you'd expect to change." (Correct: a new table + migration, a model, a
+         service, an API route, a component — and translation strings for both languages.) This is
+         the capstone question; the explanation should walk the full stack.
+      5. "The generation feature starts timing out only during a traffic spike. Name two suspects
+         you now know about." (Correct: the 60-second function limit and the exhausted Gemini API
+         key pool.)
+- [x] **Glossary tooltips** — aggressive. At minimum: debugging, dev tools, Network tab, status
+      code, log, stack trace, `try/catch`, exception, environment variable, production vs
+      development, deploy, build, bundle, Vercel, Cloudflare Workers, edge, Docker, container,
+      image (Docker sense), multi-stage build, root user, timeout, memory limit, branch, git,
+      binary search, reproduce.
+- [x] **Callout boxes** — one "aha" on *debugging is binary search, not inspiration*; one warning on
+      *a catch block that swallows errors turns a loud problem into a quiet lie*; one closing note
+      on *works locally ≠ works in production, and the difference is almost always configuration*.
+
+### Screens (aim for 6)
+
+1. **The flight recorder** — metaphor; you don't think harder, you get more readings.
+2. **The five-question ladder** — step cards + the debugging flow animation. Hero visual #1.
+3. **Three bugs from this codebase** — the silent zero (Snippet A + spot-the-bug), the environment
+   gap, the name that lies.
+4. **What to log** — Snippet B, plus never log secrets. Snippet C and the invisible ceiling.
+5. **Getting it onto the internet** — three deployment routes as cards, Snippets D and E, the build
+   step, and the reusable pre-flight checklist.
+6. **The whole picture** — the architecture diagram, the vocabulary list, the final quiz, and a
+   warm two-sentence send-off. Do not end on the quiz alone; end on encouragement.
+
+### Reference Files to Read
+
+- `references/content-philosophy.md` — all of it.
+- `references/gotchas.md` — all of it.
+- `references/interactive-elements.md` → "Code ↔ English Translation Blocks", "Multiple-Choice
+  Quizzes", "Interactive Architecture Diagram", "Message Flow / Data Flow Animation", "Spot the Bug
+  Challenge", "Callout Boxes", "Glossary Tooltips", "Numbered Step Cards", "Pattern/Feature Cards",
+  "Permission/Config Badges".
+- `references/design-system.md` → "Module Structure", "Color Palette", "Typography".
+
+### Connections
+
+- **Previous module: "Every Language, Every Screen"** — middleware routing by language, interface
+  labels vs page content in JSON data files, the English fallback, Tailwind + the 37 reusable `ui/`
+  parts + `blocks/`, button variants, and the one-file colour palette. It ended by saying the last
+  module is *what to do when it doesn't work*, and how all of this gets from a laptop onto the real
+  internet. Open on that.
+- **Next module:** none — this is the finale. Recap the whole course and send the learner off.
+- **What the other six modules covered, for the recap:**
+  1. *What Happens When You Click Generate* — request/response, the API route, the AI prompt.
+  2. *Meet the Cast* — folder map, the Route → Service → Model → Database layer rule, server vs client.
+  3. *Who Are You?* — OAuth, sessions, tokens, hashed passwords, 30 free credits on signup.
+  4. *Following the Money* — Stripe checkout, webhooks, idempotency, the append-only credits ledger.
+  5. *Memory and the Outside World* — the eight tables, schema & migrations, connection pooling, the
+     Gemini key pool, graceful degradation, and two real gotchas (a deleted Supabase database, a
+     hardcoded password).
+  6. *Every Language, Every Screen* — middleware, locales, content as data, the design system.
+- **Tone/style notes:** Accent colour is **vermillion** (warm red-orange). Warm developer-notebook
+  feel. Zero jargon without a tooltip. Second person. The learner is a "vibe coder" — builds
+  software by instructing AI, no CS background. **Never use a restaurant/kitchen metaphor.**
+  Already used elsewhere and off-limits here: photo lab (M1), film production (M2), festival
+  wristband (M3), chequebook register (M4), blueprints-and-permits (M5), museum audio guide (M6).
+  Actor naming across the course: **Browser, Server, Gemini, Database, Stripe, Storage** —
+  capitalised, consistent. Be generous and encouraging at the close: the learner has just read a
+  real production codebase end to end, which is genuinely hard.
+  Your file must contain ONLY `<section class="module" id="module-7"> ... </section>` — no
+  `<html>`, `<head>`, `<body>`, `<style>` or `<script>` tags. Write it to
+  `courses/general-course/modules/07-when-it-breaks.html`.

--- a/courses/general-course/build.sh
+++ b/courses/general-course/build.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# Assembles the course from parts.
+# Run from the course directory: bash build.sh
+set -e
+cat _base.html modules/*.html _footer.html > index.html
+echo "Built index.html — open it in your browser."

--- a/courses/general-course/index.html
+++ b/courses/general-course/index.html
@@ -1,0 +1,4187 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Inside a Real AI App</title>
+
+  <!-- Google Fonts: Bricolage Grotesque · DM Sans · JetBrains Mono -->
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:opsz,wght@12..96,400;12..96,600;12..96,700;12..96,800&family=DM+Sans:ital,opsz,wght@0,9..40,300;0,9..40,400;0,9..40,500;0,9..40,600;0,9..40,700;1,9..40,400;1,9..40,500&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+
+  <link rel="stylesheet" href="styles.css">
+
+  <!--
+    CUSTOMIZE PER COURSE — change only the three accent variables below.
+    Options:
+      vermillion  #D94F30 / #C4432A / #FDEEE9 / #E8836C  (default)
+      coral       #E06B56 / #C85A47 / #FDECEA / #E89585
+      teal        #2A7B9B / #1F6280 / #E4F2F7 / #5A9DB8
+      amber       #D4A843 / #BF9530 / #FDF5E0 / #E0C070
+      forest      #2D8B55 / #226B41 / #E8F5EE / #5AAD7A
+  -->
+  <style>
+    :root {
+      --color-accent:       #D94F30;
+      --color-accent-hover: #C4432A;
+      --color-accent-light: #FDEEE9;
+      --color-accent-muted: #E8836C;
+    }
+  </style>
+
+  <script src="main.js" defer></script>
+</head>
+<body>
+
+  <nav class="nav" id="nav">
+    <div class="progress-bar" id="progress-bar" role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100"></div>
+    <div class="nav-inner">
+      <span class="nav-title">Inside a Real AI App</span>
+      <div class="nav-dots" id="nav-dots" role="tablist">
+        <button class="nav-dot" data-target="module-1" data-tooltip="What Happens When You Click Generate" role="tab" aria-label="Module 1: What Happens When You Click Generate"></button>
+        <button class="nav-dot" data-target="module-2" data-tooltip="Meet the Cast" role="tab" aria-label="Module 2: Meet the Cast"></button>
+        <button class="nav-dot" data-target="module-3" data-tooltip="Who Are You?" role="tab" aria-label="Module 3: Who Are You?"></button>
+        <button class="nav-dot" data-target="module-4" data-tooltip="Following the Money" role="tab" aria-label="Module 4: Following the Money"></button>
+        <button class="nav-dot" data-target="module-5" data-tooltip="Memory and the Outside World" role="tab" aria-label="Module 5: Memory and the Outside World"></button>
+        <button class="nav-dot" data-target="module-6" data-tooltip="Every Language, Every Screen" role="tab" aria-label="Module 6: Every Language, Every Screen"></button>
+        <button class="nav-dot" data-target="module-7" data-tooltip="When It Breaks" role="tab" aria-label="Module 7: When It Breaks"></button>
+      </div>
+    </div>
+  </nav>
+
+  <main id="main">
+    <!-- modules/*.html content is assembled here by build.sh -->
+<section class="module" id="module-1" style="background: var(--color-bg-warm)">
+  <div class="module-content">
+    <header class="module-header animate-in">
+      <span class="module-number">01</span>
+      <h1 class="module-title">What Happens When You Click "Generate"</h1>
+      <p class="module-subtitle">Ten seconds, five pieces of code, one message traveling there and back.</p>
+    </header>
+
+    <div class="module-body">
+
+      <!-- SCREEN 1 — What this app even is -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">What This App Even Is</h2>
+        <p>You pick a photo of yourself, hit Generate, watch a spinner for about ten seconds, and a cartoon version of you appears in the Charlie &amp; Lola style. Those ten seconds are basically this whole course, running in miniature — let's slow them down.</p>
+
+        <div class="icon-rows">
+          <div class="icon-row">
+            <div class="icon-circle" style="background: var(--color-actor-1)">📷</div>
+            <div>
+              <strong><span class="term" data-definition="To upload is to send a file from your device to a server somewhere else on the internet. Uploading is the opposite of downloading.">Upload</span> a photo</strong>
+              <p>Any selfie or portrait, straight from your camera roll.</p>
+            </div>
+          </div>
+          <div class="icon-row">
+            <div class="icon-circle" style="background: var(--color-actor-3)">🎨</div>
+            <div>
+              <strong>Get a cartoon</strong>
+              <p>A Charlie &amp; Lola style version, drawn by an AI <span class="term" data-definition="In AI, a model is the trained system that actually does the work — recognizing images, generating text, or in this case, drawing a cartoon. Different models are good at different tasks.">model</span>.</p>
+            </div>
+          </div>
+          <div class="icon-row">
+            <div class="icon-circle" style="background: var(--color-actor-4)">🆓</div>
+            <div>
+              <strong>Free to try</strong>
+              <p>No account needed just to see a preview.</p>
+            </div>
+          </div>
+          <div class="icon-row">
+            <div class="icon-circle" style="background: var(--color-actor-2)">💳</div>
+            <div>
+              <strong>Sign in for credits</strong>
+              <p>Downloading full resolution and generating more costs credits.</p>
+            </div>
+          </div>
+        </div>
+
+        <p>Under the hood this is a full commercial product — payments, accounts, two languages, an AI model — packed into roughly 330 <span class="term" data-definition="TypeScript is a version of JavaScript that adds strict rules about what type of data (text, number, etc.) each piece of code expects, which helps catch mistakes before the code even runs.">TypeScript</span> files. That's more machinery than it looks like from the outside.</p>
+      </section>
+
+      <!-- SCREEN 2 — The photo lab metaphor -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">The Envelope You Never See Behind</h2>
+        <p>Picture a one-hour photo lab. You slide your film into a paper envelope, write "matte finish, 4x6" on the outside, and post it through a slot in the wall. You never see what happens back there.</p>
+
+        <div class="step-cards">
+          <div class="step-card">
+            <div class="step-num">1</div>
+            <div class="step-body">
+              <strong>You write your options on the envelope</strong>
+              <p>Your photo, plus the finish and size you want.</p>
+            </div>
+          </div>
+          <div class="step-card">
+            <div class="step-num">2</div>
+            <div class="step-body">
+              <strong>You push it through the slot in the wall</strong>
+              <p>It leaves your hands entirely.</p>
+            </div>
+          </div>
+          <div class="step-card">
+            <div class="step-num">3</div>
+            <div class="step-body">
+              <strong>The back room develops it</strong>
+              <p>You cannot see this part happening — you just wait.</p>
+            </div>
+          </div>
+          <div class="step-card">
+            <div class="step-num">4</div>
+            <div class="step-body">
+              <strong>An envelope of prints comes back out</strong>
+              <p>The finished result, handed back to you.</p>
+            </div>
+          </div>
+        </div>
+
+        <p>Your <span class="term" data-definition="The browser is the app running on your own computer or phone — Chrome, Safari, and so on. It's the 'client': the one asking for things, as opposed to the server that provides them.">browser</span> and the <span class="term" data-definition="A server is a computer sitting somewhere else, waiting to receive requests and act on them. In this app, it validates your photo, talks to the AI, and hands back a cartoon.">server</span> are two separate computers that can only pass each other messages — nothing more. Everything an app does is really just: package a message, send it, wait, unpack the reply.</p>
+
+        <p>In this app: the envelope is your <span class="term" data-definition="A request is a message sent from one computer to another asking it to do something, like a note passed through a mail slot. It carries data plus instructions about what you want back.">request</span>; the slot is the <span class="term" data-definition="API stands for Application Programming Interface — a defined way for one piece of software to ask another for something, like a menu of requests a computer will accept. When instructing an AI, you might say 'call the API' to mean 'ask the server for this.'">API</span> <span class="term" data-definition="An endpoint is one specific address a server listens on, like a numbered door in a building. Each endpoint handles one kind of request — this app's image endpoint is /api/generate-cyberpunk.">endpoint</span>; the back room is the server; and the prints coming back are the <span class="term" data-definition="A response is the message a server sends back after handling a request — the reply to your note. It carries the result, or an explanation of what went wrong.">response</span>.</p>
+
+        <div class="callout callout-accent">
+          <div class="callout-icon">💡</div>
+          <div class="callout-content">
+            <strong class="callout-title">Key Insight</strong>
+            <p>The entire internet is just this loop, over and over: package a message, send it, wait, unpack the reply. Once you can see that loop, nothing on the internet is actually mysterious — just message after message.</p>
+          </div>
+        </div>
+      </section>
+
+      <!-- SCREEN 3 — The envelope (Snippet A) -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">The Envelope</h2>
+        <p>When you click Generate, the browser doesn't send your photo file all by itself — it builds a <span class="term" data-definition="FormData is a browser feature for bundling a file (like your photo) together with other form fields into one package ready to send. Think of it as a box you can drop files and labels into before mailing it.">FormData</span> package first: your photo, plus every option you picked.</p>
+
+        <p>The photo itself started life as a giant <span class="term" data-definition="Base64 is a way of turning a photo's raw bytes into a long string of letters and numbers, so it can be stored or sent as plain text. It isn't compression — it just repackages the same picture as text.">base64</span> text string, sitting quietly in memory and <span class="term" data-definition="localStorage is a small storage locker inside your browser that keeps data on your device even after you close the tab, until something clears it.">localStorage</span> the moment you dropped it in — long before you ever clicked Generate.</p>
+
+        <p>This whole exchange is powered by a single JavaScript command called <span class="term" data-definition="fetch() is the browser's built-in tool for sending a request to a server and waiting for the reply. It's the JavaScript equivalent of typing a URL and hitting enter, but from inside code.">fetch</span>. Here's the actual code that packs and sends the envelope:</p>
+
+        <div class="translation-block animate-in">
+          <div class="translation-code">
+            <span class="translation-label">CODE</span>
+            <pre><code>
+<span class="code-line">      <span class="code-keyword">const</span> formData = <span class="code-keyword">new</span> <span class="code-function">FormData</span>();</span>
+<span class="code-line"></span>
+<span class="code-line">      formData.<span class="code-function">append</span>(<span class="code-string">'mode'</span>, <span class="code-string">'image2image'</span>);</span>
+<span class="code-line">      formData.<span class="code-function">append</span>(<span class="code-string">'style'</span>, <span class="code-string">'charlie-lola'</span>); <span class="code-comment">// Fixed style for Charlie and Lola</span></span>
+<span class="code-line">      formData.<span class="code-function">append</span>(<span class="code-string">'aspectRatio'</span>, aspectRatio);</span>
+<span class="code-line">      formData.<span class="code-function">append</span>(<span class="code-string">'outputFormat'</span>, outputFormat);</span>
+<span class="code-line">      formData.<span class="code-function">append</span>(<span class="code-string">'model'</span>, <span class="code-string">'standard'</span>); <span class="code-comment">// Fixed model</span></span>
+<span class="code-line"></span>
+<span class="code-line">      <span class="code-keyword">if</span> (customPrompt.trim()) {</span>
+<span class="code-line">        formData.<span class="code-function">append</span>(<span class="code-string">'customPrompt'</span>, customPrompt);</span>
+<span class="code-line">      }</span>
+<span class="code-line"></span>
+<span class="code-line">      <span class="code-keyword">for</span> (<span class="code-keyword">let</span> i = 0; i &lt; uploadedImages.length; i++) {</span>
+<span class="code-line">        <span class="code-keyword">const</span> response = <span class="code-keyword">await</span> <span class="code-function">fetch</span>(uploadedImages[i]);</span>
+<span class="code-line">        <span class="code-keyword">const</span> blob = <span class="code-keyword">await</span> response.<span class="code-function">blob</span>();</span>
+<span class="code-line">        formData.<span class="code-function">append</span>(`image_${i}`, blob);</span>
+<span class="code-line">      }</span>
+<span class="code-line"></span>
+<span class="code-line">      formData.<span class="code-function">append</span>(<span class="code-string">'imageCount'</span>, uploadedImages.length.<span class="code-function">toString</span>());</span>
+<span class="code-line"></span>
+<span class="code-line">      <span class="code-keyword">const</span> apiResponse = <span class="code-keyword">await</span> <span class="code-function">fetch</span>(<span class="code-string">'/api/generate-cyberpunk'</span>, {</span>
+<span class="code-line">        method: <span class="code-string">'POST'</span>,</span>
+<span class="code-line">        body: formData,</span>
+<span class="code-line">      });</span>
+            </code></pre>
+          </div>
+          <div class="translation-english">
+            <span class="translation-label">PLAIN ENGLISH</span>
+            <div class="translation-lines">
+              <p class="tl">Create an empty envelope you can put things inside.</p>
+              <p class="tl">Label it: this is a Charlie &amp; Lola image-to-image job.</p>
+              <p class="tl">Note the aspect ratio and file format you asked for.</p>
+              <p class="tl">The model setting is fixed to "standard" — always the same.</p>
+              <p class="tl">If you typed a custom instruction, tuck that in too.</p>
+              <p class="tl">Loop through every photo you uploaded (up to 5) and turn each one into raw bytes.</p>
+              <p class="tl">Drop each photo into the envelope, one by one.</p>
+              <p class="tl">Write down how many photos are inside.</p>
+              <p class="tl">Push the whole envelope through the slot in the wall — a <span class="term" data-definition="POST is a type of request that sends data to the server to create or change something, as opposed to GET, which just asks to read something. Uploading your photo is a POST.">POST</span> request to /api/generate-cyberpunk.</p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- SCREEN 4 — The back room -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">The Back Room</h2>
+        <p>Behind the slot, code called an API route unpacks your envelope and <span class="term" data-definition="To validate something is to check that it meets the rules before acting on it — right size, right format, right permissions. Servers validate requests so they don't waste work on bad data.">validates</span> it before doing anything expensive: valid aspect ratio? a photo actually attached? each under 10 <span class="term" data-definition="MB stands for megabyte, a unit of file size. A typical phone photo is a few MB — this app rejects any single image over 10 MB.">MB</span>? enough credits, if you're signed in? a free AI key available right now?</p>
+
+        <div class="translation-block animate-in">
+          <div class="translation-code">
+            <span class="translation-label">CODE</span>
+            <pre><code>
+<span class="code-line"><span class="code-keyword">export async function</span> <span class="code-function">POST</span>(request: Request) {</span>
+<span class="code-line">  <span class="code-keyword">try</span> {</span>
+<span class="code-line">    <span class="code-keyword">const</span> formData = <span class="code-keyword">await</span> request.<span class="code-function">formData</span>();</span>
+<span class="code-line">    <span class="code-keyword">const</span> style = formData.<span class="code-function">get</span>(<span class="code-string">'style'</span>) <span class="code-keyword">as</span> <span class="code-keyword">string</span> || <span class="code-string">'charlie-lola'</span>;</span>
+<span class="code-line">    <span class="code-keyword">const</span> mode = formData.<span class="code-function">get</span>(<span class="code-string">'mode'</span>) <span class="code-keyword">as</span> <span class="code-keyword">string</span> || <span class="code-string">'image2image'</span>; <span class="code-comment">// Charlie and Lola style transformation</span></span>
+<span class="code-line">    <span class="code-keyword">const</span> customPrompt = formData.<span class="code-function">get</span>(<span class="code-string">'customPrompt'</span>) <span class="code-keyword">as</span> <span class="code-keyword">string</span> || <span class="code-string">''</span>;</span>
+<span class="code-line">    <span class="code-keyword">const</span> aspectRatio = formData.<span class="code-function">get</span>(<span class="code-string">'aspectRatio'</span>) <span class="code-keyword">as</span> <span class="code-keyword">string</span> || <span class="code-string">'4:3'</span>;</span>
+<span class="code-line">    <span class="code-keyword">const</span> outputFormat = formData.<span class="code-function">get</span>(<span class="code-string">'outputFormat'</span>) <span class="code-keyword">as</span> <span class="code-keyword">string</span> || <span class="code-string">'png'</span>;</span>
+<span class="code-line">    <span class="code-keyword">const</span> model = formData.<span class="code-function">get</span>(<span class="code-string">'model'</span>) <span class="code-keyword">as</span> <span class="code-keyword">string</span> || <span class="code-string">'standard'</span>;</span>
+<span class="code-line">    <span class="code-keyword">const</span> imageCount = <span class="code-function">parseInt</span>(formData.<span class="code-function">get</span>(<span class="code-string">'imageCount'</span>) <span class="code-keyword">as</span> <span class="code-keyword">string</span> || <span class="code-string">'0'</span>);</span>
+            </code></pre>
+          </div>
+          <div class="translation-english">
+            <span class="translation-label">PLAIN ENGLISH</span>
+            <div class="translation-lines">
+              <p class="tl">This function runs whenever a POST request hits this address.</p>
+              <p class="tl">Try to open the envelope and read what's inside.</p>
+              <p class="tl">Pull out the style — default to "charlie-lola" if nothing was sent.</p>
+              <p class="tl">Pull out the mode — this is an image-to-image transformation.</p>
+              <p class="tl">Pull out any custom instructions you typed.</p>
+              <p class="tl">Pull out the aspect ratio and file format you chose.</p>
+              <p class="tl">Pull out the model setting.</p>
+              <p class="tl">Pull out how many photos you said you were sending.</p>
+            </div>
+          </div>
+        </div>
+
+        <p>If everything checks out, the server builds the actual instruction for the AI — the <span class="term" data-definition="A prompt is the plain-English instructions sent to an AI model telling it what to do. In this app, it's just a string of text sitting in a code file — anyone who can edit that string can change what the AI produces.">prompt</span>.</p>
+
+        <div class="translation-block animate-in">
+          <div class="translation-code">
+            <span class="translation-label">CODE</span>
+            <pre><code>
+<span class="code-line">    <span class="code-keyword">const</span> imageEditPrompt = [</span>
+<span class="code-line">      { text: charlieLolaPrompt },</span>
+<span class="code-line">      {</span>
+<span class="code-line">        inlineData: {</span>
+<span class="code-line">          mimeType: mimeType,</span>
+<span class="code-line">          data: base64Image,</span>
+<span class="code-line">        },</span>
+<span class="code-line">      },</span>
+<span class="code-line">    ];</span>
+<span class="code-line"></span>
+<span class="code-line">    console.<span class="code-function">log</span>(<span class="code-string">"🔄 Generating Charlie and Lola style image..."</span>);</span>
+<span class="code-line"></span>
+<span class="code-line">    <span class="code-keyword">let</span> response;</span>
+<span class="code-line">    <span class="code-keyword">try</span> {</span>
+<span class="code-line">      <span class="code-comment">// Generate edited image using Gemini 2.5 Flash Image Preview</span></span>
+<span class="code-line">      response = <span class="code-keyword">await</span> ai.models.<span class="code-function">generateContent</span>({</span>
+<span class="code-line">        model: <span class="code-string">"gemini-2.5-flash-image-preview"</span>,</span>
+<span class="code-line">        contents: imageEditPrompt,</span>
+<span class="code-line">      });</span>
+            </code></pre>
+          </div>
+          <div class="translation-english">
+            <span class="translation-label">PLAIN ENGLISH</span>
+            <div class="translation-lines">
+              <p class="tl">Build the actual message to the AI: instructions plus your photo.</p>
+              <p class="tl">The instructions are one big block of English text called charlieLolaPrompt.</p>
+              <p class="tl">The photo rides along too — its file type and its base64 bytes.</p>
+              <p class="tl">Print a log line so developers can see this step happening.</p>
+              <p class="tl">Send it all to Google's Gemini model and wait for the answer.</p>
+            </div>
+          </div>
+        </div>
+
+        <p>Tucked inside that prompt is a whole paragraph of do-nots: <em>"No realistic shading, no detailed rendering, no anime or manga style, no 3D modeling, no photographic textures!"</em> It's just text in a file — anyone who can edit that string can change the entire product.</p>
+
+        <div class="callout callout-warning">
+          <div class="callout-icon">⚠️</div>
+          <div class="callout-content">
+            <strong class="callout-title">The Name Lies</strong>
+            <p>This endpoint is called <code>/api/generate-cyberpunk</code> even though the app makes Charlie &amp; Lola cartoons — a leftover name from an earlier version of the product. Real codebases drift like this constantly, which is exactly why you should describe <em>behavior</em> to an AI assistant, not guess from a filename.</p>
+          </div>
+        </div>
+
+        <p>Here's the whole journey, start to finish. Click through it:</p>
+
+        <div class="flow-animation" data-steps='[
+          {"highlight":"flow-actor-1","label":"Browser packs your photo and chosen options into a FormData envelope."},
+          {"highlight":"flow-actor-2","label":"POST to /api/generate-cyberpunk — the envelope goes through the slot.","packet":true,"from":"actor-1","to":"actor-2"},
+          {"highlight":"flow-actor-2","label":"Server checks the envelope: valid aspect ratio? photo present? under 10MB? enough credits? a free AI key available?"},
+          {"highlight":"flow-actor-3","label":"Server sends the prompt plus your photo bytes to Gemini and waits.","packet":true,"from":"actor-2","to":"actor-3"},
+          {"highlight":"flow-actor-2","label":"Gemini finishes drawing and sends back raw image data.","packet":true,"from":"actor-3","to":"actor-2"},
+          {"highlight":"flow-actor-4","label":"Server uploads the image to Cloudflare R2 storage and gets a URL back.","packet":true,"from":"actor-2","to":"actor-4"},
+          {"highlight":"flow-actor-1","label":"Server sends back one JSON reply containing that imageUrl.","packet":true,"from":"actor-2","to":"actor-1"},
+          {"highlight":"flow-actor-1","label":"Browser puts the URL into an image tag and pops up a toast. Done."}
+        ]'>
+          <div class="flow-actors">
+            <div class="flow-actor" id="flow-actor-1">
+              <div class="flow-actor-icon">🌐</div>
+              <span>Browser</span>
+            </div>
+            <div class="flow-actor" id="flow-actor-2">
+              <div class="flow-actor-icon">🖥️</div>
+              <span>Server</span>
+            </div>
+            <div class="flow-actor" id="flow-actor-3">
+              <div class="flow-actor-icon">✨</div>
+              <span>Gemini</span>
+            </div>
+            <div class="flow-actor" id="flow-actor-4">
+              <div class="flow-actor-icon">☁️</div>
+              <span>Storage</span>
+            </div>
+          </div>
+
+          <div class="flow-packet" id="flow-packet"></div>
+
+          <div class="flow-step-label" id="flow-label">Click "Next Step" to begin</div>
+
+          <div class="flow-controls">
+            <button class="btn flow-next-btn">Next Step</button>
+            <button class="btn flow-reset-btn">Restart</button>
+            <span class="flow-progress"></span>
+          </div>
+        </div>
+
+        <p>Notice that the reply gets a <span class="term" data-definition="A URL is a web address — the string you'd paste into a browser bar to go straight to one specific thing, like an image.">URL</span> from <span class="term" data-definition="Cloud storage is a service that keeps files (like your generated cartoon) on someone else's servers permanently, and gives you a URL to fetch them later instead of storing them on your own device.">cloud storage</span> before it ever reaches you — Gemini itself never hands out a link, only raw pixels.</p>
+      </section>
+
+      <!-- SCREEN 5 — The prints come back -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">The Prints Come Back</h2>
+        <p>Gemini's answer arrives as raw image bytes, not a link. So the server uploads it, then packages the whole result as one <span class="term" data-definition="JSON is a plain-text way of packaging data as labeled fields, like a filled-out form: { &quot;name&quot;: &quot;value&quot; }. It's the format almost every API uses to send replies.">JSON</span> object.</p>
+
+        <div class="translation-block animate-in">
+          <div class="translation-code">
+            <span class="translation-label">CODE</span>
+            <pre><code>
+<span class="code-line">    <span class="code-keyword">return</span> <span class="code-function">respData</span>({</span>
+<span class="code-line">      imageUrl: responseImageUrl,</span>
+<span class="code-line">      filename: storedFilename,</span>
+<span class="code-line">      message: <span class="code-string">"Charlie and Lola style transformation completed successfully"</span>,</span>
+<span class="code-line">      provider: <span class="code-string">"google.gemini"</span>,</span>
+<span class="code-line">      model: <span class="code-string">"gemini-2.5-flash-image-preview"</span>,</span>
+<span class="code-line">      creditsUsed: isRegisteredUser ? requiredCredits : 0,</span>
+<span class="code-line">      aspectRatio,</span>
+<span class="code-line">      outputFormat: fileExtension,</span>
+<span class="code-line">      style: style,</span>
+<span class="code-line">      storedLocally: hasStorageConfig &amp;&amp; !finalImageUrl.startsWith(<span class="code-string">'data:'</span>),</span>
+<span class="code-line">      requiresRegistration,</span>
+<span class="code-line">      isPreview: !isRegisteredUser,</span>
+<span class="code-line">      downloadUrl: isRegisteredUser ? responseImageUrl : null,</span>
+<span class="code-line">    });</span>
+            </code></pre>
+          </div>
+          <div class="translation-english">
+            <span class="translation-label">PLAIN ENGLISH</span>
+            <div class="translation-lines">
+              <p class="tl">Package the final reply as one object.</p>
+              <p class="tl">imageUrl is where your cartoon actually lives now.</p>
+              <p class="tl">message and provider are just friendly labels about what happened.</p>
+              <p class="tl">creditsUsed says how many credits this cost — zero if you weren't signed in.</p>
+              <p class="tl">requiresRegistration and downloadUrl are the fields that decide whether you see a Sign In button or a working Download button.</p>
+            </div>
+          </div>
+        </div>
+
+        <p>Watch the same journey play out as a conversation between the three main characters:</p>
+
+        <div class="chat-window" id="chat-module1">
+          <div class="chat-messages">
+            <div class="chat-message" data-msg="0" data-sender="browser" style="display:none">
+              <div class="chat-avatar" style="background: var(--color-actor-1)">🌐</div>
+              <div class="chat-bubble">
+                <span class="chat-sender" style="color: var(--color-actor-1)">Browser</span>
+                <p>Here's a photo and some options — make it Charlie &amp; Lola.</p>
+              </div>
+            </div>
+            <div class="chat-message" data-msg="1" data-sender="server" style="display:none">
+              <div class="chat-avatar" style="background: var(--color-actor-2)">🖥️</div>
+              <div class="chat-bubble">
+                <span class="chat-sender" style="color: var(--color-actor-2)">Server</span>
+                <p>Hold on — aspect ratio valid? image present? under 10MB? ok.</p>
+              </div>
+            </div>
+            <div class="chat-message" data-msg="2" data-sender="server" style="display:none">
+              <div class="chat-avatar" style="background: var(--color-actor-2)">🖥️</div>
+              <div class="chat-bubble">
+                <span class="chat-sender" style="color: var(--color-actor-2)">Server → Gemini</span>
+                <p>Turn this person into a Charlie &amp; Lola character. No 3D, no anime, no photographic textures.</p>
+              </div>
+            </div>
+            <div class="chat-message" data-msg="3" data-sender="gemini" style="display:none">
+              <div class="chat-avatar" style="background: var(--color-actor-3)">✨</div>
+              <div class="chat-bubble">
+                <span class="chat-sender" style="color: var(--color-actor-3)">Gemini</span>
+                <p>...done. Here's the raw pixels.</p>
+              </div>
+            </div>
+            <div class="chat-message" data-msg="4" data-sender="server" style="display:none">
+              <div class="chat-avatar" style="background: var(--color-actor-2)">🖥️</div>
+              <div class="chat-bubble">
+                <span class="chat-sender" style="color: var(--color-actor-2)">Server</span>
+                <p>Filing a copy in storage. Here's your URL.</p>
+              </div>
+            </div>
+            <div class="chat-message" data-msg="5" data-sender="browser" style="display:none">
+              <div class="chat-avatar" style="background: var(--color-actor-1)">🌐</div>
+              <div class="chat-bubble">
+                <span class="chat-sender" style="color: var(--color-actor-1)">Browser</span>
+                <p>🎉</p>
+              </div>
+            </div>
+          </div>
+
+          <div class="chat-typing" id="chat-typing" style="display:none">
+            <div class="chat-avatar" id="typing-avatar">?</div>
+            <div class="chat-typing-dots">
+              <span class="typing-dot"></span>
+              <span class="typing-dot"></span>
+              <span class="typing-dot"></span>
+            </div>
+          </div>
+
+          <div class="chat-controls">
+            <button class="btn chat-next-btn">Next Message</button>
+            <button class="btn chat-all-btn">Play All</button>
+            <button class="btn chat-reset-btn">Replay</button>
+            <span class="chat-progress"></span>
+          </div>
+        </div>
+
+        <p>Now here's the code on the browser's side, unpacking that exact reply:</p>
+
+        <div class="translation-block animate-in">
+          <div class="translation-code">
+            <span class="translation-label">CODE</span>
+            <pre><code>
+<span class="code-line">      <span class="code-keyword">const</span> result = <span class="code-keyword">await</span> apiResponse.<span class="code-function">json</span>();</span>
+<span class="code-line"></span>
+<span class="code-line">      <span class="code-keyword">if</span> (result.code === 0 &amp;&amp; result.data?.imageUrl) {</span>
+<span class="code-line">        <span class="code-function">setGeneratedImage</span>(result.data.imageUrl);</span>
+<span class="code-line"></span>
+<span class="code-line">        <span class="code-comment">// Handle different response types</span></span>
+<span class="code-line">        <span class="code-keyword">if</span> (result.data.requiresRegistration &amp;&amp; !session) {</span>
+<span class="code-line">          toast.<span class="code-function">success</span>(<span class="code-string">"Image generated! Sign in to download full resolution image."</span>);</span>
+<span class="code-line">        } <span class="code-keyword">else if</span> (result.msg === <span class="code-string">'QUEUE_REQUIRED'</span>) {</span>
+<span class="code-line">          toast.<span class="code-function">warning</span>(<span class="code-string">"🚧 Service is busy. You're in the queue. Upgrade to premium to skip the queue!"</span>);</span>
+<span class="code-line">        } <span class="code-keyword">else</span> {</span>
+<span class="code-line">          toast.<span class="code-function">success</span>(t.messages.success.generated);</span>
+<span class="code-line">          <span class="code-keyword">if</span> (session) {</span>
+<span class="code-line">            <span class="code-function">refreshCredits</span>();</span>
+<span class="code-line">          }</span>
+<span class="code-line">        }</span>
+            </code></pre>
+          </div>
+          <div class="translation-english">
+            <span class="translation-label">PLAIN ENGLISH</span>
+            <div class="translation-lines">
+              <p class="tl">Read the server's reply and unpack the JSON.</p>
+              <p class="tl">If the reply says code 0 and there's an imageUrl, save that URL into this component's <span class="term" data-definition="State is the data a piece of the interface currently remembers, like 'which image is showing right now.' When state changes, the screen updates to match it.">state</span> — the picture appears immediately.</p>
+              <p class="tl">If you're not signed in, a <span class="term" data-definition="A toast is the small pop-up notification that briefly appears on screen (like 'Image generated!') and then fades away on its own.">toast</span> reminds you that signing in unlocks the full download.</p>
+              <p class="tl">Otherwise, if the service is busy, a different toast tells you you're in a queue.</p>
+              <p class="tl">Otherwise, celebrate: show a success toast and refresh your credit balance.</p>
+            </div>
+          </div>
+        </div>
+
+        <p>That JSON became <span class="term" data-definition="React is the JavaScript library this app's interface is built with. It lets the page update itself automatically whenever the underlying state changes.">React</span> state the instant it arrived — that single change is what makes the picture appear and the toast slide in.</p>
+
+        <h2 class="screen-heading" style="margin-top: var(--space-12)">Quick Check</h2>
+        <div class="quiz-container" id="quiz-module1">
+
+          <div class="quiz-question-block"
+               data-correct="check-request"
+               data-explanation-right="Exactly — open the browser's Network tab and see how far the envelope actually got. That one question turns 'it's broken' into a specific, fixable claim."
+               data-explanation-wrong="Not quite. Rewriting the prompt or the button color assumes you already know where the problem is — but you don't yet. The first move is always to trace the message.">
+            <h3 class="quiz-question">A user says "I clicked Generate and nothing happened — the spinner just spins forever." Where do you look FIRST, and why?</h3>
+            <div class="quiz-options">
+              <button class="quiz-option" data-value="rewrite-prompt" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>Rewrite the AI prompt</span>
+              </button>
+              <button class="quiz-option" data-value="check-request" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>Check whether the request left the browser, and what the server replied</span>
+              </button>
+              <button class="quiz-option" data-value="change-color" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>Change the button's color</span>
+              </button>
+              <button class="quiz-option" data-value="reinstall" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>Reinstall the app</span>
+              </button>
+            </div>
+            <div class="quiz-feedback"></div>
+          </div>
+
+          <div class="quiz-question-block"
+               data-correct="edit-prompt"
+               data-explanation-right="Exactly! The prompt is just an English string sitting in the API route. No new AI model, no database change — you'd just tell the AI to keep the background instead of dropping it."
+               data-explanation-wrong="Not quite. Nothing about swapping backgrounds needs a different model or a new database table — the instructions the AI follows are plain text, and that text is the only thing that has to change.">
+            <h3 class="quiz-question">You want the cartoon characters to keep a background instead of a transparent one. What actually has to change?</h3>
+            <div class="quiz-options">
+              <button class="quiz-option" data-value="new-model" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>Swap in a different AI model</span>
+              </button>
+              <button class="quiz-option" data-value="edit-prompt" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>Edit the prompt text inside the API route</span>
+              </button>
+              <button class="quiz-option" data-value="new-db-table" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>Add a new database table</span>
+              </button>
+              <button class="quiz-option" data-value="change-css" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>Change the button's CSS color</span>
+              </button>
+            </div>
+            <div class="quiz-feedback"></div>
+          </div>
+
+          <div class="quiz-question-block"
+               data-correct="requiresregistration-field"
+               data-explanation-right="Exactly — requiresRegistration and downloadUrl (which is null for guests) are what the button checks. The image itself is already there; it's these two fields that gate the download."
+               data-explanation-wrong="Not quite. imageUrl, creditsUsed, and provider are all present for everyone, guest or not — they don't distinguish who gets to download. Look at the fields that are specifically about registration.">
+            <h3 class="quiz-question">Guests see the generated image, but the download button asks them to sign in. Based on the JSON reply from Screen 5, which fields is the app checking?</h3>
+            <div class="quiz-options">
+              <button class="quiz-option" data-value="imageurl-field" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>The imageUrl field</span>
+              </button>
+              <button class="quiz-option" data-value="creditsused-field" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>The creditsUsed field</span>
+              </button>
+              <button class="quiz-option" data-value="requiresregistration-field" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>requiresRegistration, and downloadUrl being null</span>
+              </button>
+              <button class="quiz-option" data-value="provider-field" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>The provider field</span>
+              </button>
+            </div>
+            <div class="quiz-feedback"></div>
+          </div>
+
+          <button class="quiz-check-btn" onclick="checkQuiz('quiz-module1')">Check Answers</button>
+          <button class="quiz-reset-btn" onclick="resetQuiz('quiz-module1')">Try Again</button>
+        </div>
+
+        <p style="margin-top: var(--space-10)">We just watched a message travel through five different pieces of code without ever asking <em>who</em> those pieces are, or why the code is split up the way it is. That's next, in <strong>Meet the Cast</strong>.</p>
+      </section>
+
+    </div>
+  </div>
+</section>
+<section class="module" id="module-2" style="background: var(--color-bg)">
+  <div class="module-content">
+    <header class="module-header animate-in">
+      <span class="module-number">02</span>
+      <h1 class="module-title">Meet the Cast — How the Code Is Organised</h1>
+      <p class="module-subtitle">Every file has a job. Once you know the roles, you know exactly where to tell an AI to make a change.</p>
+    </header>
+
+    <div class="module-body">
+
+      <!-- SCREEN 1: The metaphor -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">A Codebase Is a Film Production</h2>
+        <p>In Module 1, a message travelled through five different pieces of code — and nobody introduced them. Time to meet the cast, because the single most useful thing you can tell an AI coding assistant is <strong>where</strong> a change belongs.</p>
+
+        <div class="pattern-cards">
+          <div class="pattern-card" style="border-top: 3px solid var(--color-actor-1)">
+            <div class="pattern-icon" style="background: var(--color-actor-1)">🎭</div>
+            <h4 class="pattern-title">The Cast</h4>
+            <p class="pattern-desc">The parts you actually see — buttons, upload boxes, preview panels. In code, these are
+              <span class="term" data-definition="A framework for building user interfaces out of small, reusable pieces called components. It's the toolkit that turns 'a button and a box' into an actual interactive webpage.">React</span>
+              <span class="term" data-definition="A reusable building block of a web page — like a Lego brick other Lego bricks snap onto. Big apps are just many small components combined.">components</span>
+              living in <code>src/components/blocks/</code>.</p>
+          </div>
+          <div class="pattern-card" style="border-top: 3px solid var(--color-actor-2)">
+            <div class="pattern-icon" style="background: var(--color-actor-2)">🎬</div>
+            <h4 class="pattern-title">The Crew</h4>
+            <p class="pattern-desc">They work behind the camera and never appear in the shot:
+              <span class="term" data-definition="Short for Application Programming Interface — a defined way one piece of code asks another piece of code to do something, usually over the network.">API</span> routes, services, models, and the
+              <span class="term" data-definition="Where all the app's permanent data lives — user accounts, credit balances, orders. Think of it as a giant, always-available filing cabinet.">database</span>.
+              This is where the actual <span class="term" data-definition="The real rules of how the app is supposed to behave — 'new users get 30 credits' — as opposed to how something looks on screen.">business logic</span> lives.</p>
+          </div>
+          <div class="pattern-card" style="border-top: 3px solid var(--color-actor-3)">
+            <div class="pattern-icon" style="background: var(--color-actor-3)">🪑</div>
+            <h4 class="pattern-title">Props Department</h4>
+            <p class="pattern-desc">A shelf of generic, reusable objects any scene can borrow — a chair, a mug, a lamp. In code: 37 small pieces like buttons, cards, and dialogs in <code>src/components/ui/</code>.</p>
+          </div>
+          <div class="pattern-card" style="border-top: 3px solid var(--color-actor-4)">
+            <div class="pattern-icon" style="background: var(--color-actor-4)">🪜</div>
+            <h4 class="pattern-title">Chain of Command</h4>
+            <p class="pattern-desc">An actor doesn't wander into the accounts office to rewrite the budget. Requests travel up a strict chain, one step at a time — nobody skips ahead.</p>
+          </div>
+        </div>
+
+        <p>When you tell an AI "add a rule that Pro users get 3 free generations a day," it has to put that rule <em>somewhere</em>. Knowing which department owns that rule is often the difference between a
+          <span class="term" data-definition="All the code that makes up a project, taken together — every file, every folder.">codebase</span> that survives a year of changes and one that quietly falls apart before you even
+          <span class="term" data-definition="To publish a new version of the app so real users can actually access it.">deploy</span> it again.</p>
+      </section>
+
+      <!-- SCREEN 2: The map -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">The Map: Who Lives Where</h2>
+        <p>Here's the real top-level
+          <span class="term" data-definition="A container for organizing files on a computer — the same folders you see in Finder or File Explorer, just holding code instead of photos.">folder</span>
+          structure of <code>src/</code> — annotated with each department's film-crew role.</p>
+
+        <div class="file-tree">
+          <div class="ft-folder open">
+            <span class="ft-name">app/</span>
+            <span class="ft-desc"><strong>The stage.</strong> Every page and every
+              <span class="term" data-definition="A specific web address (like /pricing) and the code that responds when someone visits it.">route</span>
+              — an
+              <span class="term" data-definition="One specific address an API responds to, like a single phone extension in a large office.">endpoint</span> — lives here. The folder path IS the address.</span>
+          </div>
+          <div class="ft-folder">
+            <span class="ft-name">components/blocks/</span>
+            <span class="ft-desc"><strong>The cast.</strong> Big page sections: hero, pricing, faq, footer, imagen-wrapper.</span>
+          </div>
+          <div class="ft-folder">
+            <span class="ft-name">components/ui/</span>
+            <span class="ft-desc"><strong>Props department.</strong> 37 small generic pieces: button.tsx, card.tsx, dialog.tsx, tabs.tsx.</span>
+          </div>
+          <div class="ft-folder">
+            <span class="ft-name">services/</span>
+            <span class="ft-desc"><strong>The crew chiefs.</strong> Business rules: credit.ts, order.ts, user.ts, stripe.ts, affiliate.ts.</span>
+          </div>
+          <div class="ft-folder">
+            <span class="ft-name">models/</span>
+            <span class="ft-desc"><strong>The records office.</strong> The only files allowed to touch the database: user.ts, credit.ts, order.ts, post.ts.</span>
+          </div>
+          <div class="ft-folder">
+            <span class="ft-name">db/</span>
+            <span class="ft-desc"><strong>The filing cabinet itself.</strong></span>
+            <div class="ft-children">
+              <div class="ft-file">
+                <span class="ft-name">schema.ts</span>
+                <span class="ft-desc">The <span class="term" data-definition="The blueprint for a database table — which columns exist and what kind of data each one holds.">schema</span> — table shapes.</span>
+              </div>
+              <div class="ft-file">
+                <span class="ft-name">index.ts</span>
+                <span class="ft-desc">The live connection to the database.</span>
+              </div>
+            </div>
+          </div>
+          <div class="ft-folder">
+            <span class="ft-name">auth/</span>
+            <span class="ft-desc"><strong>Security.</strong> Who you are — covered in Module 3.</span>
+          </div>
+          <div class="ft-folder">
+            <span class="ft-name">i18n/</span>
+            <span class="ft-desc"><strong>Translation department.</strong> English and Chinese text — Module 6.</span>
+          </div>
+          <div class="ft-folder">
+            <span class="ft-name">lib/</span>
+            <span class="ft-desc"><strong>The toolbox.</strong> Small helpers used by everyone: hash.ts, time.ts, resp.ts, storage.ts.</span>
+          </div>
+          <div class="ft-folder">
+            <span class="ft-name">aisdk/</span>
+            <span class="ft-desc"><strong>The specialist rig.</strong> A hand-built adapter for the Kling video-generation service.</span>
+          </div>
+        </div>
+      </section>
+
+      <!-- SCREEN 3: folders become URLs -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">Folders Become Web Addresses</h2>
+        <p>In
+          <span class="term" data-definition="A framework built on top of React that adds routing, server rendering, and API endpoints — the production company running the whole show.">Next.js</span>
+          — the
+          <span class="term" data-definition="A pre-built structure of rules and tools an app is built on top of, so you don't reinvent the basics every time.">framework</span>
+          this app runs on — folders under <code>src/app/</code> literally become the
+          <span class="term" data-definition="The part of a web address after the domain name — the '/pricing' in charlieandlola.net/pricing.">URL path</span> in your browser bar.</p>
+
+        <div class="badge-list">
+          <div class="badge-item">
+            <code class="badge-code">[locale]/(default)/pricing/page.tsx</code>
+            <span class="badge-desc">becomes <strong>charlieandlola.net/en/pricing</strong></span>
+          </div>
+          <div class="badge-item">
+            <code class="badge-code">api/checkout/route.ts</code>
+            <span class="badge-desc">becomes <strong>charlieandlola.net/api/checkout</strong></span>
+          </div>
+          <div class="badge-item">
+            <code class="badge-code">(admin)/admin/orders/page.tsx</code>
+            <span class="badge-desc">becomes <strong>charlieandlola.net/admin/orders</strong></span>
+          </div>
+        </div>
+
+        <p>Two notations make this readable once you know the trick:</p>
+
+        <div class="icon-rows">
+          <div class="icon-row">
+            <div class="icon-circle" style="background: var(--color-actor-2)">[ ]</div>
+            <div>
+              <strong>[locale] — square brackets</strong>
+              <p>Means "anything goes here, and tell me what it was." That's how /en/pricing and /zh/pricing are the same one file.</p>
+            </div>
+          </div>
+          <div class="icon-row">
+            <div class="icon-circle" style="background: var(--color-actor-3)">( )</div>
+            <div>
+              <strong>(default), (admin), (console) — round brackets</strong>
+              <p>Mean "this folder is for organizing only." It does <strong>not</strong> appear in the URL at all — genuinely confusing the first time you see it.</p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- SCREEN 4: chain of command -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">The Chain of Command, in Three Files</h2>
+        <p>Remember <code>generate-cyberpunk/route.ts</code> from Module 1? Watch how one request passes through three layers, and how each layer only ever talks to the one directly below it.</p>
+
+        <h3 class="screen-heading" style="font-size: var(--text-lg)">Layer 1 — The Route</h3>
+        <p>Takes the request, checks in with the Service layer, and replies. File: <code>src/app/api/generate-cyberpunk/route.ts</code></p>
+        <div class="translation-block animate-in">
+          <div class="translation-code">
+            <span class="translation-label">CODE</span>
+            <pre><code>
+<span class="code-line"><span class="code-comment">// Get user info</span></span>
+<span class="code-line"><span class="code-keyword">const</span> userUuid = <span class="code-keyword">await</span> <span class="code-function">getUserUuid</span>();</span>
+<span class="code-line"><span class="code-keyword">const</span> isRegisteredUser = !!userUuid;</span>
+<span class="code-line"> </span>
+<span class="code-line"><span class="code-comment">// Check credits for registered users</span></span>
+<span class="code-line"><span class="code-keyword">if</span> (isRegisteredUser) {</span>
+<span class="code-line">  <span class="code-keyword">const</span> userCredits = <span class="code-keyword">await</span> <span class="code-function">getUserCredits</span>(userUuid);</span>
+<span class="code-line">  <span class="code-keyword">if</span> (userCredits.<span class="code-property">left_credits</span> &lt; CreditsAmount.<span class="code-property">ImageGeneration</span>) {</span>
+<span class="code-line">    <span class="code-keyword">return</span> <span class="code-function">respErr</span>(<span class="code-string">`Insufficient credits. You need ${CreditsAmount.ImageGeneration} credits but only have ${userCredits.left_credits}. Please recharge to continue.`</span>, <span class="code-string">'INSUFFICIENT_CREDITS'</span>);</span>
+<span class="code-line">  }</span>
+<span class="code-line">}</span>
+            </code></pre>
+          </div>
+          <div class="translation-english">
+            <span class="translation-label">PLAIN ENGLISH</span>
+            <div class="translation-lines">
+              <p class="tl">Ask Security who's making this request — their <span class="term" data-definition="The record that keeps you 'logged in' as you move between pages, without re-entering your password every click.">session</span> (Module 3 opens this box).</p>
+              <p class="tl">Turn that into a plain yes/no: are they signed in at all?</p>
+              <p class="tl">If they ARE signed in, check their <span class="term" data-definition="The app's internal currency — a countable balance that gets spent whenever someone generates an image.">credits</span> balance before doing anything expensive.</p>
+              <p class="tl">Ask the Model layer how many credits this user actually has left.</p>
+              <p class="tl">Compare it to the price of one image — a number defined in the Service layer, not here.</p>
+              <p class="tl">Not enough? Stop immediately and send back a clear error message.</p>
+            </div>
+          </div>
+        </div>
+
+        <h3 class="screen-heading" style="font-size: var(--text-lg)">Layer 2 — The Service</h3>
+        <p>Knows the business rules. File: <code>src/services/credit.ts</code></p>
+        <div class="translation-block animate-in">
+          <div class="translation-code">
+            <span class="translation-label">CODE</span>
+            <pre><code>
+<span class="code-line"><span class="code-keyword">export</span> <span class="code-keyword">enum</span> CreditsAmount {</span>
+<span class="code-line">  NewUserGet = <span class="code-number">30</span>,</span>
+<span class="code-line">  PingCost = <span class="code-number">1</span>,</span>
+<span class="code-line">  ImageGeneration = <span class="code-number">10</span>,</span>
+<span class="code-line">}</span>
+            </code></pre>
+          </div>
+          <div class="translation-english">
+            <span class="translation-label">PLAIN ENGLISH</span>
+            <div class="translation-lines">
+              <p class="tl">Define a fixed, named menu of credit amounts — an <span class="term" data-definition="Short for 'enumeration' — a fixed, named list of values, like a menu a value must be chosen from.">enum</span> — used everywhere in the app.</p>
+              <p class="tl">New users start with 30 credits, free.</p>
+              <p class="tl">A test "ping" costs 1 credit.</p>
+              <p class="tl">Generating one image costs 10 credits. Change this ONE number and the whole app updates.</p>
+              <p class="tl">End of the list.</p>
+            </div>
+          </div>
+        </div>
+
+        <h3 class="screen-heading" style="font-size: var(--text-lg)">Layer 3 — The Model</h3>
+        <p>The only code allowed to touch the database. File: <code>src/models/credit.ts</code></p>
+        <div class="translation-block animate-in">
+          <div class="translation-code">
+            <span class="translation-label">CODE</span>
+            <pre><code>
+<span class="code-line"><span class="code-keyword">export</span> <span class="code-keyword">async</span> <span class="code-keyword">function</span> <span class="code-function">getAllUserCredits</span>(</span>
+<span class="code-line">  user_uuid: <span class="code-keyword">string</span></span>
+<span class="code-line">): Promise&lt;(<span class="code-keyword">typeof</span> credits.$inferSelect)[] | undefined&gt; {</span>
+<span class="code-line">  <span class="code-keyword">const</span> data = <span class="code-keyword">await</span> <span class="code-function">db</span>()</span>
+<span class="code-line">    .<span class="code-function">select</span>()</span>
+<span class="code-line">    .<span class="code-function">from</span>(credits)</span>
+<span class="code-line">    .<span class="code-function">where</span>(<span class="code-function">eq</span>(credits.<span class="code-property">user_uuid</span>, user_uuid))</span>
+<span class="code-line">    .<span class="code-function">orderBy</span>(<span class="code-function">asc</span>(credits.<span class="code-property">created_at</span>));</span>
+<span class="code-line"> </span>
+<span class="code-line">  <span class="code-keyword">return</span> data;</span>
+<span class="code-line">}</span>
+            </code></pre>
+          </div>
+          <div class="translation-english">
+            <span class="translation-label">PLAIN ENGLISH</span>
+            <div class="translation-lines">
+              <p class="tl">A <span class="term" data-definition="A named, reusable block of code that performs one task — write it once, call it whenever you need that task done.">function</span> that takes one input: which user's records to fetch.</p>
+              <p class="tl"><span class="term" data-definition="A stricter version of JavaScript that catches typos and mismatched data before the code ever runs — spell-check for programming logic.">TypeScript</span> promises the answer will be a list of credit records, or nothing.</p>
+              <p class="tl">Open a connection to the database — this file is the ONLY one in the whole app allowed to do this.</p>
+              <p class="tl">Ask for rows from the credits table, but only the ones belonging to this one user.</p>
+              <p class="tl">Sort them oldest first, then hand the results back up to the Service layer.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="layer-demo">
+          <div class="layer-tabs">
+            <button class="layer-tab active" onclick="showLayer('route')">Route</button>
+            <button class="layer-tab" onclick="showLayer('service')">Service</button>
+            <button class="layer-tab" onclick="showLayer('model')">Model</button>
+            <button class="layer-tab" onclick="showLayer('database')">Database</button>
+          </div>
+          <div class="layer-viewport">
+            <div class="layer" id="layer-route" style="display:block">
+              <div class="icon-row">
+                <div class="icon-circle" style="background: var(--color-actor-1)">📮</div>
+                <div>
+                  <strong>The Route</strong>
+                  <p>Takes the incoming request, asks Security who's asking, and asks the Service layer if the rules allow it. Never touches the database directly.</p>
+                </div>
+              </div>
+            </div>
+            <div class="layer" id="layer-service" style="display:none">
+              <div class="icon-row">
+                <div class="icon-circle" style="background: var(--color-actor-2)">📋</div>
+                <div>
+                  <strong>The Service</strong>
+                  <p>Owns the business rules — prices, limits, permissions. "10 credits per image" is written down here, and only here.</p>
+                </div>
+              </div>
+            </div>
+            <div class="layer" id="layer-model" style="display:none">
+              <div class="icon-row">
+                <div class="icon-circle" style="background: var(--color-actor-3)">🗂️</div>
+                <div>
+                  <strong>The Model</strong>
+                  <p>The only code allowed to run a database query. Every other layer has to ask it — nobody else writes the query themselves.</p>
+                </div>
+              </div>
+            </div>
+            <div class="layer" id="layer-database" style="display:none">
+              <div class="icon-row">
+                <div class="icon-circle" style="background: var(--color-actor-4)">🗄️</div>
+                <div>
+                  <strong>Database</strong>
+                  <p><span class="term" data-definition="A popular, reliable type of database software for storing structured data in tables.">Postgres</span>, accessed through
+                    <span class="term" data-definition="A tool that lets code talk to the database using normal JavaScript/TypeScript instead of writing raw SQL by hand.">Drizzle ORM</span>.
+                    The actual filing cabinet where every credit balance, order, and user record lives.</p>
+                </div>
+              </div>
+            </div>
+          </div>
+          <p class="layer-description" id="layer-desc">Click a tab above. Notice each layer only ever talks to the one directly below it — Route never queries the database, Service never touches SQL.</p>
+        </div>
+
+        <div class="callout callout-accent">
+          <div class="callout-icon">💡</div>
+          <div class="callout-content">
+            <strong class="callout-title">A Rule Should Live in Exactly One Place</strong>
+            <p>Engineers call this <span class="term" data-definition="A design principle: each piece of code should be responsible for exactly one job, and that job should live in exactly one place.">separation of concerns</span>. If "10 credits per image" lived in a button instead of the Service layer, you'd end up with the rule in five places — and four of them wrong within a month.</p>
+          </div>
+        </div>
+      </section>
+
+      <!-- SCREEN 5: cast vs crew, server vs client -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">Cast vs Crew: On Stage and Backstage</h2>
+        <p>Some components run on the company's
+          <span class="term" data-definition="Code that runs on the company's computer before anything is sent to your browser. It can safely use secrets and talk to the database.">server</span>, before the page even reaches you. Others run in your own browser, on the
+          <span class="term" data-definition="Code that runs inside your own browser, after the page loads. It can react to your clicks, but can't be trusted with secrets.">client</span> side — the line is one piece of text at the top of a file: <code>'use client'</code>.</p>
+
+        <div class="icon-rows">
+          <div class="icon-row">
+            <div class="icon-circle" style="background: var(--color-actor-2)">🖥️</div>
+            <div>
+              <strong>Server — index.tsx</strong>
+              <p>Looks up the translated text and hands it down. Can read secrets and databases — but can't respond to a click.</p>
+            </div>
+          </div>
+          <div class="icon-row">
+            <div class="icon-circle" style="background: var(--color-actor-1)">🖱️</div>
+            <div>
+              <strong>Client — imagen-client.tsx</strong>
+              <p>Handles clicks, drag-and-drop, spinners — anything that reacts to a human. Never trusted with secrets, because anything in the browser can be read by the user.</p>
+            </div>
+          </div>
+        </div>
+
+        <p>Server fetches, client interacts — a hand-off pair from the same feature.</p>
+
+        <div class="translation-block animate-in">
+          <div class="translation-code">
+            <span class="translation-label">CODE — server half</span>
+            <pre><code>
+<span class="code-line"><span class="code-keyword">export</span> <span class="code-keyword">default</span> <span class="code-keyword">async</span> <span class="code-keyword">function</span> <span class="code-function">ImagenWrapper</span>({ locale = <span class="code-string">'en'</span> }: ImagenWrapperProps = {}) {</span>
+<span class="code-line">  <span class="code-comment">// Set the request locale for server-side translations</span></span>
+<span class="code-line">  <span class="code-function">setRequestLocale</span>(locale);</span>
+<span class="code-line"> </span>
+<span class="code-line">  <span class="code-comment">// Get the translations on the server side with explicit locale</span></span>
+<span class="code-line">  <span class="code-keyword">const</span> t = <span class="code-keyword">await</span> <span class="code-function">getTranslations</span>({ locale, <span class="code-property">namespace</span>: <span class="code-string">'imagen'</span> });</span>
+<span class="code-line"> </span>
+<span class="code-line">  <span class="code-comment">// Pass translations as props to the client component</span></span>
+<span class="code-line">  <span class="code-keyword">const</span> translations = {</span>
+<span class="code-line">    <span class="code-property">badge</span>: { <span class="code-property">text</span>: t(<span class="code-string">'badge.text'</span>) },</span>
+<span class="code-line">    <span class="code-property">title</span>: { <span class="code-property">main</span>: t(<span class="code-string">'title.main'</span>), <span class="code-property">subtitle</span>: t(<span class="code-string">'title.subtitle'</span>) },</span>
+            </code></pre>
+          </div>
+          <div class="translation-english">
+            <span class="translation-label">PLAIN ENGLISH</span>
+            <div class="translation-lines">
+              <p class="tl">This function runs on the server. It <span class="term" data-definition="To turn code into the actual pixels shown on screen.">renders</span> before your browser ever sees it.</p>
+              <p class="tl">Lock in which language this request is for.</p>
+              <p class="tl">Fetch all the English/Chinese text for the "imagen" section — a
+                <span class="term" data-definition="A named group of text strings for one part of the app, so 'imagen' text and 'pricing' text don't get mixed up across languages.">translation namespace</span>.</p>
+              <p class="tl">Bundle that text up as
+                <span class="term" data-definition="Short for 'properties' — data handed from a parent component down to a child component, like a director handing an actor their lines.">props</span>
+                — ready to pass down to the client component below.</p>
+              <p class="tl">Each piece of on-screen copy gets its own labelled slot.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="translation-block animate-in">
+          <div class="translation-code">
+            <span class="translation-label">CODE — client half</span>
+            <pre><code>
+<span class="code-line"><span class="code-string">'use client'</span>;</span>
+<span class="code-line"> </span>
+<span class="code-line"><span class="code-keyword">import</span> React, { useState, useRef, useEffect } <span class="code-keyword">from</span> <span class="code-string">'react'</span>;</span>
+<span class="code-line"><span class="code-keyword">import</span> { useSession } <span class="code-keyword">from</span> <span class="code-string">'next-auth/react'</span>;</span>
+<span class="code-line"><span class="code-keyword">import</span> { Card, CardContent } <span class="code-keyword">from</span> <span class="code-string">'@/components/ui/card'</span>;</span>
+<span class="code-line"><span class="code-keyword">import</span> { Button } <span class="code-keyword">from</span> <span class="code-string">'@/components/ui/button'</span>;</span>
+<span class="code-line"><span class="code-keyword">import</span> { cn } <span class="code-keyword">from</span> <span class="code-string">'@/lib/utils'</span>;</span>
+<span class="code-line"><span class="code-keyword">import</span> { useUserCredits } <span class="code-keyword">from</span> <span class="code-string">'@/hooks/useUserCredits'</span>;</span>
+<span class="code-line"><span class="code-keyword">import</span> CreditDisplay <span class="code-keyword">from</span> <span class="code-string">'@/components/blocks/credits-display'</span>;</span>
+<span class="code-line"><span class="code-keyword">import</span> { toast } <span class="code-keyword">from</span> <span class="code-string">'sonner'</span>;</span>
+<span class="code-line"><span class="code-keyword">import</span> { convertToCdnUrl } <span class="code-keyword">from</span> <span class="code-string">'@/lib/cdn-url'</span>;</span>
+<span class="code-line"><span class="code-keyword">import</span> { useTheme } <span class="code-keyword">from</span> <span class="code-string">'@/contexts/theme-context'</span>;</span>
+            </code></pre>
+          </div>
+          <div class="translation-english">
+            <span class="translation-label">PLAIN ENGLISH</span>
+            <div class="translation-lines">
+              <p class="tl">This one line flips the switch: everything below runs in the browser, not the server.</p>
+              <p class="tl"><span class="term" data-definition="A line of code that pulls in a tool, component, or function from another file so this file can use it.">Import</span> React's own tools for tracking state and reacting to page loads.</p>
+              <p class="tl">Bring in the tool for checking whether someone is signed in — their session.</p>
+              <p class="tl">Borrow two generic props-department pieces: Card and CardContent.</p>
+              <p class="tl">Borrow the generic Button piece too.</p>
+              <p class="tl">A small helper for combining CSS class names cleanly.</p>
+              <p class="tl">A <span class="term" data-definition="A special React function (its name always starts with 'use') that lets a component tap into features like live data or session state.">hook</span> — a live, always-up-to-date read of this user's credit balance.</p>
+              <p class="tl">The small badge that shows the credit balance on screen.</p>
+              <p class="tl">A library for showing little pop-up notifications.</p>
+              <p class="tl">A helper that rewrites image links to load from a
+                <span class="term" data-definition="A network of servers around the world that deliver files, like images, fast — from a copy stored near you.">CDN</span> instead of one far-away server.</p>
+              <p class="tl">The current light/dark theme setting.</p>
+            </div>
+          </div>
+        </div>
+
+        <h3 class="screen-heading" style="font-size: var(--text-lg)">The Assembled Page</h3>
+        <p>The landing page barely contains content of its own — it's a list of cast members, each handed a slice of data. File: <code>src/app/[locale]/(default)/page.tsx</code></p>
+
+        <div class="translation-block animate-in">
+          <div class="translation-code">
+            <span class="translation-label">CODE</span>
+            <pre><code>
+<span class="code-line">&lt;ImagenWrapper locale={locale} /&gt;</span>
+<span class="code-line">{page.introduce &amp;&amp; &lt;Feature1 section={page.introduce} /&gt;}</span>
+<span class="code-line">{page.benefit &amp;&amp; &lt;Feature2 section={page.benefit} /&gt;}</span>
+<span class="code-line">{page.usage &amp;&amp; &lt;Feature3 section={page.usage} /&gt;}</span>
+<span class="code-line">{page.feature &amp;&amp; &lt;Feature section={page.feature} /&gt;}</span>
+<span class="code-line">{page.showcase &amp;&amp; &lt;Showcase section={page.showcase} /&gt;}</span>
+<span class="code-line">{page.stats &amp;&amp; &lt;Stats section={page.stats} /&gt;}</span>
+<span class="code-line">{page.pricing &amp;&amp; &lt;Pricing pricing={page.pricing} /&gt;}</span>
+<span class="code-line">{page.testimonial &amp;&amp; &lt;Testimonial section={page.testimonial} /&gt;}</span>
+<span class="code-line">{page.faq &amp;&amp; &lt;FAQ section={page.faq} /&gt;}</span>
+<span class="code-line">{page.cta &amp;&amp; &lt;CTA section={page.cta} /&gt;}</span>
+            </code></pre>
+          </div>
+          <div class="translation-english">
+            <span class="translation-label">PLAIN ENGLISH</span>
+            <div class="translation-lines">
+              <p class="tl">Always draw the upload widget — it's always there.</p>
+              <p class="tl">Only draw the "introduce" section if the data file actually has content for it.</p>
+              <p class="tl">Same trick, section by section: benefit, usage, feature, showcase, stats.</p>
+              <p class="tl">…pricing, testimonials, FAQ, and the final call-to-action — each one optional.</p>
+              <p class="tl">The <code>&amp;&amp;</code> means "only draw this if there's something to draw." No content, no section — nothing crashes.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="callout callout-accent">
+          <div class="callout-icon">💡</div>
+          <div class="callout-content">
+            <strong class="callout-title">The Page Is a Template. The Content Is Data.</strong>
+            <p>The landing page component doesn't hard-code a single word of copy. It just asks "does the data file have a pricing section?" — and Module 6 shows you exactly where that data file lives.</p>
+          </div>
+        </div>
+
+        <div class="quiz-container" id="quiz-module2">
+          <div class="quiz-question-block"
+               data-correct="q1-b"
+               data-explanation-right="Exactly — CreditsAmount lives in exactly one place. Change ImageGeneration from 10 to 5 and every route, every check, everywhere in the app updates automatically."
+               data-explanation-wrong="Not quite. Think about the 'one place, one rule' idea — if the price lived in a button or was copy-pasted into every route, you'd have to hunt down every copy and update them all, and you'd inevitably miss one.">
+            <h3 class="quiz-question">You want to change the cost of generating an image from 10 credits to 5. Which file do you edit?</h3>
+            <div class="quiz-options">
+              <button class="quiz-option" data-value="q1-a" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>The button component that starts the generation</span>
+              </button>
+              <button class="quiz-option" data-value="q1-b" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span><code>src/services/credit.ts</code> — the CreditsAmount list</span>
+              </button>
+              <button class="quiz-option" data-value="q1-c" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>The database, directly</span>
+              </button>
+              <button class="quiz-option" data-value="q1-d" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>Every API route that generates images</span>
+              </button>
+            </div>
+            <div class="quiz-feedback"></div>
+          </div>
+
+          <div class="quiz-question-block"
+               data-correct="q2-a"
+               data-explanation-right="Exactly. Once a query lives in a component instead of the Model layer, someone will write a slightly different version of that same query somewhere else — and now the two can quietly disagree."
+               data-explanation-wrong="Not quite — the real risk isn't speed or syntax. It's that the database rule now lives in two places instead of one, and those two places can drift apart over time.">
+            <h3 class="quiz-question">An AI coding assistant writes a database query directly inside a page component. Why should you push back?</h3>
+            <div class="quiz-options">
+              <button class="quiz-option" data-value="q2-a" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>It skips the Service and Model layers, so the rule can now drift out of sync in two places</span>
+              </button>
+              <button class="quiz-option" data-value="q2-b" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>Page components are written in the wrong programming language for database queries</span>
+              </button>
+              <button class="quiz-option" data-value="q2-c" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>It will make the page load slightly slower</span>
+              </button>
+              <button class="quiz-option" data-value="q2-d" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>It's not really a problem — as long as it works, the layers don't matter</span>
+              </button>
+            </div>
+            <div class="quiz-feedback"></div>
+          </div>
+
+          <div class="quiz-question-block"
+               data-correct="q3-b"
+               data-explanation-right="Exactly. A countdown that updates every second has to react to time passing in front of the user's eyes — that's client territory. Telling an AI 'mark it use client' is precise enough that it knows exactly what to build."
+               data-explanation-wrong="Think about what a countdown actually needs to do: update on its own, every second, right in front of the user. That's a job for the client, not the server.">
+            <h3 class="quiz-question">You need a component that shows a live countdown timer, updating every second. Server or client component — and how do you tell the AI?</h3>
+            <div class="quiz-options">
+              <button class="quiz-option" data-value="q3-a" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>Server component — say "keep it on the server"</span>
+              </button>
+              <button class="quiz-option" data-value="q3-b" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>Client component — say "mark it <code>'use client'</code>"</span>
+              </button>
+              <button class="quiz-option" data-value="q3-c" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>Doesn't matter — either works exactly the same</span>
+              </button>
+              <button class="quiz-option" data-value="q3-d" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>Neither — countdown timers can't be built as components</span>
+              </button>
+            </div>
+            <div class="quiz-feedback"></div>
+          </div>
+
+          <div class="quiz-question-block"
+               data-correct="q4-b"
+               data-explanation-right="Exactly. Round brackets like (console) or (admin) tell Next.js 'organize the files this way, but don't put it in the address.' Only square brackets like [locale], and plain folder names, ever show up in the URL."
+               data-explanation-wrong="Round-bracket folders are a Next.js-specific trick for tidying up files without changing the address a visitor types. Try picturing the folder path with (console) simply deleted from it — that's the real URL.">
+            <h3 class="quiz-question">In the URL, where does the folder name <code>(console)</code> show up?</h3>
+            <div class="quiz-options">
+              <button class="quiz-option" data-value="q4-a" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>Right after the domain: charlieandlola.net/(console)/</span>
+              </button>
+              <button class="quiz-option" data-value="q4-b" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>Nowhere — round-bracket folders are for organizing files only</span>
+              </button>
+              <button class="quiz-option" data-value="q4-c" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>Only when the user is signed in</span>
+              </button>
+              <button class="quiz-option" data-value="q4-d" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>At the very end of the address</span>
+              </button>
+            </div>
+            <div class="quiz-feedback"></div>
+          </div>
+
+          <button class="quiz-check-btn" onclick="checkQuiz('quiz-module2')">Check Answers</button>
+          <button class="quiz-reset-btn" onclick="resetQuiz('quiz-module2')">Try Again</button>
+        </div>
+
+        <p>The route in this module called <code>getUserUuid()</code> and we just... trusted it. Next module — <strong>Who Are You?</strong> — opens that box: sign-in, sessions, and how the server knows which account a request belongs to.</p>
+      </section>
+
+    </div>
+  </div>
+</section>
+<section class="module" id="module-3" style="background: var(--color-bg-warm)">
+  <div class="module-content">
+    <header class="module-header animate-in">
+      <span class="module-number">03</span>
+      <h1 class="module-title">Who Are You? Sign-In, Sessions, and Trust</h1>
+      <p class="module-subtitle">How a click on "Sign in with Google" turns into a stamped, tamper-evident wristband your Browser carries everywhere.</p>
+    </header>
+
+    <div class="module-body">
+
+      <!-- SCREEN 1: The wristband metaphor -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">Two Very Different Jobs</h2>
+        <p>You can use this app without signing in — you just can't <em>download</em>. Last module we spotted the image route quietly calling <code>getUserUuid()</code> and promised we'd open that box. This is that box.</p>
+
+        <div class="pattern-cards">
+          <div class="pattern-card" style="border-top: 3px solid var(--color-actor-4)">
+            <div class="pattern-icon" style="background: var(--color-actor-4)">🎟️</div>
+            <h4 class="pattern-title">The Gate</h4>
+            <p class="pattern-desc">Once, you queue up and prove who you are the hard way — passport, booking reference, a good look at your face.</p>
+          </div>
+          <div class="pattern-card" style="border-top: 3px solid var(--color-accent)">
+            <div class="pattern-icon" style="background: var(--color-accent)">🎫</div>
+            <h4 class="pattern-title">The Wristband</h4>
+            <p class="pattern-desc">After that, nobody checks your passport again. Every bar, every stage, every backstage door just glances at the wristband.</p>
+          </div>
+          <div class="pattern-card" style="border-top: 3px solid var(--color-actor-3)">
+            <div class="pattern-icon" style="background: var(--color-actor-3)">⏳</div>
+            <h4 class="pattern-title">Tamper-Evident, and It Expires</h4>
+            <p class="pattern-desc">You can't peel it off and hand it to a friend without it showing. And it stops working at the end of the weekend.</p>
+          </div>
+        </div>
+
+        <p>The gate is the sign-in flow. The wristband is a
+          <span class="term" data-definition="A session is the record of you being recognized as logged-in, kept alive as you move around a site or app without having to prove yourself again on every page.">session</span> —
+          a signed
+          <span class="term" data-definition="A cookie is a small piece of data a website asks your Browser to store, which the Browser then automatically sends back on every later visit to that site.">cookie</span>
+          holding a signed
+          <span class="term" data-definition="A token is a piece of data that proves a fact — like who you are — in a way that's very hard to fake, usually because it's digitally signed with a secret key only the server knows.">token</span>.
+          "Show me your wristband" is <code>getUserUuid()</code>.
+        </p>
+
+        <div class="callout callout-accent">
+          <div class="callout-icon">💡</div>
+          <div class="callout-content">
+            <strong class="callout-title">Key Insight</strong>
+            <p><span class="term" data-definition="Authentication is the act of proving who you are — showing ID at the gate, not showing a ticket.">Authenticating</span> you is expensive and happens <em>once</em>. Remembering who you are is cheap and happens on <em>every single request</em>. That's different from <span class="term" data-definition="Authorisation is deciding what someone who's already proven who they are is allowed to do — like a wristband color deciding which backstage areas you can enter.">authorisation</span>, which comes after. Confusing these jobs is where most auth bugs come from — and this app never stores your Google password. It never even sees it.</p>
+          </div>
+        </div>
+      </section>
+
+      <!-- SCREEN 2: Three doors into the same building -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">Three Doors Into the Same Building</h2>
+        <p>The app offers several ways to prove who you are. Every one of them is a different door — but they all lead into the same room.</p>
+
+        <div class="pattern-cards">
+          <div class="pattern-card" style="border-top: 3px solid var(--color-actor-4)">
+            <div class="pattern-icon" style="background: var(--color-actor-4)">G</div>
+            <h4 class="pattern-title">Google</h4>
+            <p class="pattern-desc">Standard <span class="term" data-definition="OAuth is a standard way for one app to let you log in through another service — like Google or GitHub — without ever handing your password to the first app.">OAuth</span> <span class="term" data-definition="A redirect is when a server tells your Browser to load a different page or site instead — like being pointed to a different queue.">redirect</span>. Your Browser leaves for Google and comes back.</p>
+          </div>
+          <div class="pattern-card" style="border-top: 3px solid var(--color-actor-3)">
+            <div class="pattern-icon" style="background: var(--color-actor-3)">🐙</div>
+            <h4 class="pattern-title">GitHub</h4>
+            <p class="pattern-desc">The same redirect pattern, for developers who'd rather use their GitHub account.</p>
+          </div>
+          <div class="pattern-card" style="border-top: 3px solid var(--color-actor-4)">
+            <div class="pattern-icon" style="background: var(--color-actor-4)">⚡</div>
+            <h4 class="pattern-title">Google One Tap</h4>
+            <p class="pattern-desc">The "Continue as…" bubble top-right. It hands over a token the server checks against Google's own <span class="term" data-definition="An endpoint is a specific address on a server designed to answer one particular kind of request — like a numbered counter at a service desk.">tokeninfo endpoint</span>.</p>
+          </div>
+          <div class="pattern-card" style="border-top: 3px solid var(--color-actor-5)">
+            <div class="pattern-icon" style="background: var(--color-actor-5)">🔑</div>
+            <h4 class="pattern-title">Email + Password</h4>
+            <p class="pattern-desc">Only switched on if enabled. The app <em>does</em> store something here — but only a scrambled fingerprint, never the actual password.</p>
+          </div>
+          <div class="pattern-card" style="border-top: 3px solid var(--color-accent)">
+            <div class="pattern-icon" style="background: var(--color-accent)">🧩</div>
+            <h4 class="pattern-title">API Key</h4>
+            <p class="pattern-desc">For developers calling the app by code, not by browser. A key that starts with <code>sk-</code>.</p>
+          </div>
+        </div>
+
+        <p>Here's the clever bit: none of these
+          <span class="term" data-definition="A provider is the outside service vouching for who you are during sign-in — Google, GitHub, or a plain email-and-password check.">providers</span>
+          are hard-coded "on". Each one only exists if the matching
+          <span class="term" data-definition="An environment variable is a setting stored outside your code — like a name tag stuck on the server — that changes how the app behaves without anyone editing the code itself.">environment variables</span>
+          are set. The list of sign-in buttons is literally computed from the server's configuration at startup.
+        </p>
+
+        <div class="translation-block animate-in">
+          <div class="translation-code">
+            <span class="translation-label">CODE</span>
+            <pre><code>
+<span class="code-line"><span class="code-comment">// Google Auth</span></span>
+<span class="code-line"><span class="code-keyword">if</span> (</span>
+<span class="code-line">  process.env.NEXT_PUBLIC_AUTH_GOOGLE_ENABLED === <span class="code-string">"true"</span> &&</span>
+<span class="code-line">  process.env.AUTH_GOOGLE_ID &&</span>
+<span class="code-line">  process.env.AUTH_GOOGLE_SECRET</span>
+<span class="code-line">) {</span>
+<span class="code-line">  providers.push(</span>
+<span class="code-line">    <span class="code-function">GoogleProvider</span>({</span>
+<span class="code-line">      <span class="code-property">clientId</span>: process.env.AUTH_GOOGLE_ID,</span>
+<span class="code-line">      <span class="code-property">clientSecret</span>: process.env.AUTH_GOOGLE_SECRET,</span>
+<span class="code-line">    })</span>
+<span class="code-line">  );</span>
+<span class="code-line">}</span>
+            </code></pre>
+          </div>
+          <div class="translation-english">
+            <span class="translation-label">PLAIN ENGLISH</span>
+            <div class="translation-lines">
+              <p class="tl">Just a label — this chunk of code is about the Google door.</p>
+              <p class="tl">Before doing anything, check three things: is Google sign-in switched on, and are both of Google's secret keys present?</p>
+              <p class="tl">If — and only if — all three checks pass, add Google to the list of sign-in buttons users will see.</p>
+              <p class="tl">Hand Google the two <span class="term" data-definition="Credentials are the pieces of information — like an ID and a secret key, or a username and password — used to prove identity.">credentials</span> it needs to verify people later: an ID and a secret.</p>
+              <p class="tl">Close everything up. Google is now one of the doors — but only because someone set those environment variables.</p>
+            </div>
+          </div>
+        </div>
+
+        <p>Every other provider follows this exact same if-it's-configured pattern:</p>
+        <div class="badge-list">
+          <div class="badge-item">
+            <code class="badge-code">NEXT_PUBLIC_AUTH_GOOGLE_ENABLED</code>
+            <span class="badge-desc">Master switch — must literally be "true" or the Google door doesn't exist</span>
+          </div>
+          <div class="badge-item">
+            <code class="badge-code">AUTH_GOOGLE_ID</code>
+            <span class="badge-desc">The public half of this app's Google credentials</span>
+          </div>
+          <div class="badge-item">
+            <code class="badge-code">AUTH_GOOGLE_SECRET</code>
+            <span class="badge-desc">The private half — miss either one and Google never makes it onto the list</span>
+          </div>
+        </div>
+      </section>
+
+      <!-- SCREEN 3: The gate — flow animation + wristband printed -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">The Gate: Watch a Sign-In Happen</h2>
+        <p>Follow one real click of "Sign in with Google" from the Browser all the way to a cookie sitting in your browser.</p>
+
+        <div class="flow-animation" data-steps='[
+          {"highlight":"flow-actor-1","label":"You click Sign in with Google."},
+          {"highlight":"flow-actor-1","label":"Browser redirects to Google. The app never sees your password.","packet":true,"from":"actor-1","to":"actor-2"},
+          {"highlight":"flow-actor-2","label":"Google verifies you and sends the Browser back with a signed proof.","packet":true,"from":"actor-2","to":"actor-1"},
+          {"highlight":"flow-actor-3","label":"The jwt callback fires on the Server.","packet":true,"from":"actor-1","to":"actor-3"},
+          {"highlight":"flow-actor-3","label":"Server asks the Database: seen this email before?","packet":true,"from":"actor-3","to":"actor-4"},
+          {"highlight":"flow-actor-4","label":"New user? Create a record and grant 30 free credits."},
+          {"highlight":"flow-actor-3","label":"Server packs uuid, email and nickname into a signed token."},
+          {"highlight":"flow-actor-3","label":"Token is stored as a cookie in your Browser. Every later request carries it automatically.","packet":true,"from":"actor-3","to":"actor-1"}
+        ]'>
+          <div class="flow-actors">
+            <div class="flow-actor" id="flow-actor-1">
+              <div class="flow-actor-icon" style="background: var(--color-actor-2)">🌐</div>
+              <span>Browser</span>
+            </div>
+            <div class="flow-actor" id="flow-actor-2">
+              <div class="flow-actor-icon" style="background: var(--color-actor-4)">G</div>
+              <span>Google</span>
+            </div>
+            <div class="flow-actor" id="flow-actor-3">
+              <div class="flow-actor-icon" style="background: var(--color-accent)">🖥️</div>
+              <span>Server</span>
+            </div>
+            <div class="flow-actor" id="flow-actor-4">
+              <div class="flow-actor-icon" style="background: var(--color-actor-3)">🗄️</div>
+              <span>Database</span>
+            </div>
+          </div>
+
+          <div class="flow-packet" id="flow-packet"></div>
+          <div class="flow-step-label" id="flow-label">Click "Next Step" to begin</div>
+
+          <div class="flow-controls">
+            <button class="btn flow-next-btn">Next Step</button>
+            <button class="btn flow-reset-btn">Restart</button>
+            <span class="flow-progress"></span>
+          </div>
+        </div>
+
+        <p>Step 4 is the hinge of the whole module — a
+          <span class="term" data-definition="A callback is a function you hand off to run automatically the moment something else finishes — like leaving your number so the host calls you the second your table is ready.">callback</span>
+          called <code>jwt</code>, short for
+          <span class="term" data-definition="JWT stands for JSON Web Token — a compact, signed token format many apps use to store session data like your user id, in a way that's tamper-evident.">JWT</span>,
+          that fires the instant sign-in succeeds. This is where the wristband gets printed.</p>
+
+        <div class="translation-block animate-in">
+          <div class="translation-code">
+            <span class="translation-label">CODE</span>
+            <pre><code>
+<span class="code-line">    <span class="code-keyword">async</span> <span class="code-function">jwt</span>({ token, user, account }) {</span>
+<span class="code-line">      <span class="code-comment">// Persist the OAuth access_token and or the user id to the token right after signin</span></span>
+<span class="code-line">      <span class="code-keyword">try</span> {</span>
+<span class="code-line">        <span class="code-keyword">if</span> (!user || !account) {</span>
+<span class="code-line">          <span class="code-keyword">return</span> token;</span>
+<span class="code-line">        }</span>
+<span class="code-line">&nbsp;</span>
+<span class="code-line">        <span class="code-keyword">const</span> userInfo = <span class="code-keyword">await</span> <span class="code-function">handleSignInUser</span>(user, account);</span>
+<span class="code-line">        <span class="code-keyword">if</span> (!userInfo) {</span>
+<span class="code-line">          <span class="code-keyword">throw new</span> Error(<span class="code-string">"save user failed"</span>);</span>
+<span class="code-line">        }</span>
+<span class="code-line">&nbsp;</span>
+<span class="code-line">        token.user = {</span>
+<span class="code-line">          <span class="code-property">uuid</span>: userInfo.uuid,</span>
+<span class="code-line">          <span class="code-property">email</span>: userInfo.email,</span>
+<span class="code-line">          <span class="code-property">nickname</span>: userInfo.nickname,</span>
+<span class="code-line">          <span class="code-property">avatar_url</span>: userInfo.avatar_url,</span>
+<span class="code-line">          <span class="code-property">created_at</span>: userInfo.created_at,</span>
+<span class="code-line">        };</span>
+<span class="code-line">&nbsp;</span>
+<span class="code-line">        <span class="code-keyword">return</span> token;</span>
+<span class="code-line">      } <span class="code-keyword">catch</span> (e) {</span>
+            </code></pre>
+          </div>
+          <div class="translation-english">
+            <span class="translation-label">PLAIN ENGLISH</span>
+            <div class="translation-lines">
+              <p class="tl">This function fires the moment someone signs in successfully — the wristband-printing machine turns on.</p>
+              <p class="tl">A note for future readers: this saves the sign-in info onto the token.</p>
+              <p class="tl">If there's no user or account info yet, hand back the token unchanged and stop here.</p>
+              <p class="tl">Call <code>handleSignInUser</code> to look up or create this person's account. If that fails, raise an error.</p>
+              <p class="tl">Stamp five facts onto the token: this person's <span class="term" data-definition="A UUID (Universally Unique Identifier) is a long random ID used to tell every user apart safely, without relying on something guessable like a number that counts up.">uuid</span>, email, nickname, avatar, and join date.</p>
+              <p class="tl">Hand back the freshly-stamped token. The wristband is printed.</p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- SCREEN 4: Your first 30 credits -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">Your First 30 Credits</h2>
+        <p>Inside <code>handleSignInUser</code> is where the app decides: have we met this email before, or not?</p>
+
+        <div class="translation-block animate-in">
+          <div class="translation-code">
+            <span class="translation-label">CODE</span>
+            <pre><code>
+<span class="code-line">    <span class="code-keyword">const</span> existUser = <span class="code-keyword">await</span> <span class="code-function">findUserByEmail</span>(user.email);</span>
+<span class="code-line">&nbsp;</span>
+<span class="code-line">    <span class="code-keyword">if</span> (!existUser) {</span>
+<span class="code-line">      <span class="code-comment">// user not exist, create a new user</span></span>
+<span class="code-line">      <span class="code-keyword">if</span> (!user.uuid) {</span>
+<span class="code-line">        user.uuid = <span class="code-function">getUuid</span>();</span>
+<span class="code-line">      }</span>
+<span class="code-line">&nbsp;</span>
+<span class="code-line">      console.log(<span class="code-string">"user to be inserted:"</span>, user);</span>
+<span class="code-line">&nbsp;</span>
+<span class="code-line">      <span class="code-keyword">const</span> dbUser = <span class="code-keyword">await</span> <span class="code-function">insertUser</span>(user <span class="code-keyword">as</span> <span class="code-keyword">typeof</span> users.$inferInsert);</span>
+<span class="code-line">&nbsp;</span>
+<span class="code-line">      <span class="code-comment">// increase credits for new user, expire in one year</span></span>
+<span class="code-line">      <span class="code-keyword">await</span> <span class="code-function">increaseCredits</span>({</span>
+<span class="code-line">        <span class="code-property">user_uuid</span>: user.uuid,</span>
+<span class="code-line">        <span class="code-property">trans_type</span>: CreditsTransType.NewUser,</span>
+<span class="code-line">        <span class="code-property">credits</span>: CreditsAmount.NewUserGet,</span>
+<span class="code-line">        <span class="code-property">expired_at</span>: <span class="code-function">getOneYearLaterTimestr</span>(),</span>
+<span class="code-line">      });</span>
+            </code></pre>
+          </div>
+          <div class="translation-english">
+            <span class="translation-label">PLAIN ENGLISH</span>
+            <div class="translation-lines">
+              <p class="tl">Ask the Database: does anyone already have this email?</p>
+              <p class="tl">If nobody does, this is a brand-new person — give them a fresh unique id if they don't already have one.</p>
+              <p class="tl">Log what's about to be saved, then insert a new
+                <span class="term" data-definition="A database record is a single saved entry in a database — like one card in a filing cabinet, with fields for name, email, and so on.">database record</span>
+                for them.
+              </p>
+              <p class="tl">Now the reward: hand this brand-new user free starting credits, set to expire exactly one year from today.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="pattern-cards">
+          <div class="pattern-card" style="border-top: 3px solid var(--color-success)">
+            <div class="pattern-icon" style="background: var(--color-success)">✨</div>
+            <h4 class="pattern-title">New Email</h4>
+            <p class="pattern-desc">Create the account, then grant 30 free credits, expiring in one year.</p>
+          </div>
+          <div class="pattern-card" style="border-top: 3px solid var(--color-info)">
+            <div class="pattern-icon" style="background: var(--color-info)">🔁</div>
+            <h4 class="pattern-title">Existing Email</h4>
+            <p class="pattern-desc">Just load their existing record. No new credits — they already have their history.</p>
+          </div>
+        </div>
+      </section>
+
+      <!-- SCREEN 5: Show me your wristband -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">Show Me Your Wristband</h2>
+        <p>Every protected action in the app starts with the same question, asked of the same function.</p>
+
+        <div class="translation-block animate-in">
+          <div class="translation-code">
+            <span class="translation-label">CODE</span>
+            <pre><code>
+<span class="code-line"><span class="code-keyword">export async function</span> <span class="code-function">getUserUuid</span>() {</span>
+<span class="code-line">  <span class="code-keyword">let</span> user_uuid = <span class="code-string">""</span>;</span>
+<span class="code-line">&nbsp;</span>
+<span class="code-line">  <span class="code-keyword">const</span> token = <span class="code-keyword">await</span> <span class="code-function">getBearerToken</span>();</span>
+<span class="code-line">&nbsp;</span>
+<span class="code-line">  <span class="code-keyword">if</span> (token) {</span>
+<span class="code-line">    <span class="code-comment">// api key</span></span>
+<span class="code-line">    <span class="code-keyword">if</span> (token.startsWith(<span class="code-string">"sk-"</span>)) {</span>
+<span class="code-line">      <span class="code-keyword">const</span> user_uuid = <span class="code-keyword">await</span> <span class="code-function">getUserUuidByApiKey</span>(token);</span>
+<span class="code-line">&nbsp;</span>
+<span class="code-line">      <span class="code-keyword">return</span> user_uuid || <span class="code-string">""</span>;</span>
+<span class="code-line">    }</span>
+<span class="code-line">  }</span>
+<span class="code-line">&nbsp;</span>
+<span class="code-line">  <span class="code-keyword">const</span> session = <span class="code-keyword">await</span> <span class="code-function">auth</span>();</span>
+<span class="code-line">  <span class="code-keyword">if</span> (session && session.user && session.user.uuid) {</span>
+<span class="code-line">    user_uuid = session.user.uuid;</span>
+<span class="code-line">  }</span>
+<span class="code-line">&nbsp;</span>
+<span class="code-line">  <span class="code-keyword">return</span> user_uuid;</span>
+<span class="code-line">}</span>
+            </code></pre>
+          </div>
+          <div class="translation-english">
+            <span class="translation-label">PLAIN ENGLISH</span>
+            <div class="translation-lines">
+              <p class="tl">Start by assuming this visitor is a guest: an empty id.</p>
+              <p class="tl">Check whether the request came with a
+                <span class="term" data-definition="A bearer token is a token that works like cash — whoever is holding it can use it, no extra proof of identity required.">bearer token</span>
+                instead of a cookie.
+              </p>
+              <p class="tl">If that token starts with <code>sk-</code>, it's a developer's
+                <span class="term" data-definition="An API key is a secret, password-like string that lets a program — not a person sitting at a keyboard — prove who it is when calling a service.">API key</span>. Look up whose it is and return that.
+              </p>
+              <p class="tl">Otherwise, ask NextAuth for the current
+                <span class="term" data-definition="Server-side means code that runs on the company's own computer, not in your browser — a visitor can't see it or tamper with it.">server-side</span>
+                session — the signed, verified wristband.
+              </p>
+              <p class="tl">If there's a valid session with a user id, use it.</p>
+              <p class="tl">Hand back whatever was found — a real id, or still just an empty string.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="callout callout-info">
+          <div class="callout-icon">🎫</div>
+          <div class="callout-content">
+            <strong class="callout-title">Being a Guest Isn't an Error</strong>
+            <p><code>getUserUuid()</code> never throws, never says "unauthorized". It just returns an empty string for a guest. That single design choice is <em>why</em> this app can let logged-out visitors generate images for free — a guest isn't a failure state, it's just another answer.</p>
+          </div>
+        </div>
+      </section>
+
+      <!-- SCREEN 6: The golden rule + spot the bug -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">The Golden Rule</h2>
+        <p><code>getUserUuid()</code> reads the session <strong>on the Server</strong>. The Browser sends the cookie; the Server checks its signature before believing a single word of it.</p>
+
+        <div class="callout callout-warning">
+          <div class="callout-icon">⚠️</div>
+          <div class="callout-content">
+            <strong class="callout-title">The Server Never Takes the Browser's Word</strong>
+            <p>An AI assistant will happily write
+              <span class="term" data-definition="Client-side means code that runs inside your own browser — fully visible and editable by anyone using dev tools, unlike code that runs privately on the server.">client-side</span>
+              code that reads <code>session.user.uuid</code> and sends it to the server as a plain parameter. Anyone can open dev tools and rewrite that value to someone else's id before it's sent. <strong>Rule: identity comes from the verified session, never from anything the Browser typed into a request.</strong> (Cookies can also be marked "secure", meaning they're only ever sent over <span class="term" data-definition="HTTPS is the secure, encrypted version of the web's HTTP protocol — the padlock icon you see in your browser's address bar.">HTTPS</span>, never plain, unencrypted HTTP.)</p>
+          </div>
+        </div>
+
+        <div class="bug-challenge">
+          <h3>Find the bug in this "download" button:</h3>
+          <div class="bug-code">
+            <div class="bug-line" data-line="1" onclick="checkBugLine(this, false)">
+              <span class="line-num">1</span>
+              <code>'use client';</code>
+            </div>
+            <div class="bug-line" data-line="2" onclick="checkBugLine(this, false)">
+              <span class="line-num">2</span>
+              <code>function DownloadButton({ imageId }) {</code>
+            </div>
+            <div class="bug-line" data-line="3" onclick="checkBugLine(this, false)">
+              <span class="line-num">3</span>
+              <code>&nbsp;&nbsp;const { data: session } = useSession();</code>
+            </div>
+            <div class="bug-line" data-line="4" onclick="checkBugLine(this, false)">
+              <span class="line-num">4</span>
+              <code>&nbsp;&nbsp;async function handleClick() {</code>
+            </div>
+            <div class="bug-line" data-line="5" onclick="checkBugLine(this, false)">
+              <span class="line-num">5</span>
+              <code>&nbsp;&nbsp;&nbsp;&nbsp;await fetch('/api/download', {</code>
+            </div>
+            <div class="bug-line" data-line="6" onclick="checkBugLine(this, false)">
+              <span class="line-num">6</span>
+              <code>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;method: 'POST',</code>
+            </div>
+            <div class="bug-line bug-target" data-line="7" onclick="checkBugLine(this, true)">
+              <span class="line-num">7</span>
+              <code>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;body: JSON.stringify({ user_uuid: session.user.uuid, imageId }),</code>
+            </div>
+            <div class="bug-line" data-line="8" onclick="checkBugLine(this, false)">
+              <span class="line-num">8</span>
+              <code>&nbsp;&nbsp;&nbsp;&nbsp;});</code>
+            </div>
+            <div class="bug-line" data-line="9" onclick="checkBugLine(this, false)">
+              <span class="line-num">9</span>
+              <code>&nbsp;&nbsp;}</code>
+            </div>
+            <div class="bug-line" data-line="10" onclick="checkBugLine(this, false)">
+              <span class="line-num">10</span>
+              <code>&nbsp;&nbsp;return &lt;button onClick={handleClick}&gt;Download&lt;/button&gt;;</code>
+            </div>
+            <div class="bug-line" data-line="11" onclick="checkBugLine(this, false)">
+              <span class="line-num">11</span>
+              <code>}</code>
+            </div>
+          </div>
+          <div class="bug-feedback" id="bug-feedback"></div>
+        </div>
+      </section>
+
+      <!-- SCREEN 7: hashes -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">A One-Way Blender</h2>
+        <p>Sign-in with a password is one of the doors — but the app never stores the password itself, only a
+          <span class="term" data-definition="A hash is a one-way scramble of data — easy to create from the original, but practically impossible to reverse back into it.">hash</span>.
+        </p>
+
+        <div class="translation-block animate-in">
+          <div class="translation-code">
+            <span class="translation-label">CODE</span>
+            <pre><code>
+<span class="code-line">          <span class="code-keyword">if</span> (!user || !user.password_hash) {</span>
+<span class="code-line">            <span class="code-keyword">return null</span>;</span>
+<span class="code-line">          }</span>
+<span class="code-line">&nbsp;</span>
+<span class="code-line">          <span class="code-comment">// Verify password</span></span>
+<span class="code-line">          <span class="code-keyword">const</span> isValidPassword = <span class="code-keyword">await</span> <span class="code-function">verifyPassword</span>(password, user.password_hash);</span>
+<span class="code-line">&nbsp;</span>
+<span class="code-line">          <span class="code-keyword">if</span> (!isValidPassword) {</span>
+<span class="code-line">            <span class="code-keyword">return null</span>;</span>
+<span class="code-line">          }</span>
+            </code></pre>
+          </div>
+          <div class="translation-english">
+            <span class="translation-label">PLAIN ENGLISH</span>
+            <div class="translation-lines">
+              <p class="tl">If there's no matching user, or they have no password hash on file, stop and return nothing.</p>
+              <p class="tl">Blend the password the visitor just typed and compare fingerprints against the one stored on file.</p>
+              <p class="tl">If the fingerprints don't match, stop and return nothing — the exact same response as "no such user".</p>
+            </div>
+          </div>
+        </div>
+
+        <p>You can turn "hunter2" into a fingerprint, but you can't turn the fingerprint back into "hunter2". Notice too: a wrong password and a non-existent account both return the same nothing — the app never tells an attacker which one it was. That's the opposite of storing passwords in
+          <span class="term" data-definition="Plain text means unencrypted, unscrambled data — readable by literally anyone who gets access to it, which is exactly what you never want a password to be.">plain text</span>, the classic disaster.
+        </p>
+      </section>
+
+      <!-- SCREEN 8: Quiz -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">Check Your Understanding</h2>
+        <p>Four scenarios. Think like the engineer who has to actually fix these.</p>
+
+        <div class="quiz-container" id="quiz-module3">
+
+          <div class="quiz-question-block"
+               data-correct="q1-a"
+               data-explanation-right="Exactly — getting signed out on every refresh is almost always a cookie problem: it's not being written, it's expiring immediately, or a secure-cookie setting is rejecting it over plain HTTP."
+               data-explanation-wrong="Not quite. Nothing about a Google account or the Database changes on a page refresh — but the cookie gets re-checked every single time. Start there.">
+            <h3 class="quiz-question">Users report they get signed out every time they refresh the page. Where do you look first?</h3>
+            <div class="quiz-options">
+              <button class="quiz-option" data-value="q1-a" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>The cookie/token setup — is it being set at all, expiring too fast, or blocked because it expects HTTPS on a plain-HTTP site?</span>
+              </button>
+              <button class="quiz-option" data-value="q1-b" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>Their Google account settings</span>
+              </button>
+              <button class="quiz-option" data-value="q1-c" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>The Database</span>
+              </button>
+            </div>
+            <div class="quiz-feedback"></div>
+          </div>
+
+          <div class="scenario-block">
+            <div class="scenario-context">
+              <span class="scenario-label">Scenario</span>
+              <p>An AI assistant writes a client component that reads <code>session.user.uuid</code> in the browser and sends it to the server as part of the request body, so the server can figure out whose data to touch.</p>
+            </div>
+            <div class="quiz-question-block"
+                 data-correct="q2-b"
+                 data-explanation-right="Exactly — the Browser is not a trusted narrator. Anyone can rewrite that request before it leaves their machine. The server must call getUserUuid() itself and read its own verified session — never take a visitor's word for who they are."
+                 data-explanation-wrong="Think about who controls the Browser. If a value the Browser sends decides whose data gets touched, anyone with dev tools can edit it and impersonate someone else.">
+              <h3 class="quiz-question">What is wrong with that approach?</h3>
+              <div class="quiz-options">
+                <button class="quiz-option" data-value="q2-a" onclick="selectOption(this)">
+                  <div class="quiz-option-radio"></div>
+                  <span>Nothing — the id came from their own session, so it's trustworthy</span>
+                </button>
+                <button class="quiz-option" data-value="q2-b" onclick="selectOption(this)">
+                  <div class="quiz-option-radio"></div>
+                  <span>Anyone can open dev tools and edit that value before it's sent, letting a visitor claim to be a different user</span>
+                </button>
+                <button class="quiz-option" data-value="q2-c" onclick="selectOption(this)">
+                  <div class="quiz-option-radio"></div>
+                  <span>It's a performance problem, not a security one</span>
+                </button>
+              </div>
+              <div class="quiz-feedback"></div>
+            </div>
+          </div>
+
+          <div class="quiz-question-block"
+               data-correct="q3-b"
+               data-explanation-right="Exactly — remember, every provider is wrapped in an if that checks its environment variables. Locally you had a .env file with those values; production is missing them, so the provider was silently never added to the list."
+               data-explanation-wrong="GitHub itself being down is very unlikely, and a working local setup rules out a code bug. What's different between your machine and production? Usually: environment variables.">
+            <h3 class="quiz-question">You add a "Sign in with GitHub" button, but nothing happens in production — even though it works fine locally. What's the most likely cause?</h3>
+            <div class="quiz-options">
+              <button class="quiz-option" data-value="q3-a" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>GitHub's servers are down</span>
+              </button>
+              <button class="quiz-option" data-value="q3-b" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>The environment variables gating that provider aren't set on the production server, so it was never added to the list</span>
+              </button>
+              <button class="quiz-option" data-value="q3-c" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>The Database isn't connected</span>
+              </button>
+            </div>
+            <div class="quiz-feedback"></div>
+          </div>
+
+          <div class="quiz-question-block"
+               data-correct="q4-b"
+               data-explanation-right="Exactly — if sign-in fully works, the jwt callback and the Database connection are clearly fine. The credit grant only happens inside the branch that runs for brand-new emails, so it most likely never ran for them."
+               data-explanation-wrong="If sign-in works end to end, the jwt callback and the Database are both clearly fine. The credit grant is one specific branch inside that flow — think about what could make the app believe they weren't actually new.">
+            <h3 class="quiz-question">New signups aren't receiving their 30 free credits, but they <em>can</em> sign in just fine. Which step most likely failed?</h3>
+            <div class="quiz-options">
+              <button class="quiz-option" data-value="q4-a" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>The jwt callback isn't firing at all</span>
+              </button>
+              <button class="quiz-option" data-value="q4-b" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>The branch that only runs for brand-new emails — maybe they'd already signed up under a different provider, so the app treated them as returning</span>
+              </button>
+              <button class="quiz-option" data-value="q4-c" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>The Database is offline</span>
+              </button>
+            </div>
+            <div class="quiz-feedback"></div>
+          </div>
+
+          <button class="quiz-check-btn" onclick="checkQuiz('quiz-module3')">Check Answers</button>
+          <button class="quiz-reset-btn" onclick="resetQuiz('quiz-module3')">Try Again</button>
+        </div>
+
+        <p>New users get 30 credits. An image costs 10. So what happens on the fourth one? That's a payment question — and payments have a plot twist.</p>
+      </section>
+
+    </div>
+  </div>
+</section>
+<section class="module" id="module-4" style="background: var(--color-bg)">
+  <div class="module-content">
+    <header class="module-header animate-in">
+      <span class="module-number">04</span>
+      <h1 class="module-title">Following the Money</h1>
+      <p class="module-subtitle">Thirty free credits, ten per image — so the fourth image is where this app has to become a business. The way it handles money is quietly the most carefully-built part of the whole codebase.</p>
+    </header>
+
+    <div class="module-body">
+
+      <!-- SCREEN 1: The chequebook register -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">There Is No Balance</h2>
+        <p>Last module ended on a cliffhanger: new accounts get 30 credits, an image costs 10, so what happens on the fourth one? The honest answer is that you run out — and the app has to know that with total certainty.</p>
+
+        <p>Picture the paper stub in the back of an old chequebook. One line per transaction: date, description, <em>+£200</em> or <em>−£35</em>. The rule that makes it trustworthy is this: <strong>you never rub out the balance and write a new one.</strong> You only ever add a line.</p>
+
+        <div class="badge-list">
+          <div class="badge-item">
+            <code class="badge-code">+30</code>
+            <span class="badge-desc"><strong>new_user</strong> — signed up on 3 March. Expires in one year.</span>
+          </div>
+          <div class="badge-item">
+            <code class="badge-code">−10</code>
+            <span class="badge-desc"><strong>image_generation</strong> — first cartoon</span>
+          </div>
+          <div class="badge-item">
+            <code class="badge-code">−10</code>
+            <span class="badge-desc"><strong>image_generation</strong> — second cartoon</span>
+          </div>
+          <div class="badge-item">
+            <code class="badge-code">+1000</code>
+            <span class="badge-desc"><strong>order_pay</strong> — bought the Premium plan, order #7429</span>
+          </div>
+          <div class="badge-item">
+            <code class="badge-code">−10</code>
+            <span class="badge-desc"><strong>image_generation</strong> — third cartoon</span>
+          </div>
+        </div>
+
+        <p>That list is a real
+          <span class="term" data-definition="A database table is a grid of saved information — columns for the kinds of fact you store, and one row for each thing you have stored. Think of a spreadsheet the app can search instantly.">table</span>
+          in this app&apos;s database, called <code>credits</code>. Look at the columns it does <em>not</em> have: there is no column called <code>balance</code> anywhere. Your balance is not a number the app keeps — it is the sum of those
+          <span class="term" data-definition="A row is one single entry in a database table — one line in the ledger, one card in the filing cabinet.">rows</span>, added up fresh every time anyone asks.</p>
+
+        <div class="callout callout-accent">
+          <div class="callout-icon">💡</div>
+          <div class="callout-content">
+            <strong class="callout-title">Never Overwrite a Balance. Always Append a Line.</strong>
+            <p>Engineers call this an <span class="term" data-definition="An append-only ledger is a record where you can add new entries but never edit or delete old ones — like a chequebook stub or a bank statement. The current total is worked out by adding everything up.">append-only ledger</span>, and it is one of the most valuable instructions you can give an AI assistant. Ask for &quot;add credits&quot; and you will almost certainly get <code>UPDATE users SET credits = credits - 10</code> — a single number being overwritten. That works right up until two requests land at the same moment, or a customer asks where their credits went, and then there is nothing to look at.</p>
+          </div>
+        </div>
+      </section>
+
+      <!-- SCREEN 2: The price never comes from the browser -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">Buying: The Price Does Not Come From You</h2>
+        <p>When you click a plan on the pricing page, your Browser sends the Server a small package of information — a
+          <span class="term" data-definition="POST is one of the standard kinds of web request. A GET request asks for something; a POST request sends something to the server, like a form or an order.">POST</span>
+          request carrying three things: which product, which currency, which language.</p>
+
+        <div class="pattern-cards">
+          <div class="pattern-card" style="border-top: 3px solid var(--color-actor-2)">
+            <div class="pattern-icon" style="background: var(--color-actor-2)">🏷️</div>
+            <h4 class="pattern-title">product_id</h4>
+            <p class="pattern-desc">Which plan you clicked. Just a name, like <code>premium</code>.</p>
+          </div>
+          <div class="pattern-card" style="border-top: 3px solid var(--color-actor-4)">
+            <div class="pattern-icon" style="background: var(--color-actor-4)">💱</div>
+            <h4 class="pattern-title">currency</h4>
+            <p class="pattern-desc">Dollars or yuan — which price list to read from.</p>
+          </div>
+          <div class="pattern-card" style="border-top: 3px solid var(--color-actor-3)">
+            <div class="pattern-icon" style="background: var(--color-actor-3)">🌍</div>
+            <h4 class="pattern-title">locale</h4>
+            <p class="pattern-desc">Which language you are browsing in.</p>
+          </div>
+          <div class="pattern-card" style="border-top: 3px solid var(--color-error)">
+            <div class="pattern-icon" style="background: var(--color-error)">🚫</div>
+            <h4 class="pattern-title">the price</h4>
+            <p class="pattern-desc"><strong>Not sent.</strong> Not now, not ever. The Server looks it up itself.</p>
+          </div>
+        </div>
+
+        <div class="translation-block animate-in">
+          <div class="translation-code">
+            <span class="translation-label">CODE</span>
+            <pre><code>
+<span class="code-line">    <span class="code-comment">// validate checkout params</span></span>
+<span class="code-line">    <span class="code-keyword">const</span> page = <span class="code-keyword">await</span> <span class="code-function">getPricingPage</span>(locale);</span>
+<span class="code-line">    <span class="code-keyword">if</span> (!page || !page.pricing || !page.pricing.items) {</span>
+<span class="code-line">      <span class="code-keyword">return</span> <span class="code-function">respErr</span>(<span class="code-string">"invalid pricing table"</span>);</span>
+<span class="code-line">    }</span>
+<span class="code-line">&nbsp;</span>
+<span class="code-line">    <span class="code-keyword">const</span> item = page.pricing.items.<span class="code-function">find</span>(</span>
+<span class="code-line">      (item: PricingItem) =&gt; item.product_id === product_id</span>
+<span class="code-line">    );</span>
+<span class="code-line">&nbsp;</span>
+<span class="code-line">    <span class="code-keyword">if</span> (!item || !item.amount || !item.interval || !item.currency) {</span>
+<span class="code-line">      <span class="code-keyword">return</span> <span class="code-function">respErr</span>(<span class="code-string">"invalid checkout params"</span>);</span>
+<span class="code-line">    }</span>
+            </code></pre>
+          </div>
+          <div class="translation-english">
+            <span class="translation-label">PLAIN ENGLISH</span>
+            <div class="translation-lines">
+              <p class="tl">A note for future readers: we are about to check that this order makes sense.</p>
+              <p class="tl">Load the Server&apos;s own price list for this language. Not the Browser&apos;s copy — the real one.</p>
+              <p class="tl">If the price list is missing or empty, stop immediately and say so. Never guess.</p>
+              <p class="tl">Search that list for the plan the visitor clicked, matching on its name.</p>
+              <p class="tl">If there is no such plan, or it has no price, no billing period or no currency, refuse the whole request.</p>
+              <p class="tl">Everything after this point uses <code>item.amount</code> — a number that came from the Server&apos;s own files, and never from you.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="callout callout-warning">
+          <div class="callout-icon">⚠️</div>
+          <div class="callout-content">
+            <strong class="callout-title">Never Trust the Client With Anything That Matters</strong>
+            <p>If the price arrived in the request, anyone could open dev tools, change <code>amount</code> to <code>1</code>, and buy the $99 plan for one
+              <span class="term" data-definition="Prices in payment systems are almost always stored in the smallest unit of the currency — cents rather than dollars — because whole numbers avoid the tiny rounding errors that decimals introduce.">cent</span>.
+              The rule generalises far beyond money: the Browser is a place your code runs, not a source of truth. Anything the Server decides must be looked up by the Server.</p>
+          </div>
+        </div>
+      </section>
+
+      <!-- SCREEN 3: The plot twist — webhooks -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">The Plot Twist: Nobody Tells the Server You Paid</h2>
+        <p>The Server creates an <strong>order</strong> row with status <code>created</code>, asks
+          <span class="term" data-definition="Stripe is a company that handles card payments for other businesses. Your app hands the customer over to Stripe, Stripe takes the money, and your app never touches the card details.">Stripe</span>
+          for a payment page, and sends your Browser there. Your card details never touch this app&apos;s servers.</p>
+
+        <p>Then you pay, and Stripe
+          <span class="term" data-definition="A redirect is when one site tells your browser to go and load a different page instead — like being handed a slip of paper and pointed at a different counter.">redirects</span>
+          you back. Here is the part that surprises everyone: <strong>that redirect is not proof of payment.</strong> Anyone could type that return address into their browser bar.</p>
+
+        <p>So Stripe does something separate. Its own servers make a request to <em>your</em> server, at a special address, saying &quot;this actually happened&quot;. That call-back-when-it-is-real message is a
+          <span class="term" data-definition="A webhook is a message one service sends to your server, unprompted, when something happens — like a delivery firm phoning you when the parcel is actually delivered, instead of you standing at the door guessing.">webhook</span>.</p>
+
+        <div class="callout callout-info">
+          <div class="callout-icon">📦</div>
+          <div class="callout-content">
+            <strong class="callout-title">The Delivery Firm Phones You Back</strong>
+            <p>You do not stand at the door guessing whether the parcel arrived. The courier rings you when it is actually delivered. The customer walking back through your door is a hopeful sign; the courier&apos;s phone call is the fact.</p>
+          </div>
+        </div>
+
+        <p>Watch the whole conversation happen. Three participants, and one of them speaks up without being asked.</p>
+
+        <div class="chat-window" id="chat-module4">
+          <div class="chat-messages">
+            <div class="chat-message" data-msg="0" data-sender="browser" style="display:none">
+              <div class="chat-avatar" style="background: var(--color-actor-2)">🌐</div>
+              <div class="chat-bubble">
+                <span class="chat-sender" style="color: var(--color-actor-2)">Browser</span>
+                <p>Hi — I would like the Premium plan, please. In dollars, in English.</p>
+              </div>
+            </div>
+            <div class="chat-message" data-msg="1" data-sender="server" style="display:none">
+              <div class="chat-avatar" style="background: var(--color-accent)">🖥️</div>
+              <div class="chat-bubble">
+                <span class="chat-sender" style="color: var(--color-accent)">Server</span>
+                <p>Let me look up what Premium actually costs. I am not taking your word for it.</p>
+              </div>
+            </div>
+            <div class="chat-message" data-msg="2" data-sender="server" style="display:none">
+              <div class="chat-avatar" style="background: var(--color-accent)">🖥️</div>
+              <div class="chat-bubble">
+                <span class="chat-sender" style="color: var(--color-accent)">Server</span>
+                <p>$0.99. Creating order <strong>#7429</strong>, status: <code>created</code>. Nobody has paid anything yet.</p>
+              </div>
+            </div>
+            <div class="chat-message" data-msg="3" data-sender="server" style="display:none">
+              <div class="chat-avatar" style="background: var(--color-accent)">🖥️</div>
+              <div class="chat-bubble">
+                <span class="chat-sender" style="color: var(--color-accent)">Server</span>
+                <p>Stripe — set me up a checkout for $0.99, and tag it with order 7429 so I know which one it was.</p>
+              </div>
+            </div>
+            <div class="chat-message" data-msg="4" data-sender="stripe" style="display:none">
+              <div class="chat-avatar" style="background: var(--color-actor-3)">💳</div>
+              <div class="chat-bubble">
+                <span class="chat-sender" style="color: var(--color-actor-3)">Stripe</span>
+                <p>Done. Here is a payment page. Send them over to me.</p>
+              </div>
+            </div>
+            <div class="chat-message" data-msg="5" data-sender="browser" style="display:none">
+              <div class="chat-avatar" style="background: var(--color-actor-2)">🌐</div>
+              <div class="chat-bubble">
+                <span class="chat-sender" style="color: var(--color-actor-2)">Browser</span>
+                <p><em>pays on Stripe&apos;s page — the Server never sees the card</em></p>
+              </div>
+            </div>
+            <div class="chat-message" data-msg="6" data-sender="stripe" style="display:none">
+              <div class="chat-avatar" style="background: var(--color-actor-3)">💳</div>
+              <div class="chat-bubble">
+                <span class="chat-sender" style="color: var(--color-actor-3)">Stripe</span>
+                <p>📩 <code>checkout.session.completed</code> for order 7429. Signed, so you can prove it came from me.</p>
+              </div>
+            </div>
+            <div class="chat-message" data-msg="7" data-sender="server" style="display:none">
+              <div class="chat-avatar" style="background: var(--color-accent)">🖥️</div>
+              <div class="chat-bubble">
+                <span class="chat-sender" style="color: var(--color-accent)">Server</span>
+                <p>Signature checks out. Order 7429 was <code>created</code> → now <code>paid</code>. Writing a <strong>+1000</strong> line in the ledger.</p>
+              </div>
+            </div>
+            <div class="chat-message" data-msg="8" data-sender="stripe" style="display:none">
+              <div class="chat-avatar" style="background: var(--color-actor-3)">💳</div>
+              <div class="chat-bubble">
+                <span class="chat-sender" style="color: var(--color-actor-3)">Stripe</span>
+                <p>📩 <code>checkout.session.completed</code> for order 7429.</p>
+              </div>
+            </div>
+            <div class="chat-message" data-msg="9" data-sender="server" style="display:none">
+              <div class="chat-avatar" style="background: var(--color-accent)">🖥️</div>
+              <div class="chat-bubble">
+                <span class="chat-sender" style="color: var(--color-accent)">Server</span>
+                <p>Already paid. Ignoring. 🙂</p>
+              </div>
+            </div>
+          </div>
+
+          <div class="chat-typing" id="chat-module4-typing" style="display:none">
+            <div class="chat-avatar" id="chat-module4-typing-avatar">?</div>
+            <div class="chat-typing-dots">
+              <span class="typing-dot"></span>
+              <span class="typing-dot"></span>
+              <span class="typing-dot"></span>
+            </div>
+          </div>
+
+          <div class="chat-controls">
+            <button class="btn chat-next-btn">Next Message</button>
+            <button class="btn chat-all-btn">Play All</button>
+            <button class="btn chat-reset-btn">Replay</button>
+            <span class="chat-progress"></span>
+          </div>
+        </div>
+
+        <p>Two things in that conversation are worth pulling apart. First, how the Server knows the message really came from Stripe. Second, that last exchange — Stripe said the same thing twice.</p>
+      </section>
+
+      <!-- SCREEN 4: Verifying the signature -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">Proving Who Sent It</h2>
+        <p>The webhook address is a public address on the internet. Anyone can send a message to it claiming a payment succeeded — so every message arrives with a
+          <span class="term" data-definition="A cryptographic signature is a scrambled fingerprint of a message, made using a secret only the sender and receiver know. If even one character of the message changes, the fingerprint stops matching — so it proves both who sent it and that nobody edited it in transit.">cryptographic signature</span>
+          attached, and the Server refuses to believe anything it cannot verify.</p>
+
+        <div class="translation-block animate-in">
+          <div class="translation-code">
+            <span class="translation-label">CODE</span>
+            <pre><code>
+<span class="code-line">    <span class="code-keyword">const</span> sign = req.headers.<span class="code-function">get</span>(<span class="code-string">"stripe-signature"</span>) <span class="code-keyword">as</span> string;</span>
+<span class="code-line">    <span class="code-keyword">const</span> body = <span class="code-keyword">await</span> req.<span class="code-function">text</span>();</span>
+<span class="code-line">    <span class="code-keyword">if</span> (!sign || !body) {</span>
+<span class="code-line">      <span class="code-keyword">throw new</span> Error(<span class="code-string">"invalid notify data"</span>);</span>
+<span class="code-line">    }</span>
+<span class="code-line">&nbsp;</span>
+<span class="code-line">    <span class="code-keyword">const</span> event = <span class="code-keyword">await</span> stripe.webhooks.<span class="code-function">constructEventAsync</span>(</span>
+<span class="code-line">      body,</span>
+<span class="code-line">      sign,</span>
+<span class="code-line">      stripeWebhookSecret</span>
+<span class="code-line">    );</span>
+<span class="code-line">&nbsp;</span>
+<span class="code-line">    console.<span class="code-function">log</span>(<span class="code-string">"stripe notify event: "</span>, event);</span>
+<span class="code-line">&nbsp;</span>
+<span class="code-line">    <span class="code-keyword">switch</span> (event.type) {</span>
+<span class="code-line">      <span class="code-keyword">case</span> <span class="code-string">"checkout.session.completed"</span>: {</span>
+<span class="code-line">        <span class="code-comment">// get checkout session</span></span>
+<span class="code-line">        <span class="code-keyword">const</span> session = event.data.object;</span>
+<span class="code-line">        <span class="code-keyword">await</span> <span class="code-function">handleCheckoutSession</span>(stripe, session);</span>
+<span class="code-line">        <span class="code-keyword">break</span>;</span>
+<span class="code-line">      }</span>
+            </code></pre>
+          </div>
+          <div class="translation-english">
+            <span class="translation-label">PLAIN ENGLISH</span>
+            <div class="translation-lines">
+              <p class="tl">Pull the signature Stripe attached to this message, and the raw text of the message itself.</p>
+              <p class="tl">If either one is missing, stop right here — this is not a message worth reading.</p>
+              <p class="tl">Hand all three to Stripe&apos;s own checking function: the message, the signature, and a shared secret only Stripe and this Server know.</p>
+              <p class="tl">If the fingerprint does not match, this line fails and nothing below it ever runs. A forged message dies here.</p>
+              <p class="tl">Write the verified message into the log, so there is a record if anyone needs to reconstruct what happened.</p>
+              <p class="tl">Stripe sends many kinds of message. Look at which kind this is and pick the matching branch.</p>
+              <p class="tl">If it is &quot;the customer finished checking out&quot;, pull out the details and go do the actual work of marking the order paid.</p>
+            </div>
+          </div>
+        </div>
+
+        <p>Notice where <code>stripeWebhookSecret</code> comes from: an
+          <span class="term" data-definition="An environment variable is a setting stored outside your code — like a name tag stuck on the server — that changes how the app behaves without anyone editing the code itself. Secrets live here, never in the code.">environment variable</span>
+          set on the server, never written into the code. If that secret is wrong, every real payment message gets rejected — and that is a very common launch-day bug.</p>
+      </section>
+
+      <!-- SCREEN 5: Idempotency -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">Safe to Do Twice</h2>
+        <p>Stripe will sometimes send the same webhook more than once. That is deliberate: if a network blip means the first message was not acknowledged, sending it again is far better than losing a payment.</p>
+
+        <p>Which puts the burden on your side. The code has to be safe to run twice — a property with a name worth learning:
+          <span class="term" data-definition="Idempotent means doing something twice has exactly the same result as doing it once. Pressing a lift call button five times is idempotent; pressing a vending machine button five times is not.">idempotent</span>.
+          Say that word to an AI assistant and the payment code you get back is immediately better.</p>
+
+        <div class="translation-block animate-in">
+          <div class="translation-code">
+            <span class="translation-label">CODE</span>
+            <pre><code>
+<span class="code-line">    <span class="code-comment">// order already paied</span></span>
+<span class="code-line">    <span class="code-keyword">if</span> (order.status === OrderStatus.Paid) {</span>
+<span class="code-line">      <span class="code-keyword">return</span>;</span>
+<span class="code-line">    }</span>
+<span class="code-line">&nbsp;</span>
+<span class="code-line">    <span class="code-comment">// only update order status from created to paid</span></span>
+<span class="code-line">    <span class="code-keyword">if</span> (order.status !== OrderStatus.Created) {</span>
+<span class="code-line">      <span class="code-keyword">throw new</span> Error(<span class="code-string">"invalid order status"</span>);</span>
+<span class="code-line">    }</span>
+<span class="code-line">&nbsp;</span>
+<span class="code-line">    <span class="code-keyword">const</span> paid_at = <span class="code-function">getIsoTimestr</span>();</span>
+<span class="code-line">    <span class="code-keyword">await</span> <span class="code-function">updateOrderStatus</span>(</span>
+<span class="code-line">      order_no,</span>
+<span class="code-line">      OrderStatus.Paid,</span>
+<span class="code-line">      paid_at,</span>
+<span class="code-line">      paid_email,</span>
+<span class="code-line">      paid_detail</span>
+<span class="code-line">    );</span>
+<span class="code-line">&nbsp;</span>
+<span class="code-line">    <span class="code-keyword">if</span> (order.user_uuid) {</span>
+<span class="code-line">      <span class="code-keyword">if</span> (order.credits &gt; 0) {</span>
+<span class="code-line">        <span class="code-comment">// increase credits for paied order</span></span>
+<span class="code-line">        <span class="code-keyword">await</span> <span class="code-function">updateCreditForOrder</span>(order <span class="code-keyword">as</span> unknown <span class="code-keyword">as</span> Order);</span>
+<span class="code-line">      }</span>
+            </code></pre>
+          </div>
+          <div class="translation-english">
+            <span class="translation-label">PLAIN ENGLISH</span>
+            <div class="translation-lines">
+              <p class="tl">A note from whoever wrote this — with a typo in it, because real codebases have typos.</p>
+              <p class="tl"><strong>Guard one:</strong> if this order is already marked paid, quietly stop. No error, no fuss, no second helping of credits.</p>
+              <p class="tl">If the order is in some other unexpected state — cancelled, say — that is a genuine problem, so raise a loud error instead of continuing.</p>
+              <p class="tl">Record the exact moment of payment.</p>
+              <p class="tl">Flip the order from <code>created</code> to <code>paid</code>, storing who paid and Stripe&apos;s full record of it alongside.</p>
+              <p class="tl">Only if this order belongs to a signed-in account, and only if it actually bought credits…</p>
+              <p class="tl">…add the credits. Which has a guard of its own.</p>
+            </div>
+          </div>
+        </div>
+
+        <p>That second guard lives in the credit service, and it is even simpler: before writing the <code>+1000</code> line, look for a line that already carries this order number.</p>
+
+        <div class="badge-list">
+          <div class="badge-item">
+            <code class="badge-code">order.status === Paid</code>
+            <span class="badge-desc">Guard one — the order itself remembers it was already settled</span>
+          </div>
+          <div class="badge-item">
+            <code class="badge-code">findCreditByOrderNo</code>
+            <span class="badge-desc">Guard two — the ledger already has a line tagged with this order number, so stop</span>
+          </div>
+        </div>
+
+        <p>Two independent guards for the same mistake. That is not paranoia; that is what code touching money should look like.</p>
+      </section>
+
+      <!-- SCREEN 6: Spending — the ledger in motion -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">Spending Is Just a Minus Sign</h2>
+        <p>Generating an image spends 10 credits. Here is the entire mechanism for that — and the whole idea of the module is hiding on one line.</p>
+
+        <div class="translation-block animate-in">
+          <div class="translation-code">
+            <span class="translation-label">CODE</span>
+            <pre><code>
+<span class="code-line">    <span class="code-keyword">const</span> new_credit: <span class="code-keyword">typeof</span> creditsTable.$inferInsert = {</span>
+<span class="code-line">      <span class="code-property">trans_no</span>: <span class="code-function">getSnowId</span>(),</span>
+<span class="code-line">      <span class="code-property">created_at</span>: <span class="code-keyword">new</span> <span class="code-function">Date</span>(<span class="code-function">getIsoTimestr</span>()),</span>
+<span class="code-line">      <span class="code-property">expired_at</span>: <span class="code-keyword">new</span> <span class="code-function">Date</span>(expired_at),</span>
+<span class="code-line">      <span class="code-property">user_uuid</span>: user_uuid,</span>
+<span class="code-line">      <span class="code-property">trans_type</span>: trans_type,</span>
+<span class="code-line">      <span class="code-property">credits</span>: <span class="code-number">0</span> - credits,</span>
+<span class="code-line">      <span class="code-property">order_no</span>: order_no,</span>
+<span class="code-line">    };</span>
+<span class="code-line">    <span class="code-keyword">await</span> <span class="code-function">insertCredit</span>(new_credit);</span>
+            </code></pre>
+          </div>
+          <div class="translation-english">
+            <span class="translation-label">PLAIN ENGLISH</span>
+            <div class="translation-lines">
+              <p class="tl">Build one new ledger line, ready to be written.</p>
+              <p class="tl">Give it a unique reference number of its own, so this exact
+                <span class="term" data-definition="A transaction here means one single movement of value — one line in the ledger. Every grant and every spend is its own transaction with its own reference number.">transaction</span>
+                can always be pointed at.</p>
+              <p class="tl">Stamp it with right now, and with the date it stops counting.</p>
+              <p class="tl">Record whose it is, and what kind of movement it was — a purchase, a signup gift, an image generation.</p>
+              <p class="tl"><strong>Here it is.</strong> Zero minus the amount. That single minus sign is the entire spending mechanism — a spend is just a grant with the sign flipped.</p>
+              <p class="tl">Note which order it relates to, if any.</p>
+              <p class="tl">Write the line. Nothing else in the database changes. Nothing is overwritten.</p>
+            </div>
+          </div>
+        </div>
+
+        <p>And when the app needs your balance, it does exactly what you would do with a chequebook stub: adds the lines up.</p>
+
+        <div class="translation-block animate-in">
+          <div class="translation-code">
+            <span class="translation-label">CODE</span>
+            <pre><code>
+<span class="code-line">    <span class="code-comment">// Get only valid credits for current balance</span></span>
+<span class="code-line">    <span class="code-keyword">const</span> validCredits = <span class="code-keyword">await</span> <span class="code-function">getUserValidCredits</span>(user_uuid);</span>
+<span class="code-line">    <span class="code-keyword">if</span> (validCredits) {</span>
+<span class="code-line">      validCredits.<span class="code-function">forEach</span>((v) =&gt; {</span>
+<span class="code-line">        user_credits.left_credits += v.credits || <span class="code-number">0</span>;</span>
+<span class="code-line">      });</span>
+<span class="code-line">    }</span>
+            </code></pre>
+          </div>
+          <div class="translation-english">
+            <span class="translation-label">PLAIN ENGLISH</span>
+            <div class="translation-lines">
+              <p class="tl">Ask the Database for this person&apos;s ledger lines — but only the ones that have not expired.</p>
+              <p class="tl">If there are any, walk through them one at a time.</p>
+              <p class="tl">Add each line&apos;s number to a running total. The plus rows push it up, the minus rows pull it down.</p>
+              <p class="tl">Whatever the total ends up being <em>is</em> the balance. It was worked out just now and will be thrown away again immediately.</p>
+            </div>
+          </div>
+        </div>
+
+        <p>Step through it once and watch the balance appear out of nowhere at the end.</p>
+
+        <div class="flow-animation" data-steps='[
+          {"highlight":"flow-actor-4-1","label":"Day one: you sign in. A line is written — plus 30, type new_user, expiring in a year."},
+          {"highlight":"flow-actor-4-2","label":"You generate a cartoon. A NEW line is written: minus 10. The plus-30 line is not touched."},
+          {"highlight":"flow-actor-4-3","label":"Another cartoon, another line: minus 10. Two separate lines, not one number edited twice."},
+          {"highlight":"flow-actor-4-4","label":"You buy the Premium plan. Stripe confirms by webhook, so a line is written: plus 1000, tagged with order 7429."},
+          {"highlight":"flow-actor-4-5","label":"Another cartoon: minus 10. Five lines now, and still no balance stored anywhere."},
+          {"highlight":"flow-actor-4-6","label":"Now the app needs your balance. It has to go and work it out.","packet":true,"from":"actor-4-1","to":"actor-4-6"},
+          {"highlight":"flow-actor-4-6","label":"Plus 30, minus 10 — running total 20.","packet":true,"from":"actor-4-2","to":"actor-4-6"},
+          {"highlight":"flow-actor-4-6","label":"Minus 10 again — running total 10.","packet":true,"from":"actor-4-3","to":"actor-4-6"},
+          {"highlight":"flow-actor-4-6","label":"Plus 1000 from the purchase — running total 1010.","packet":true,"from":"actor-4-4","to":"actor-4-6"},
+          {"highlight":"flow-actor-4-6","label":"Minus 10 for the last cartoon — running total 1000.","packet":true,"from":"actor-4-5","to":"actor-4-6"},
+          {"highlight":"flow-actor-4-6","label":"Balance: 1000 credits. Calculated from the lines, never stored. Expired lines were left out entirely."}
+        ]'>
+          <div class="flow-actors">
+            <div class="flow-actor" id="flow-actor-4-1">
+              <div class="flow-actor-icon" style="background: var(--color-success)">+30</div>
+              <span>new_user</span>
+            </div>
+            <div class="flow-actor" id="flow-actor-4-2">
+              <div class="flow-actor-icon" style="background: var(--color-error)">−10</div>
+              <span>image</span>
+            </div>
+            <div class="flow-actor" id="flow-actor-4-3">
+              <div class="flow-actor-icon" style="background: var(--color-error)">−10</div>
+              <span>image</span>
+            </div>
+            <div class="flow-actor" id="flow-actor-4-4">
+              <div class="flow-actor-icon" style="background: var(--color-success)">+1000</div>
+              <span>order_pay</span>
+            </div>
+            <div class="flow-actor" id="flow-actor-4-5">
+              <div class="flow-actor-icon" style="background: var(--color-error)">−10</div>
+              <span>image</span>
+            </div>
+            <div class="flow-actor" id="flow-actor-4-6">
+              <div class="flow-actor-icon" style="background: var(--color-accent)">Σ</div>
+              <span>Balance</span>
+            </div>
+          </div>
+
+          <div class="flow-packet" id="flow-packet-4"></div>
+          <div class="flow-step-label" id="flow-label-4">Click "Next Step" to begin</div>
+
+          <div class="flow-controls">
+            <button class="btn flow-next-btn">Next Step</button>
+            <button class="btn flow-reset-btn">Restart</button>
+            <span class="flow-progress"></span>
+          </div>
+        </div>
+
+        <div class="callout callout-info">
+          <div class="callout-icon">⏳</div>
+          <div class="callout-content">
+            <strong class="callout-title">Two Business Decisions Hiding in the Code</strong>
+            <p>Every line has an
+              <span class="term" data-definition="To expire means to stop counting after a certain date. An expired credit line stays in the ledger forever as history, but is skipped when the balance is added up.">expiry</span>
+              date — signup credits last a year, purchased credits last until the end of the billing period. And when credits are spent, the lines are read in expiry order, soonest first. Nobody wrote a memo about that; the rule lives in one small phrase, <code>orderBy(asc(credits.expired_at))</code>, and it is as real a piece of company policy as anything in the terms of service.</p>
+          </div>
+        </div>
+      </section>
+
+      <!-- SCREEN 7: The whole price list in one place + quiz -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">Five Kinds of Line, One Price List</h2>
+        <p>Everything a credit line can possibly be, and everything a credit can possibly cost, sits in thirteen lines of code.</p>
+
+        <div class="translation-block animate-in">
+          <div class="translation-code">
+            <span class="translation-label">CODE</span>
+            <pre><code>
+<span class="code-line"><span class="code-keyword">export enum</span> CreditsTransType {</span>
+<span class="code-line">  NewUser = <span class="code-string">"new_user"</span>, <span class="code-comment">// initial credits for new user</span></span>
+<span class="code-line">  OrderPay = <span class="code-string">"order_pay"</span>, <span class="code-comment">// user pay for credits</span></span>
+<span class="code-line">  SystemAdd = <span class="code-string">"system_add"</span>, <span class="code-comment">// system add credits</span></span>
+<span class="code-line">  Ping = <span class="code-string">"ping"</span>, <span class="code-comment">// cost for ping api</span></span>
+<span class="code-line">  ImageGeneration = <span class="code-string">"image_generation"</span>, <span class="code-comment">// cost for image generation</span></span>
+<span class="code-line">}</span>
+<span class="code-line">&nbsp;</span>
+<span class="code-line"><span class="code-keyword">export enum</span> CreditsAmount {</span>
+<span class="code-line">  NewUserGet = <span class="code-number">30</span>,</span>
+<span class="code-line">  PingCost = <span class="code-number">1</span>,</span>
+<span class="code-line">  ImageGeneration = <span class="code-number">10</span>,</span>
+<span class="code-line">}</span>
+            </code></pre>
+          </div>
+          <div class="translation-english">
+            <span class="translation-label">PLAIN ENGLISH</span>
+            <div class="translation-lines">
+              <p class="tl">Here is the complete list of reasons a ledger line can exist — an
+                <span class="term" data-definition="An enum is a fixed, named list of allowed values. Instead of letting any text be written into a field, the code says these five are the only options — so a typo becomes an error rather than a mystery.">enum</span>,
+                which means these five are the <em>only</em> options.</p>
+              <p class="tl">A signup gift, a purchase, a manual top-up from support, a test call, and an image generation.</p>
+              <p class="tl">And here is the whole price list, as plain numbers.</p>
+              <p class="tl">Thirty free on signup. One credit for a test ping. Ten credits per cartoon. Change the number 10 here and the price of the product changes everywhere.</p>
+            </div>
+          </div>
+        </div>
+
+        <p>A few more real facts about how the money side is put together:</p>
+
+        <div class="pattern-cards">
+          <div class="pattern-card" style="border-top: 3px solid var(--color-actor-4)">
+            <div class="pattern-icon" style="background: var(--color-actor-4)">📝</div>
+            <h4 class="pattern-title">Prices Are a Text File</h4>
+            <p class="pattern-desc">All 8 plans live in <code>pricing/en.json</code>, not in a database. The featured plan is Premium at <code>amount: 99</code> — that is 99 cents.</p>
+          </div>
+          <div class="pattern-card" style="border-top: 3px solid var(--color-actor-3)">
+            <div class="pattern-icon" style="background: var(--color-actor-3)">🔀</div>
+            <h4 class="pattern-title">Two Payment Companies</h4>
+            <p class="pattern-desc">Stripe or Creem, chosen by one environment variable. Chinese customers also get WeChat Pay and Alipay.</p>
+          </div>
+          <div class="pattern-card" style="border-top: 3px solid var(--color-actor-5)">
+            <div class="pattern-icon" style="background: var(--color-actor-5)">🤝</div>
+            <h4 class="pattern-title">Someone Else Gets Paid Too</h4>
+            <p class="pattern-desc">A paid order also triggers the
+              <span class="term" data-definition="An affiliate is someone who gets a share of the money when a person they referred makes a purchase — a referral commission.">affiliate</span>
+              payout to whoever invited that customer.</p>
+          </div>
+        </div>
+      </section>
+
+      <!-- SCREEN 8: Quiz -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">Check Your Understanding</h2>
+        <p>Four money scenarios. These are the ones that cost real money and real trust when you get them wrong.</p>
+
+        <div class="quiz-container" id="quiz-module4">
+
+          <div class="quiz-question-block"
+               data-correct="q1-b"
+               data-explanation-right="Exactly — the webhook is a completely separate message from Stripe&apos;s servers to yours. It has nothing to do with the customer&apos;s browser, their tab, their wifi, or whether they ever came back to your site. That is the whole reason the redirect is not used as proof."
+               data-explanation-wrong="Think about who sends what. The redirect happens in the customer&apos;s browser — but the message that actually grants the credits comes from Stripe&apos;s own servers, directly to yours, with nobody in between.">
+            <h3 class="quiz-question">A customer pays on Stripe&apos;s page, then closes the tab before it redirects back to the app. Do they get their credits?</h3>
+            <div class="quiz-options">
+              <button class="quiz-option" data-value="q1-a" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>No — the credits are granted by the page they land on when they come back</span>
+              </button>
+              <button class="quiz-option" data-value="q1-b" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>Yes — the webhook travels server-to-server and does not depend on their browser at all</span>
+              </button>
+              <button class="quiz-option" data-value="q1-c" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>Only if they sign in again within a few minutes</span>
+              </button>
+            </div>
+            <div class="quiz-feedback"></div>
+          </div>
+
+          <div class="quiz-question-block"
+               data-correct="q2-c"
+               data-explanation-right="Exactly — two independent guards. The order refuses to move from paid to paid, and the ledger refuses to write a second line carrying an order number it already has. Either one alone would do the job; having both is what payment code should look like."
+               data-explanation-wrong="Stripe repeating itself is deliberate, not a fault — it is how a payment survives a dropped connection. So the protection has to be on your side, in code that is safe to run twice.">
+            <h3 class="quiz-question">Stripe sends the same &quot;payment complete&quot; message twice. What stops the customer getting double credits?</h3>
+            <div class="quiz-options">
+              <button class="quiz-option" data-value="q2-a" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>Stripe never sends anything twice, so it cannot happen</span>
+              </button>
+              <button class="quiz-option" data-value="q2-b" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>Nothing — support has to notice and take the credits back manually</span>
+              </button>
+              <button class="quiz-option" data-value="q2-c" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>The order is already marked paid, and the ledger already has a line tagged with that order number — so the second run does nothing</span>
+              </button>
+            </div>
+            <div class="quiz-feedback"></div>
+          </div>
+
+          <div class="scenario-block">
+            <div class="scenario-context">
+              <span class="scenario-label">Scenario</span>
+              <p>You ask an AI assistant to add a credits feature. It proposes putting a single <code>credits</code> number on the users table and adding to or subtracting from it whenever something happens.</p>
+            </div>
+            <div class="quiz-question-block"
+                 data-correct="q3-c"
+                 data-explanation-right="Exactly — and it is all three at once. You cannot answer &quot;where did my credits go?&quot;, you cannot expire some credits and not others, and two requests arriving at the same moment can each read the same starting number and overwrite each other. Say the words &quot;append-only ledger&quot; and you get a far better design first time."
+                 data-explanation-wrong="Have another look at what the ledger gives you that a single number cannot: a history you can read, a per-line expiry date, and safety when two things happen at once. This design costs one of those — actually, all of them.">
+              <h3 class="quiz-question">Name what gets worse.</h3>
+              <div class="quiz-options">
+                <button class="quiz-option" data-value="q3-a" onclick="selectOption(this)">
+                  <div class="quiz-option-radio"></div>
+                  <span>Nothing important — it is simpler and does the same job</span>
+                </button>
+                <button class="quiz-option" data-value="q3-b" onclick="selectOption(this)">
+                  <div class="quiz-option-radio"></div>
+                  <span>It is slower to read the balance</span>
+                </button>
+                <button class="quiz-option" data-value="q3-c" onclick="selectOption(this)">
+                  <div class="quiz-option-radio"></div>
+                  <span>You lose the history, you can no longer expire credits selectively, and simultaneous requests can overwrite each other</span>
+                </button>
+              </div>
+              <div class="quiz-feedback"></div>
+            </div>
+          </div>
+
+          <div class="quiz-question-block"
+               data-correct="q4-a"
+               data-explanation-right="Exactly — nothing happens, because the price was never in the request to begin with. The Server reads it from its own pricing file every time. Generalise this instinct: any value that decides money, permissions or identity must be looked up by the Server, never accepted from the Browser."
+               data-explanation-wrong="Look again at what the Browser actually sends: a product name, a currency, and a language. There is no price in that package — the Server finds the price itself, so there is nothing for an attacker to edit.">
+            <h3 class="quiz-question">Someone edits the request in their browser to send <code>amount: 1</code> instead of the real price. What happens?</h3>
+            <div class="quiz-options">
+              <button class="quiz-option" data-value="q4-a" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>Nothing — the Browser never sends a price, so the extra field is simply ignored</span>
+              </button>
+              <button class="quiz-option" data-value="q4-b" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>They buy the plan for one cent</span>
+              </button>
+              <button class="quiz-option" data-value="q4-c" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>Stripe catches it and rejects the payment</span>
+              </button>
+            </div>
+            <div class="quiz-feedback"></div>
+          </div>
+
+          <button class="quiz-check-btn" onclick="checkQuiz('quiz-module4')">Check Answers</button>
+          <button class="quiz-reset-btn" onclick="resetQuiz('quiz-module4')">Try Again</button>
+        </div>
+
+        <p style="margin-top: var(--space-10)">We have written a lot of rows to a database this module without once asking what a database actually <em>is</em> — or what happens when it disappears. It disappeared. Really. That is <strong>Memory and the Outside World</strong>.</p>
+      </section>
+
+    </div>
+  </div>
+</section>
+<section class="module" id="module-5" style="background: var(--color-bg-warm)">
+  <div class="module-content">
+    <header class="module-header animate-in">
+      <span class="module-number">05</span>
+      <h1 class="module-title">Memory and the Outside World</h1>
+      <p class="module-subtitle">Every module so far has said &quot;and then it saves it to the database&quot; as if that were one word. It is about six ideas — and the most useful thing about this particular database is that when we went looking for it, it was gone.</p>
+    </header>
+
+    <div class="module-body">
+
+      <!-- SCREEN 1: Blueprints and permits -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">Blueprints and Permits</h2>
+        <p>A
+          <span class="term" data-definition="A database is a program whose whole job is to store information safely and find it again fast. Think of a filing system that never forgets, can be searched instantly, and can be used by thousands of people at once.">database</span>
+          is a program whose entire job is to remember things reliably and find them again instantly. This app uses
+          <span class="term" data-definition="PostgreSQL (usually said Post-gress) is one of the most widely used databases in the world. It is free, open-source, and the default sensible choice for most web apps.">PostgreSQL</span>,
+          rented from a company called
+          <span class="term" data-definition="Supabase is a company that runs PostgreSQL databases for you, so you do not have to own or maintain a server. It has a free tier, which matters later in this module.">Supabase</span>.</p>
+
+        <p>There is a file in this project called <code>schema.ts</code>. It is the building&apos;s blueprint: this building has a Users room with these dimensions, an Orders room with those, a Credits room down the hall.</p>
+
+        <div class="pattern-cards">
+          <div class="pattern-card" style="border-top: 3px solid var(--color-actor-2)">
+            <div class="pattern-icon" style="background: var(--color-actor-2)">📐</div>
+            <h4 class="pattern-title">The Blueprint</h4>
+            <p class="pattern-desc">The <span class="term" data-definition="A schema is the description of what a database contains — which tables exist, what columns each one has, and what kind of value goes in each column.">schema</span>: what rooms exist and what shape they are.</p>
+          </div>
+          <div class="pattern-card" style="border-top: 3px solid var(--color-accent)">
+            <div class="pattern-icon" style="background: var(--color-accent)">📋</div>
+            <h4 class="pattern-title">The Permits</h4>
+            <p class="pattern-desc">Numbered, dated changes: <em>#0004 — add a password column to Users.</em> Applied in order, they build the whole thing.</p>
+          </div>
+          <div class="pattern-card" style="border-top: 3px solid var(--color-actor-4)">
+            <div class="pattern-icon" style="background: var(--color-actor-4)">🏢</div>
+            <h4 class="pattern-title">The Building</h4>
+            <p class="pattern-desc">The live database, with real people living in it right now. You cannot just hand a builder a new blueprint.</p>
+          </div>
+        </div>
+
+        <p>That last card is the whole problem. Redrawing a blueprint is easy. Changing a building people already live in, without knocking it down, is a completely different job — and it is why
+          <span class="term" data-definition="A migration is a small, numbered file describing one change to a database — add this column, rename that table. Run in order, migrations take a database from empty to its current shape, and anyone can read exactly what changed.">migrations</span>
+          exist.</p>
+      </section>
+
+      <!-- SCREEN 2: The eight tables -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">Eight Rooms</h2>
+        <p>Here is the entire product, described as furniture. Eight
+          <span class="term" data-definition="A database table is a grid of saved information — columns for the kinds of fact you store, one row per thing stored. Like a spreadsheet the app can search instantly.">tables</span>,
+          nothing else.</p>
+
+        <div class="badge-list">
+          <div class="badge-item">
+            <code class="badge-code">users</code>
+            <span class="badge-desc">One row per account: uuid, email, nickname, avatar, which service they signed in with, invite code</span>
+          </div>
+          <div class="badge-item">
+            <code class="badge-code">orders</code>
+            <span class="badge-desc">One row per purchase attempt: order number, amount, status, Stripe session id, credits bought</span>
+          </div>
+          <div class="badge-item">
+            <code class="badge-code">credits</code>
+            <span class="badge-desc">The ledger from last module — one row per grant or spend</span>
+          </div>
+          <div class="badge-item">
+            <code class="badge-code">apikeys</code>
+            <span class="badge-desc">Developer keys, the ones starting <code>sk-</code></span>
+          </div>
+          <div class="badge-item">
+            <code class="badge-code">posts</code>
+            <span class="badge-desc">Blog articles</span>
+          </div>
+          <div class="badge-item">
+            <code class="badge-code">categories</code>
+            <span class="badge-desc">Blog categories</span>
+          </div>
+          <div class="badge-item">
+            <code class="badge-code">affiliates</code>
+            <span class="badge-desc">Referral rewards — who invited whom, and what they earned</span>
+          </div>
+          <div class="badge-item">
+            <code class="badge-code">feedbacks</code>
+            <span class="badge-desc">User feedback and ratings</span>
+          </div>
+        </div>
+
+        <p>And here is one of those rooms as the blueprint actually describes it. The surprise for most people: this is not database language, it is ordinary
+          <span class="term" data-definition="TypeScript is a version of JavaScript that also lets you describe what shape your data is. The editor then catches mistakes as you type, before the code ever runs.">TypeScript</span>.</p>
+
+        <div class="translation-block animate-in">
+          <div class="translation-code">
+            <span class="translation-label">CODE</span>
+            <pre><code>
+<span class="code-line"><span class="code-keyword">export const</span> credits = <span class="code-function">pgTable</span>(<span class="code-string">"credits"</span>, {</span>
+<span class="code-line">  <span class="code-property">id</span>: <span class="code-function">integer</span>().<span class="code-function">primaryKey</span>().<span class="code-function">generatedAlwaysAsIdentity</span>(),</span>
+<span class="code-line">  <span class="code-property">trans_no</span>: <span class="code-function">varchar</span>({ <span class="code-property">length</span>: <span class="code-number">255</span> }).<span class="code-function">notNull</span>().<span class="code-function">unique</span>(),</span>
+<span class="code-line">  <span class="code-property">created_at</span>: <span class="code-function">timestamp</span>({ <span class="code-property">withTimezone</span>: <span class="code-keyword">true</span> }),</span>
+<span class="code-line">  <span class="code-property">user_uuid</span>: <span class="code-function">varchar</span>({ <span class="code-property">length</span>: <span class="code-number">255</span> }).<span class="code-function">notNull</span>(),</span>
+<span class="code-line">  <span class="code-property">trans_type</span>: <span class="code-function">varchar</span>({ <span class="code-property">length</span>: <span class="code-number">50</span> }).<span class="code-function">notNull</span>(),</span>
+<span class="code-line">  <span class="code-property">credits</span>: <span class="code-function">integer</span>().<span class="code-function">notNull</span>(),</span>
+<span class="code-line">  <span class="code-property">order_no</span>: <span class="code-function">varchar</span>({ <span class="code-property">length</span>: <span class="code-number">255</span> }),</span>
+<span class="code-line">  <span class="code-property">expired_at</span>: <span class="code-function">timestamp</span>({ <span class="code-property">withTimezone</span>: <span class="code-keyword">true</span> }),</span>
+<span class="code-line">});</span>
+            </code></pre>
+          </div>
+          <div class="translation-english">
+            <span class="translation-label">PLAIN ENGLISH</span>
+            <div class="translation-lines">
+              <p class="tl">Describe a table called <code>credits</code>. Everything in the curly brackets is a
+                <span class="term" data-definition="A column is one kind of fact a table stores — the email column, the amount column. Every row has a value for every column.">column</span>.</p>
+              <p class="tl">A plain counting number that the database fills in itself, and that is the row&apos;s
+                <span class="term" data-definition="A primary key is the one column guaranteed to be unique for every row — the thing you use to point at exactly one record and no other.">primary key</span>:
+                the thing you point at to mean this row and no other.</p>
+              <p class="tl">A reference number, up to 255 characters, that must be present and must never repeat.</p>
+              <p class="tl">When this line was written, stored with its
+                <span class="term" data-definition="A timestamp is a stored moment in time. Storing it with a timezone means the same instant reads correctly whether you are in London or Shanghai.">timezone</span>
+                so it means the same instant everywhere in the world.</p>
+              <p class="tl">Whose line it is, and what kind of movement it was. Both required.</p>
+              <p class="tl">The amount — a whole number, positive or negative. This is the plus and minus from last module.</p>
+              <p class="tl">Which order it relates to, if any, and the date it stops counting. Both optional — a signup gift has no order.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="callout callout-info">
+          <div class="callout-icon">🧩</div>
+          <div class="callout-content">
+            <strong class="callout-title">Why Describe the Database in TypeScript?</strong>
+            <p>A tool called <span class="term" data-definition="Drizzle is an ORM — a translator that turns ordinary code into database instructions, so developers describe what they want in the language they are already writing in.">Drizzle</span> reads that file and generates the real database instructions. The payoff is that your editor now knows the shape of your data: misspell <code>left_credits</code> and you are told immediately, in red, before the code ever runs. Software that catches your mistakes while you type is worth an enormous amount.</p>
+          </div>
+        </div>
+      </section>
+
+      <!-- SCREEN 3: Migrations -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">The Permits</h2>
+        <p>There are five permits in this project, in a folder called <code>migrations</code>, with names generated from a word list. They look absurd and they are completely serious.</p>
+
+        <div class="file-tree">
+          <div class="ft-folder open">
+            <span class="ft-name">src/db/migrations/</span>
+            <span class="ft-desc">Every change ever made to the shape of this database, in order</span>
+            <div class="ft-children">
+              <div class="ft-file"><span class="ft-name">0000_flimsy_toad.sql</span><span class="ft-desc">The empty lot becomes a building</span></div>
+              <div class="ft-file"><span class="ft-name">0001, 0002</span><span class="ft-desc">Two more changes along the way</span></div>
+              <div class="ft-file"><span class="ft-name">0003_steady_toad.sql</span><span class="ft-desc">Add a category column to Posts</span></div>
+              <div class="ft-file"><span class="ft-name">0004_striped_colossus.sql</span><span class="ft-desc">Add a password column to Users</span></div>
+            </div>
+          </div>
+        </div>
+
+        <p>Open <code>0004_striped_colossus.sql</code> and this is the whole file. One line. Its brevity is the point.</p>
+
+        <div class="translation-block animate-in">
+          <div class="translation-code">
+            <span class="translation-label">CODE</span>
+            <pre><code>
+<span class="code-line"><span class="code-keyword">ALTER TABLE</span> <span class="code-string">"users"</span> <span class="code-keyword">ADD COLUMN</span> <span class="code-string">"password_hash"</span> <span class="code-function">varchar</span>(<span class="code-number">255</span>);</span>
+            </code></pre>
+          </div>
+          <div class="translation-english">
+            <span class="translation-label">PLAIN ENGLISH</span>
+            <div class="translation-lines">
+              <p class="tl">Change the existing <code>users</code> table — do not rebuild it, do not empty it, just change it.</p>
+              <p class="tl">Add one new column called <code>password_hash</code>, holding up to 255 characters.</p>
+              <p class="tl">That is the entire permit. This is written in
+                <span class="term" data-definition="SQL (say sequel) is the language databases speak. It is deliberately close to English: SELECT, INSERT, ALTER TABLE, DELETE.">SQL</span>,
+                the language databases actually speak — and you can read it, which is exactly the point.</p>
+              <p class="tl">Module 3&apos;s email-and-password sign-in door needed somewhere to store a scrambled password. This file is the moment that door became possible.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="callout callout-accent">
+          <div class="callout-icon">💡</div>
+          <div class="callout-content">
+            <strong class="callout-title">Ask For the Migration, Not Just the Change</strong>
+            <p>When you tell an AI assistant &quot;add a phone number field to users&quot;, it may edit the blueprint and quietly push the change straight into your database. Say instead: <em>&quot;change the schema and generate a migration for it.&quot;</em> The difference is a file you can read, review, keep in version history, and run identically on your laptop, on the test site and in production. Invisible schema changes are how two copies of the same app drift apart.</p>
+          </div>
+        </div>
+      </section>
+
+      <!-- SCREEN 4: The day the database vanished -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">The Day the Database Vanished</h2>
+        <p>While making this course, we tried to connect to this app&apos;s database. It answered:</p>
+
+        <div class="callout callout-warning">
+          <div class="callout-icon">💀</div>
+          <div class="callout-content">
+            <strong class="callout-title">tenant or user not found</strong>
+            <p>The Supabase project had been deleted — most likely reclaimed as an idle
+              <span class="term" data-definition="A free tier is the no-cost level of a paid service. It usually comes with limits, and often with a rule that unused projects get paused or deleted after a period of inactivity.">free-tier</span>
+              project. Nothing in the code is wrong. The code is fine. The <em>thing the code depends on</em> stopped existing.</p>
+          </div>
+        </div>
+
+        <p>Learn the <em>shape</em> of that error, because you will meet it again. It appeared at the connection stage — before a single one of the app&apos;s
+          <span class="term" data-definition="A query is a single question or instruction sent to a database: find me this, save that, delete the other.">queries</span>
+          ever ran. That timing is the tell.</p>
+
+        <div class="step-cards">
+          <div class="step-card">
+            <div class="step-num">1</div>
+            <div class="step-body">
+              <strong>Errors at the connection stage</strong>
+              <p>&quot;Not found&quot;, &quot;authentication failed&quot;, &quot;could not connect&quot; — before any of your queries run. Almost never your code. Suspect the address, the credentials, or the service itself.</p>
+            </div>
+          </div>
+          <div class="step-card">
+            <div class="step-num">2</div>
+            <div class="step-body">
+              <strong>Errors from a specific query</strong>
+              <p>&quot;column does not exist&quot;, &quot;duplicate key&quot;. The connection is fine — this is your code, or a migration that was never run.</p>
+            </div>
+          </div>
+          <div class="step-card">
+            <div class="step-num">3</div>
+            <div class="step-body">
+              <strong>No error, wrong answer</strong>
+              <p>Everything &quot;works&quot; but the numbers are wrong. The hardest kind. Module 7 is about these.</p>
+            </div>
+          </div>
+        </div>
+
+        <p>Two things would have caught this earlier: a health check that actually touches the database rather than just returning &quot;OK&quot;, and knowing in advance that free tiers reclaim idle projects.</p>
+
+        <p>When the database <em>does</em> exist, the app does not open a new connection for every question it asks. Opening one is slow, so it keeps a small set open and reuses them — a
+          <span class="term" data-definition="A connection pool is a small set of open database connections kept ready and shared between requests, instead of opening a fresh one every time. Like a switchboard with a few permanent phone lines rather than dialling from scratch on every call.">connection pool</span>.</p>
+
+        <div class="badge-list">
+          <div class="badge-item">
+            <code class="badge-code">max: 10</code>
+            <span class="badge-desc">At most ten open lines at once. The eleventh request waits its turn rather than overwhelming the database.</span>
+          </div>
+          <div class="badge-item">
+            <code class="badge-code">idle_timeout: 30</code>
+            <span class="badge-desc">A line sitting unused for 30 seconds gets hung up. Do not pay to hold lines nobody is talking on.</span>
+          </div>
+          <div class="badge-item">
+            <code class="badge-code">connect_timeout: 10</code>
+            <span class="badge-desc">If dialling takes more than 10 seconds, give up and fail loudly instead of hanging forever.</span>
+          </div>
+        </div>
+      </section>
+
+      <!-- SCREEN 5: The password in the code -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">The Password in the Code</h2>
+        <p>There is a patch in <code>src/db/index.ts</code>, written to work around a database password containing a <code>/</code> character that broke the connection address. We have replaced the password with <code>[REDACTED]</code> below. <strong>The real file has it in plain text.</strong></p>
+
+        <div class="bug-challenge">
+          <h3>Two things are wrong here. Click the line that worries you most:</h3>
+          <div class="bug-code">
+            <div class="bug-line" data-line="1" onclick="checkBugLine(this, false)"
+                 data-hint="That is only a comment — a note for human readers. Honest, even. Look at what the next line is comparing against.">
+              <span class="line-num">1</span>
+              <code>// Apply URL encoding for the specific password issue we're seeing</code>
+            </div>
+            <div class="bug-line bug-target" data-line="2" onclick="checkBugLine(this, true)"
+                 data-explanation="Two lessons, and both are worth more than the bug itself. <strong>One:</strong> a real database password is written into the source code. Code gets committed, shared, copied to laptops and screenshotted in chat — a secret in code is a secret that has already leaked. It belongs in an environment variable. <strong>Two:</strong> even if the password were safe here, this is the wrong fix. The problem is that a special character breaks the address; the real solution is to URL-encode the value in the environment variable once, for any password. This patch only ever works for one specific password on one specific day.">
+              <span class="line-num">2</span>
+              <code>if (databaseUrl.includes(':[REDACTED]@')) {</code>
+            </div>
+            <div class="bug-line" data-line="3" onclick="checkBugLine(this, false)"
+                 data-hint="Close — this line has the same problem as the one above it. Look one line higher, at the check that decides whether any of this runs.">
+              <span class="line-num">3</span>
+              <code>&nbsp;&nbsp;databaseUrl = databaseUrl.replace(':[REDACTED]@', ':[REDACTED-ENCODED]@');</code>
+            </div>
+            <div class="bug-line" data-line="4" onclick="checkBugLine(this, false)"
+                 data-hint="Logging that something happened is fine and even helpful. The problem is above.">
+              <span class="line-num">4</span>
+              <code>&nbsp;&nbsp;console.log('Applied URL encoding for database password special character');</code>
+            </div>
+            <div class="bug-line" data-line="5" onclick="checkBugLine(this, false)"
+                 data-hint="A closing bracket has never hurt anyone. Look further up.">
+              <span class="line-num">5</span>
+              <code>}</code>
+            </div>
+          </div>
+          <div class="bug-feedback"></div>
+        </div>
+
+        <p>Nobody should feel bad about this. It is a 2am &quot;just make it work&quot; patch, and it did work. It is also <em>exactly</em> what an AI assistant will write if you say &quot;the database URL is failing&quot; and paste the error — a fix aimed at your one symptom rather than at the cause.</p>
+
+        <div class="callout callout-warning">
+          <div class="callout-icon">🔐</div>
+          <div class="callout-content">
+            <strong class="callout-title">Secrets Never Go in Code</strong>
+            <p>Passwords, API keys and webhook secrets belong in
+              <span class="term" data-definition="An environment variable is a setting stored outside your code — on the server itself — that the app reads at startup. Changing it does not change any code, and it never gets committed alongside the code.">environment variables</span>,
+              set on the server and never committed. And when a fix works only for one exact value, ask what the general version of that fix would be. &quot;Handle any password with special characters&quot; is a different instruction from &quot;handle this password&quot; — and you are the one who has to ask for it.</p>
+          </div>
+        </div>
+      </section>
+
+      <!-- SCREEN 6: The outside world -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">Three Things You Do Not Control</h2>
+        <p>The database is rented. So is the AI, the image storage, and the payments. Each one fails in its own particular way.</p>
+
+        <div class="pattern-cards">
+          <div class="pattern-card" style="border-top: 3px solid var(--color-actor-4)">
+            <div class="pattern-icon" style="background: var(--color-actor-4)">✨</div>
+            <h4 class="pattern-title">Google Gemini</h4>
+            <p class="pattern-desc">Makes the cartoon. Fails with
+              <span class="term" data-definition="A quota is a cap on how much of a service you may use in a period — so many requests per day. Exceed it and the service refuses you until the clock resets.">quota exceeded</span>,
+              which arrives as
+              <span class="term" data-definition="HTTP 429 is the standard web response meaning Too Many Requests — you are being rate-limited. Every service on the internet uses the same number for it.">HTTP 429</span>.</p>
+          </div>
+          <div class="pattern-card" style="border-top: 3px solid var(--color-actor-2)">
+            <div class="pattern-icon" style="background: var(--color-actor-2)">🪣</div>
+            <h4 class="pattern-title">Cloudflare R2</h4>
+            <p class="pattern-desc"><span class="term" data-definition="Object storage is a service for keeping files — images, videos, backups — and handing back a web address for each one. Cheap, enormous, and not a database.">Object storage</span> for finished images. Fails by being unreachable, or by never having been configured at all.</p>
+          </div>
+          <div class="pattern-card" style="border-top: 3px solid var(--color-actor-3)">
+            <div class="pattern-icon" style="background: var(--color-actor-3)">💳</div>
+            <h4 class="pattern-title">Stripe</h4>
+            <p class="pattern-desc">Takes the money. Fails by rejecting a signature, or by having its webhook pointed at the wrong address.</p>
+          </div>
+        </div>
+
+        <div class="callout callout-accent">
+          <div class="callout-icon">💡</div>
+          <div class="callout-content">
+            <strong class="callout-title">Your App Is Mostly a Coordinator</strong>
+            <p>Strip out the rented parts and there is surprisingly little left: some rules about credits, some pages, and a lot of careful arranging. That is normal and it is not a criticism — but it changes what &quot;the app is broken&quot; usually means. More often than not it means <em>an outside service said no</em>, and that is where to look first.</p>
+          </div>
+        </div>
+      </section>
+
+      <!-- SCREEN 7: The key pool -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">A Bank of Phone Lines</h2>
+        <p>Each Gemini
+          <span class="term" data-definition="An API key is a secret, password-like string that lets a program prove which account it belongs to when calling an outside service. Usage and billing are counted against it.">API key</span>
+          has a daily limit. So the app does not have one key — it reads up to six from environment variables and rotates through them like a switchboard rotating through phone lines.</p>
+
+        <div class="badge-list">
+          <div class="badge-item">
+            <code class="badge-code">GEMINI_API_KEY</code>
+            <span class="badge-desc">Line one. The only one that must exist.</span>
+          </div>
+          <div class="badge-item">
+            <code class="badge-code">GEMINI_API_KEY_1 … _5</code>
+            <span class="badge-desc">Five more optional lines. Any that are not set are quietly filtered out of the list at startup — no error, the pool just ends up smaller.</span>
+          </div>
+        </div>
+
+        <p>Step through the switchboard. Watch what happens when one line gets a busy signal.</p>
+
+        <div class="flow-animation" data-steps='[
+          {"highlight":"flow-actor-5-1","label":"Request 1 arrives. The switchboard hands out Key A."},
+          {"highlight":"flow-actor-5-2","label":"Key A calls Gemini. A cartoon comes back. The pool counts one request against Key A for today.","packet":true,"from":"actor-5-2","to":"actor-5-5"},
+          {"highlight":"flow-actor-5-3","label":"Request 2 arrives. Not Key A again — the switchboard rotates to Key B.","packet":true,"from":"actor-5-1","to":"actor-5-3"},
+          {"highlight":"flow-actor-5-4","label":"Request 3 arrives. Rotate again: Key C.","packet":true,"from":"actor-5-1","to":"actor-5-4"},
+          {"highlight":"flow-actor-5-5","label":"Key C calls Gemini and gets back HTTP 429: quota exceeded. That key is done for today.","packet":true,"from":"actor-5-4","to":"actor-5-5"},
+          {"highlight":"flow-actor-5-4","label":"The pool benches Key C — marks it unavailable and stops handing it out."},
+          {"highlight":"flow-actor-5-2","label":"Request 4 arrives. The switchboard skips the benched line and goes back to Key A. The user never knew anything happened.","packet":true,"from":"actor-5-1","to":"actor-5-2"},
+          {"highlight":"flow-actor-5-1","label":"If every line ends up benched, nobody gets a crash — they get an honest message saying the app is at capacity."}
+        ]'>
+          <div class="flow-actors">
+            <div class="flow-actor" id="flow-actor-5-1">
+              <div class="flow-actor-icon" style="background: var(--color-accent)">☎️</div>
+              <span>Switchboard</span>
+            </div>
+            <div class="flow-actor" id="flow-actor-5-2">
+              <div class="flow-actor-icon" style="background: var(--color-actor-2)">A</div>
+              <span>Key A</span>
+            </div>
+            <div class="flow-actor" id="flow-actor-5-3">
+              <div class="flow-actor-icon" style="background: var(--color-actor-3)">B</div>
+              <span>Key B</span>
+            </div>
+            <div class="flow-actor" id="flow-actor-5-4">
+              <div class="flow-actor-icon" style="background: var(--color-actor-4)">C</div>
+              <span>Key C</span>
+            </div>
+            <div class="flow-actor" id="flow-actor-5-5">
+              <div class="flow-actor-icon" style="background: var(--color-actor-5)">✨</div>
+              <span>Gemini</span>
+            </div>
+          </div>
+
+          <div class="flow-packet" id="flow-packet-5"></div>
+          <div class="flow-step-label" id="flow-label-5">Click "Next Step" to begin</div>
+
+          <div class="flow-controls">
+            <button class="btn flow-next-btn">Next Step</button>
+            <button class="btn flow-reset-btn">Restart</button>
+            <span class="flow-progress"></span>
+          </div>
+        </div>
+
+        <p>Here is the benching, and something else worth noticing.</p>
+
+        <div class="translation-block animate-in">
+          <div class="translation-code">
+            <span class="translation-label">CODE</span>
+            <pre><code>
+<span class="code-line">      <span class="code-comment">// Check if it&apos;s a quota/limit error</span></span>
+<span class="code-line">      <span class="code-keyword">if</span> (error.message?.<span class="code-function">includes</span>(<span class="code-string">'quota'</span>) || error.message?.<span class="code-function">includes</span>(<span class="code-string">'limit'</span>) || error.status === <span class="code-number">429</span>) {</span>
+<span class="code-line">        geminiApiPool.<span class="code-function">markKeyAsUnavailable</span>(geminiApiKey, <span class="code-string">'Quota exceeded'</span>);</span>
+<span class="code-line">        <span class="code-keyword">return</span> <span class="code-function">respErr</span>(<span class="code-string">"Too many users online! VIP users get priority access. You're in queue, please wait a moment or upgrade to VIP for instant access."</span>, <span class="code-string">'QUEUE_REQUIRED'</span>);</span>
+<span class="code-line">      }</span>
+            </code></pre>
+          </div>
+          <div class="translation-english">
+            <span class="translation-label">PLAIN ENGLISH</span>
+            <div class="translation-lines">
+              <p class="tl">Something went wrong with the AI call. Work out whether it was a
+                <span class="term" data-definition="A rate limit is a rule capping how often you may call a service — 60 requests a minute, 1,500 a day. Every serious service has them, and hitting one is a normal event, not a disaster.">rate limit</span>
+                by checking three different ways, because different services phrase it differently.</p>
+              <p class="tl">If it was: bench this key. Take it out of rotation so the next request tries a different one instead of hitting the same wall.</p>
+              <p class="tl">Then tell the user. And look closely at what they are told — this is not an error message, it is a sales pitch.</p>
+              <p class="tl">&quot;Too many users online, VIP users get priority access.&quot; A technical limit has been reframed as evidence the product is popular, and as a reason to pay. That is a deliberate product decision, living inside error-handling code.</p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- SCREEN 8: Graceful degradation + quiz -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">Worse, But Working</h2>
+        <p>What if the image storage is not configured at all? The app does not error. It quietly does something worse instead.</p>
+
+        <div class="translation-block animate-in">
+          <div class="translation-code">
+            <span class="translation-label">CODE</span>
+            <pre><code>
+<span class="code-line">    <span class="code-keyword">let</span> finalImageUrl = <span class="code-string">`data:${generatedImageMimeType};base64,${generatedImageData}`</span>;</span>
+<span class="code-line">    <span class="code-keyword">let</span> storedFilename = filename;</span>
+<span class="code-line">&nbsp;</span>
+<span class="code-line">    <span class="code-comment">// Store image if storage is configured</span></span>
+<span class="code-line">    <span class="code-keyword">const</span> hasStorageConfig = process.env.STORAGE_ENDPOINT &amp;&amp;</span>
+<span class="code-line">                            process.env.STORAGE_ACCESS_KEY &amp;&amp;</span>
+<span class="code-line">                            process.env.STORAGE_SECRET_KEY &amp;&amp;</span>
+<span class="code-line">                            process.env.STORAGE_BUCKET;</span>
+            </code></pre>
+          </div>
+          <div class="translation-english">
+            <span class="translation-label">PLAIN ENGLISH</span>
+            <div class="translation-lines">
+              <p class="tl">Start by assuming the worst case: the image address is the entire image, encoded as a gigantic block of text called a
+                <span class="term" data-definition="A data URL is a web address that contains the file itself rather than pointing at one. Instead of a link to a picture, the link IS the picture, spelled out in text — which makes it enormous.">data URL</span>.</p>
+              <p class="tl">Note that this is the <em>default</em>, set before anything is even attempted. The good outcome is the upgrade; the poor outcome is the starting point.</p>
+              <p class="tl">Now check whether proper storage is set up — all four settings must be present. Miss one and storage counts as unconfigured.</p>
+              <p class="tl">If they are all there, upload the image and replace that giant text block with a short, real web address.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="callout callout-info">
+          <div class="callout-icon">🪂</div>
+          <div class="callout-content">
+            <strong class="callout-title">Graceful Degradation</strong>
+            <p>Name the pattern:
+              <span class="term" data-definition="Graceful degradation means that when part of a system fails, the rest keeps working in a reduced way instead of collapsing. An escalator with the power off is still a staircase.">graceful degradation</span>.
+              The user still gets their cartoon. But the reply is now megabytes instead of bytes, the image is saved nowhere, and there is no link they can share. Worse, but working — and worth knowing that this is what &quot;it feels slow today&quot; sometimes actually is.</p>
+          </div>
+        </div>
+
+        <h2 class="screen-heading" style="margin-top: var(--space-12)">Check Your Understanding</h2>
+        <p>Four debugging scenarios. Two of them really happened.</p>
+
+        <div class="quiz-container" id="quiz-module5">
+
+          <div class="quiz-question-block"
+               data-correct="q1-b"
+               data-explanation-right="Exactly — and this is the real story from this codebase. The error appeared before any query ran, which points at the connection itself: wrong address, wrong credentials, or a service that no longer exists. Free tiers reclaim idle projects, and that is what had happened."
+               data-explanation-wrong="Look at the timing. The failure happened before a single query was sent — so nothing about your queries, your schema or your recent code changes can be responsible. What has to be true before any query can run at all?">
+            <h3 class="quiz-question">Your app suddenly returns errors on every page. The log says <code>tenant or user not found</code>, and it appears before any query runs. Most likely cause?</h3>
+            <div class="quiz-options">
+              <button class="quiz-option" data-value="q1-a" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>A bug in the last code change you shipped</span>
+              </button>
+              <button class="quiz-option" data-value="q1-b" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>The database itself is gone or unreachable, or the connection details are wrong — not your application code</span>
+              </button>
+              <button class="quiz-option" data-value="q1-c" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>A missing migration — some column the code expects does not exist</span>
+              </button>
+            </div>
+            <div class="quiz-feedback"></div>
+          </div>
+
+          <div class="quiz-question-block"
+               data-correct="q2-a"
+               data-explanation-right="Exactly. The blueprint change alone only updates the description. The migration is the reviewable, repeatable record that can be run on your laptop, the test site and production and produce the same result every time — and that you can read before it touches anything."
+               data-explanation-wrong="Think about the difference between redrawing the blueprint and issuing a permit. A schema edit describes the new shape; something else has to actually, safely, change the building people are living in — and leave a record of it.">
+            <h3 class="quiz-question">You ask an AI to &quot;add a phone number field to users&quot;. What should you insist it produces alongside the schema change?</h3>
+            <div class="quiz-options">
+              <button class="quiz-option" data-value="q2-a" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>A migration file — so the change is reviewable and repeats identically on every environment</span>
+              </button>
+              <button class="quiz-option" data-value="q2-b" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>A backup of the whole database</span>
+              </button>
+              <button class="quiz-option" data-value="q2-c" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>Nothing — editing the schema file is the change</span>
+              </button>
+            </div>
+            <div class="quiz-feedback"></div>
+          </div>
+
+          <div class="scenario-block">
+            <div class="scenario-context">
+              <span class="scenario-label">Scenario</span>
+              <p>Image generation works for the first few dozen users each morning. By lunchtime, everyone gets &quot;Too many users online! VIP users get priority access.&quot; Overnight it fixes itself, then does the same thing again.</p>
+            </div>
+            <div class="quiz-question-block"
+                 data-correct="q3-b"
+                 data-explanation-right="Exactly — daily quotas reset at midnight, which is why it heals overnight and breaks again by lunchtime. Every key in the pool has been benched. Your levers: add more keys, raise the paid quota, or queue requests so you spend the quota you have on the users who matter most."
+                 data-explanation-wrong="Look at the rhythm of the failure: it heals overnight and returns during the day. Something is being counted, hitting a ceiling, and resetting on a daily clock. What in this module works exactly like that?">
+              <h3 class="quiz-question">What is going on, and what is one lever you could pull?</h3>
+              <div class="quiz-options">
+                <button class="quiz-option" data-value="q3-a" onclick="selectOption(this)">
+                  <div class="quiz-option-radio"></div>
+                  <span>The server runs out of memory during the day and restarts overnight</span>
+                </button>
+                <button class="quiz-option" data-value="q3-b" onclick="selectOption(this)">
+                  <div class="quiz-option-radio"></div>
+                  <span>The daily quota on every key in the pool is exhausted — add more keys, raise the paid quota, or queue requests</span>
+                </button>
+                <button class="quiz-option" data-value="q3-c" onclick="selectOption(this)">
+                  <div class="quiz-option-radio"></div>
+                  <span>The database connection pool is full and never releases connections</span>
+                </button>
+              </div>
+              <div class="quiz-feedback"></div>
+            </div>
+          </div>
+
+          <div class="quiz-question-block"
+               data-correct="q4-c"
+               data-explanation-right="Exactly — graceful degradation in action. Generation still works, but the image comes back embedded in the reply as an enormous block of text, is saved nowhere, and cannot be linked to or shared. Nobody sees an error, which is exactly what makes this kind of fault so easy to miss."
+               data-explanation-wrong="Remember the default value at the top of that code: the giant embedded image is what happens when nothing is configured. The upload is an upgrade on top of it, not a requirement — so nothing crashes.">
+            <h3 class="quiz-question">The storage credentials are missing in production. What does a user actually experience?</h3>
+            <div class="quiz-options">
+              <button class="quiz-option" data-value="q4-a" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>An error page — image generation is unavailable</span>
+              </button>
+              <button class="quiz-option" data-value="q4-b" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>The image generates but appears blank</span>
+              </button>
+              <button class="quiz-option" data-value="q4-c" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>It works, but slower — the image is embedded in the reply, saved nowhere, and cannot be shared as a link</span>
+              </button>
+            </div>
+            <div class="quiz-feedback"></div>
+          </div>
+
+          <button class="quiz-check-btn" onclick="checkQuiz('quiz-module5')">Check Answers</button>
+          <button class="quiz-reset-btn" onclick="resetQuiz('quiz-module5')">Try Again</button>
+        </div>
+
+        <p style="margin-top: var(--space-10)">Every error message we have quoted so far has been in English. But this app runs in two languages — and none of that text lives in the components. That is <strong>Every Language, Every Screen</strong>.</p>
+      </section>
+
+    </div>
+  </div>
+</section>
+<section class="module" id="module-6" style="background: var(--color-bg)">
+  <div class="module-content">
+    <header class="module-header animate-in">
+      <span class="module-number">06</span>
+      <h1 class="module-title">Every Language, Every Screen</h1>
+      <p class="module-subtitle">Add <code>/zh</code> to the address bar and the entire app becomes Chinese — same buttons, same layout, same code. Not one component was duplicated to make that happen.</p>
+    </header>
+
+    <div class="module-body">
+
+      <!-- SCREEN 1: The audio guide -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">The Museum Audio Guide</h2>
+        <p>The museum gets built once. The paintings hang where they hang, the corridors run where they run. At the door you pick a language and get a handset — and from then on, every plaque you stand in front of is narrated in <em>your</em> language.</p>
+
+        <p>Nobody built a second museum for Mandarin speakers. That is the entire idea of this module, and it has three parts.</p>
+
+        <div class="pattern-cards">
+          <div class="pattern-card" style="border-top: 3px solid var(--color-actor-2)">
+            <div class="pattern-icon" style="background: var(--color-actor-2)">🏛️</div>
+            <h4 class="pattern-title">The Building</h4>
+            <p class="pattern-desc">The <strong>structure</strong> — components, layout, buttons, the shape of every page. Built once, shared by everyone.</p>
+          </div>
+          <div class="pattern-card" style="border-top: 3px solid var(--color-actor-4)">
+            <div class="pattern-icon" style="background: var(--color-actor-4)">🎧</div>
+            <h4 class="pattern-title">The Handset</h4>
+            <p class="pattern-desc">The <span class="term" data-definition="A locale is the language-and-region setting for a visitor — en for English, zh for Chinese. It decides not just words but also prices, dates and number formats.">locale</span>: which language you picked up at the door. In this app, it is the <code>/zh</code> in the address.</p>
+          </div>
+          <div class="pattern-card" style="border-top: 3px solid var(--color-accent)">
+            <div class="pattern-icon" style="background: var(--color-accent)">📖</div>
+            <h4 class="pattern-title">The Narration</h4>
+            <p class="pattern-desc">The <strong>content</strong> — every word on the site, living in data files rather than inside the code.</p>
+          </div>
+        </div>
+
+        <div class="callout callout-accent">
+          <div class="callout-icon">💡</div>
+          <div class="callout-content">
+            <strong class="callout-title">Separate Structure From Content</strong>
+            <p>The moment text stops living inside your components and starts living in data files, you get translations, marketing experiments, and non-developers editing copy — all for free, all at once. It is the same principle as Module 2&apos;s &quot;the page is a template, the content is data&quot;, now applied to every word on the site. Retro-fitting this later, into an app where text is scattered across two hundred components, is a brutal and expensive job.</p>
+          </div>
+        </div>
+      </section>
+
+      <!-- SCREEN 2: The doorman -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">The Doorman</h2>
+        <p>One file runs before <em>every single page request</em> in this app. It looks at the address, works out which language you want, and routes you accordingly. It is twelve lines long, and it is the only reason <code>/zh/pricing</code> works at all.</p>
+
+        <div class="translation-block animate-in">
+          <div class="translation-code">
+            <span class="translation-label">CODE</span>
+            <pre><code>
+<span class="code-line"><span class="code-keyword">import</span> createMiddleware <span class="code-keyword">from</span> <span class="code-string">"next-intl/middleware"</span>;</span>
+<span class="code-line"><span class="code-keyword">import</span> { routing } <span class="code-keyword">from</span> <span class="code-string">"./i18n/routing"</span>;</span>
+<span class="code-line">&nbsp;</span>
+<span class="code-line"><span class="code-keyword">export default</span> <span class="code-function">createMiddleware</span>(routing);</span>
+<span class="code-line">&nbsp;</span>
+<span class="code-line"><span class="code-keyword">export const</span> config = {</span>
+<span class="code-line">  <span class="code-property">matcher</span>: [</span>
+<span class="code-line">    <span class="code-string">"/"</span>,</span>
+<span class="code-line">    <span class="code-string">"/(en|en-US|zh|zh-CN|zh-TW|zh-HK|zh-MO|ja|ko|ru|fr|de|ar|es|it)/:path*"</span>,</span>
+<span class="code-line">    <span class="code-string">"/((?!privacy-policy|terms-of-service|api/|_next|_vercel|.*\\..*).*)"</span>,</span>
+<span class="code-line">  ],</span>
+<span class="code-line">};</span>
+            </code></pre>
+          </div>
+          <div class="translation-english">
+            <span class="translation-label">PLAIN ENGLISH</span>
+            <div class="translation-lines">
+              <p class="tl">Borrow a ready-made doorman from a library called next-intl, and the rules we want it to follow.</p>
+              <p class="tl">Make that doorman the thing that greets every visitor. That single line is the whole
+                <span class="term" data-definition="Middleware is code that runs in between a request arriving and the page that answers it — a checkpoint every visitor passes through. Language routing, authentication and redirects commonly live here.">middleware</span>.</p>
+              <p class="tl">Now describe which addresses the doorman should stand at.</p>
+              <p class="tl">The home page, for one.</p>
+              <p class="tl">And anything that starts with a language code. Notice this list is far longer than the two languages the app actually supports — the doorman <em>recognises</em> thirteen and the museum only narrates in two.</p>
+              <p class="tl">And everything else, <em>except</em> the legal pages, anything under <code>api/</code>, and files like images. That is a
+                <span class="term" data-definition="A regular expression is a compact notation for describing text patterns — match these addresses but not those. Famously unreadable, genuinely useful, and something you can safely ask an AI to write and explain.">regular expression</span>:
+                dense, unreadable, and doing real work.</p>
+              <p class="tl">API addresses are deliberately excluded — a program calling your app does not need a language prefix on its request.</p>
+            </div>
+          </div>
+        </div>
+
+        <p>And the actual language list is even shorter and even plainer:</p>
+
+        <div class="translation-block animate-in">
+          <div class="translation-code">
+            <span class="translation-label">CODE</span>
+            <pre><code>
+<span class="code-line"><span class="code-keyword">export const</span> locales = [<span class="code-string">"en"</span>, <span class="code-string">"zh"</span>];</span>
+<span class="code-line">&nbsp;</span>
+<span class="code-line"><span class="code-keyword">export const</span> localeNames: <span class="code-keyword">any</span> = {</span>
+<span class="code-line">  <span class="code-property">en</span>: <span class="code-string">"English"</span>,</span>
+<span class="code-line">  <span class="code-property">zh</span>: <span class="code-string">"中文"</span>,</span>
+<span class="code-line">};</span>
+<span class="code-line">&nbsp;</span>
+<span class="code-line"><span class="code-keyword">export const</span> defaultLocale = <span class="code-string">"en"</span>;</span>
+<span class="code-line">&nbsp;</span>
+<span class="code-line"><span class="code-keyword">export const</span> localePrefix = <span class="code-string">"as-needed"</span>;</span>
+            </code></pre>
+          </div>
+          <div class="translation-english">
+            <span class="translation-label">PLAIN ENGLISH</span>
+            <div class="translation-lines">
+              <p class="tl">Two real languages. That is the whole list — adding a third starts here.</p>
+              <p class="tl">What to write in the language switcher menu for each one, in that language.</p>
+              <p class="tl">If we cannot tell what someone wants, assume English.</p>
+              <p class="tl">&quot;As needed&quot; is a small, real product decision: the default language gets the clean address (<code>/pricing</code>), and only other languages carry a
+                <span class="term" data-definition="A URL prefix is a segment added to the front of a web address path — the zh in /zh/pricing. It tells the server something about the request before the page is even chosen.">prefix</span>
+                (<code>/zh/pricing</code>).</p>
+            </div>
+          </div>
+        </div>
+
+        <p>Watch a Chinese visitor and a German visitor go through the same door.</p>
+
+        <div class="flow-animation" data-steps='[
+          {"highlight":"flow-actor-6-1","label":"Someone in Shanghai asks for /zh/pricing."},
+          {"highlight":"flow-actor-6-2","label":"Before any page exists, the request passes the doorman. Every request does.","packet":true,"from":"actor-6-1","to":"actor-6-2"},
+          {"highlight":"flow-actor-6-2","label":"The doorman reads zh out of the address and notes it: this visitor is being narrated in Chinese."},
+          {"highlight":"flow-actor-6-3","label":"The pricing page component is asked to render. The SAME component English visitors get.","packet":true,"from":"actor-6-2","to":"actor-6-3"},
+          {"highlight":"flow-actor-6-4","label":"It goes and fetches two files: messages/zh.json for buttons and labels, pages/pricing/zh.json for the actual page content.","packet":true,"from":"actor-6-3","to":"actor-6-4"},
+          {"highlight":"flow-actor-6-1","label":"Back comes the same page, filled with Chinese text and prices in yuan. Zero components were duplicated.","packet":true,"from":"actor-6-4","to":"actor-6-1"},
+          {"highlight":"flow-actor-6-2","label":"Now someone in Berlin asks for /de/pricing. The doorman recognises de and waves them through."},
+          {"highlight":"flow-actor-6-4","label":"But there is no de.json to load. Instead of an error page, the loader quietly hands back English. Wrong language beats broken page."}
+        ]'>
+          <div class="flow-actors">
+            <div class="flow-actor" id="flow-actor-6-1">
+              <div class="flow-actor-icon" style="background: var(--color-actor-2)">🌐</div>
+              <span>Browser</span>
+            </div>
+            <div class="flow-actor" id="flow-actor-6-2">
+              <div class="flow-actor-icon" style="background: var(--color-accent)">🚪</div>
+              <span>Middleware</span>
+            </div>
+            <div class="flow-actor" id="flow-actor-6-3">
+              <div class="flow-actor-icon" style="background: var(--color-actor-3)">📄</div>
+              <span>Page</span>
+            </div>
+            <div class="flow-actor" id="flow-actor-6-4">
+              <div class="flow-actor-icon" style="background: var(--color-actor-4)">🗂️</div>
+              <span>Text Files</span>
+            </div>
+          </div>
+
+          <div class="flow-packet" id="flow-packet-6"></div>
+          <div class="flow-step-label" id="flow-label-6">Click "Next Step" to begin</div>
+
+          <div class="flow-controls">
+            <button class="btn flow-next-btn">Next Step</button>
+            <button class="btn flow-reset-btn">Restart</button>
+            <span class="flow-progress"></span>
+          </div>
+        </div>
+      </section>
+
+      <!-- SCREEN 3: Two kinds of text -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">Two Kinds of Text, Two Different Homes</h2>
+        <p>Not all words are the same. This app keeps them in two separate places, and the distinction is worth getting right in any project you build.</p>
+
+        <div class="pattern-cards">
+          <div class="pattern-card" style="border-top: 3px solid var(--color-actor-2)">
+            <div class="pattern-icon" style="background: var(--color-actor-2)">🔘</div>
+            <h4 class="pattern-title">Interface Labels</h4>
+            <p class="pattern-desc">Buttons, error messages, form hints. Short, reused everywhere. Home: <code>i18n/messages/en.json</code> and <code>zh.json</code>.</p>
+          </div>
+          <div class="pattern-card" style="border-top: 3px solid var(--color-accent)">
+            <div class="pattern-icon" style="background: var(--color-accent)">📰</div>
+            <h4 class="pattern-title">Page Content</h4>
+            <p class="pattern-desc">The entire marketing page, section by section. Home: <code>i18n/pages/landing/en.json</code> and <code>zh.json</code>.</p>
+          </div>
+        </div>
+
+        <p>The first kind looks like this — a
+          <span class="term" data-definition="JSON is a plain-text format for storing structured information as labels and values. It is the most common way programs exchange data, and it is readable by anyone: no programming needed to edit it.">JSON</span>
+          file of
+          <span class="term" data-definition="A key is the label you look something up by; the value is what you get back. sign_in is the key, Sign In is the value. Same key in every language file, different value.">keys and values</span>,
+          where the key is identical in both languages and only the value changes.</p>
+
+        <div class="pattern-cards">
+          <div class="pattern-card" style="border-top: 3px solid var(--color-actor-2)">
+            <div class="pattern-icon" style="background: var(--color-actor-2)">🇬🇧</div>
+            <h4 class="pattern-title">en.json</h4>
+            <p class="pattern-desc"><code>"sign_in": "Sign In"</code><br><code>"pricing": "Pricing"</code><br><code>"my_credits": "My Credits"</code></p>
+          </div>
+          <div class="pattern-card" style="border-top: 3px solid var(--color-accent)">
+            <div class="pattern-icon" style="background: var(--color-accent)">🔑</div>
+            <h4 class="pattern-title">The Component</h4>
+            <p class="pattern-desc">Asks for the key, never the words:<br><code>t("sign_in")</code><br>One component. One line. Both languages.</p>
+          </div>
+          <div class="pattern-card" style="border-top: 3px solid var(--color-actor-3)">
+            <div class="pattern-icon" style="background: var(--color-actor-3)">🇨🇳</div>
+            <h4 class="pattern-title">zh.json</h4>
+            <p class="pattern-desc"><code>"sign_in": "登录"</code><br><code>"pricing": "价格"</code><br><code>"my_credits": "我的积分"</code></p>
+          </div>
+        </div>
+
+        <p>The second kind is the surprising one. The <em>entire</em> landing page — hero headline, features, testimonials, FAQ, all eight pricing plans — is a data file, with sections named <code>hero</code>, <code>introduce</code>, <code>benefit</code>, <code>usage</code>, <code>feature</code>, <code>stats</code>, <code>testimonial</code>, <code>faq</code>, <code>cta</code>, <code>footer</code>.</p>
+
+        <p>Module 2 showed the page component drawing each section only if the data for it exists. <strong>This is where that data comes from.</strong></p>
+
+        <div class="translation-block animate-in">
+          <div class="translation-code">
+            <span class="translation-label">CODE</span>
+            <pre><code>
+<span class="code-line"><span class="code-keyword">export async function</span> <span class="code-function">getPage</span>(</span>
+<span class="code-line">  name: string,</span>
+<span class="code-line">  locale: string</span>
+<span class="code-line">): Promise&lt;LandingPage | PricingPage | ShowcasePage&gt; {</span>
+<span class="code-line">  <span class="code-keyword">try</span> {</span>
+<span class="code-line">    <span class="code-keyword">if</span> (locale === <span class="code-string">"zh-CN"</span>) {</span>
+<span class="code-line">      locale = <span class="code-string">"zh"</span>;</span>
+<span class="code-line">    }</span>
+<span class="code-line">&nbsp;</span>
+<span class="code-line">    <span class="code-keyword">return await import</span>(</span>
+<span class="code-line">      <span class="code-string">`@/i18n/pages/${name}/${locale.toLowerCase()}.json`</span></span>
+<span class="code-line">    ).<span class="code-function">then</span>((module) =&gt; module.default);</span>
+<span class="code-line">  } <span class="code-keyword">catch</span> (error) {</span>
+<span class="code-line">    console.<span class="code-function">warn</span>(<span class="code-string">`Failed to load ${locale}.json, falling back to en.json`</span>);</span>
+<span class="code-line">&nbsp;</span>
+<span class="code-line">    <span class="code-keyword">return await import</span>(<span class="code-string">`@/i18n/pages/${name}/en.json`</span>).<span class="code-function">then</span>(</span>
+<span class="code-line">      (module) =&gt; module.default</span>
+<span class="code-line">    );</span>
+<span class="code-line">  }</span>
+<span class="code-line">}</span>
+            </code></pre>
+          </div>
+          <div class="translation-english">
+            <span class="translation-label">PLAIN ENGLISH</span>
+            <div class="translation-lines">
+              <p class="tl">Given a page name and a language, go and fetch that page&apos;s content.</p>
+              <p class="tl">Treat &quot;Chinese as spoken in mainland China&quot; as plain Chinese — one file serves both.</p>
+              <p class="tl">Build a file path out of the two pieces and load it. <code>landing</code> + <code>zh</code> becomes <code>pages/landing/zh.json</code>.</p>
+              <p class="tl">Hand back whatever was inside. That object <em>is</em> the marketing page — every headline, every feature, every price.</p>
+              <p class="tl">If loading failed for any reason at all, do not crash. Leave a note in the log so someone can find out why later.</p>
+              <p class="tl">Then load the English file instead and hand that back. The visitor gets a page in the wrong language rather than no page at all.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="callout callout-info">
+          <div class="callout-icon">✍️</div>
+          <div class="callout-content">
+            <strong class="callout-title">The Marketing Team Does Not Need You</strong>
+            <p>Rewriting the entire home page means editing a text file. No component is touched, no logic changes, nothing is redeployed differently. When you are designing a new project, ask for this on day one: <em>&quot;user-facing strings go in the translation files, not inline in components.&quot;</em> It is one sentence, and it saves weeks.</p>
+          </div>
+        </div>
+      </section>
+
+      <!-- SCREEN 4: The fallback chain -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">When There Is No Narration</h2>
+        <p>The same safety net protects the interface labels. Try to load the visitor&apos;s language; if anything at all goes wrong, quietly serve English.</p>
+
+        <div class="translation-block animate-in">
+          <div class="translation-code">
+            <span class="translation-label">CODE</span>
+            <pre><code>
+<span class="code-line">  <span class="code-keyword">try</span> {</span>
+<span class="code-line">    <span class="code-keyword">const</span> messages = (<span class="code-keyword">await import</span>(<span class="code-string">`./messages/${locale.toLowerCase()}.json`</span>))</span>
+<span class="code-line">      .default;</span>
+<span class="code-line">    <span class="code-keyword">return</span> {</span>
+<span class="code-line">      <span class="code-property">locale</span>: locale,</span>
+<span class="code-line">      <span class="code-property">messages</span>: messages,</span>
+<span class="code-line">    };</span>
+<span class="code-line">  } <span class="code-keyword">catch</span> (e) {</span>
+<span class="code-line">    <span class="code-keyword">return</span> {</span>
+<span class="code-line">      <span class="code-property">locale</span>: <span class="code-string">"en"</span>,</span>
+<span class="code-line">      <span class="code-property">messages</span>: (<span class="code-keyword">await import</span>(<span class="code-string">`./messages/en.json`</span>)).default,</span>
+<span class="code-line">    };</span>
+<span class="code-line">  }</span>
+            </code></pre>
+          </div>
+          <div class="translation-english">
+            <span class="translation-label">PLAIN ENGLISH</span>
+            <div class="translation-lines">
+              <p class="tl">Try to load the label file for whatever language this visitor asked for.</p>
+              <p class="tl">If that worked, hand back both the language and its words.</p>
+              <p class="tl">If it failed for <em>any</em> reason — no such file, a typo in the language code, a corrupted file — do not throw an error.</p>
+              <p class="tl">Say the language is English and hand back the English words instead. This is the
+                <span class="term" data-definition="A fallback is the safe alternative a program uses when its first choice is unavailable — a spare tyre. Good fallbacks are quiet and keep the thing usable.">fallback</span>,
+                and it is the same graceful degradation idea from last module wearing a different costume.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="callout callout-accent">
+          <div class="callout-icon">🌏</div>
+          <div class="callout-content">
+            <strong class="callout-title">Localisation Is Adaptation, Not Translation</strong>
+            <p>The Chinese pricing file does not just carry Chinese words — it carries a separate <code>cn_amount</code>, priced for that market, and Chinese checkouts add WeChat Pay and Alipay as payment methods. Words, currency (<span class="term" data-definition="CNY is the international code for Chinese yuan, the way USD is the code for US dollars. Every currency has a three-letter code, and payment systems always use them.">CNY</span> rather than USD), date formats, payment methods, sometimes whole features. Translating the strings is the easy quarter of the job.</p>
+          </div>
+        </div>
+      </section>
+
+      <!-- SCREEN 5: Standard parts -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">Built From Standard Parts</h2>
+        <p>The building itself is not hand-carved either. The interface comes in three layers, smallest to largest.</p>
+
+        <div class="step-cards">
+          <div class="step-card">
+            <div class="step-num">1</div>
+            <div class="step-body">
+              <strong><span class="term" data-definition="Tailwind CSS is a styling approach where instead of writing style rules in a separate file, you attach lots of tiny pre-made class names directly to the element. Divisive among developers, extremely fast in practice.">Tailwind CSS</span> — the raw material</strong>
+              <p>Instead of writing <span class="term" data-definition="CSS is the language that controls how a web page looks — colours, spacing, fonts, layout. HTML says what is on the page; CSS says what it looks like.">style rules</span> in a separate file, you attach tiny
+                <span class="term" data-definition="A class name is a label attached to an element on a page so that styling can be applied to it. flex, rounded-md and gap-2 are each one small instruction.">class names</span>
+                directly to the element: <code>flex items-center gap-2 rounded-md</code>. The payoff is that there is never a mystery about which stylesheet a colour came from.</p>
+            </div>
+          </div>
+          <div class="step-card">
+            <div class="step-num">2</div>
+            <div class="step-body">
+              <strong><code>components/ui/</code> — 37 generic parts</strong>
+              <p>Button, card, dialog, tabs, tooltip, table. This is
+                <span class="term" data-definition="Shadcn UI is a collection of ready-made interface components you copy into your project rather than install. Because the code lives in your repo, you can edit any of it.">Shadcn UI</span>
+                — and crucially it is <em>not</em> an installed
+                <span class="term" data-definition="A component library is a package of ready-made interface pieces — buttons, menus, date pickers — that you install and use. Normally you cannot change how they work internally.">component library</span>.
+                The code was copied <em>into</em> the project, so any of it can be edited. You own the parts.</p>
+            </div>
+          </div>
+          <div class="step-card">
+            <div class="step-num">3</div>
+            <div class="step-body">
+              <strong><code>components/blocks/</code> — whole sections</strong>
+              <p><code>hero</code>, <code>pricing</code>, <code>faq</code>, <code>footer</code>, <code>showcase</code>. Each one assembled from the generic parts, and each one filled with text from the data files you just met.</p>
+            </div>
+          </div>
+        </div>
+
+        <p>A button is not one button. It is a small menu of options, all defined in a single file.</p>
+
+        <div class="translation-block animate-in">
+          <div class="translation-code">
+            <span class="translation-label">CODE</span>
+            <pre><code>
+<span class="code-line">      <span class="code-property">variant</span>: {</span>
+<span class="code-line">        <span class="code-property">default</span>:</span>
+<span class="code-line">          <span class="code-string">"bg-primary text-primary-foreground shadow-xs hover:bg-primary/90"</span>,</span>
+<span class="code-line">        <span class="code-property">destructive</span>:</span>
+<span class="code-line">          <span class="code-string">"bg-destructive text-white shadow-xs hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60"</span>,</span>
+<span class="code-line">        <span class="code-property">outline</span>:</span>
+<span class="code-line">          <span class="code-string">"border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50"</span>,</span>
+<span class="code-line">        <span class="code-property">secondary</span>:</span>
+<span class="code-line">          <span class="code-string">"bg-secondary text-secondary-foreground shadow-xs hover:bg-secondary/80"</span>,</span>
+<span class="code-line">        <span class="code-property">ghost</span>:</span>
+<span class="code-line">          <span class="code-string">"hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50"</span>,</span>
+<span class="code-line">        <span class="code-property">link</span>: <span class="code-string">"text-primary underline-offset-4 hover:underline"</span>,</span>
+<span class="code-line">      },</span>
+            </code></pre>
+          </div>
+          <div class="translation-english">
+            <span class="translation-label">PLAIN ENGLISH</span>
+            <div class="translation-lines">
+              <p class="tl">Here is the complete list of looks a button in this app can have. Each one is called a
+                <span class="term" data-definition="A variant is one named version of a reusable component — a primary button, a danger button, a small button. Choosing a variant is how you pick a look without inventing a new one.">variant</span>.</p>
+              <p class="tl"><strong>default</strong> — the solid brand-coloured button, slightly dimmer when your mouse is over it.</p>
+              <p class="tl"><strong>destructive</strong> — red, for the buttons that delete things. Long, because it also describes how it looks in
+                <span class="term" data-definition="Dark mode is a second colour scheme with a dark background, which many people prefer at night. Well-built apps define both and switch automatically.">dark mode</span>
+                and when keyboard-focused.</p>
+              <p class="tl"><strong>outline</strong> — a border and no fill. <strong>secondary</strong> — quieter than default. <strong>ghost</strong> — invisible until you hover.</p>
+              <p class="tl"><strong>link</strong> — looks like a link, behaves like a button.</p>
+              <p class="tl">Every button anywhere on the site is one of these six. That is what people mean by a
+                <span class="term" data-definition="A design system is an agreed set of reusable parts and rules — the approved buttons, colours, spacings — so that a product looks consistent without anyone having to police it.">design system</span>,
+                in practice.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="badge-list">
+          <div class="badge-item">
+            <code class="badge-code">variant="destructive"</code>
+            <span class="badge-desc">Every delete button on the site, changed in one place, forever</span>
+          </div>
+          <div class="badge-item">
+            <code class="badge-code">size="sm" | "lg" | "icon"</code>
+            <span class="badge-desc">Three sizes plus the default — so nobody invents a fourth by accident</span>
+          </div>
+        </div>
+      </section>
+
+      <!-- SCREEN 6: One palette + quiz -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">One Palette, One File</h2>
+        <p>Every colour in the app is defined once, in <code>theme.css</code>, and named after the cartoon it came from.</p>
+
+        <div class="translation-block animate-in">
+          <div class="translation-code">
+            <span class="translation-label">CODE</span>
+            <pre><code>
+<span class="code-line">  <span class="code-property">--cl-yellow</span>: <span class="code-function">oklch</span>(<span class="code-number">0.9 0.15 85</span>);</span>
+<span class="code-line">  <span class="code-property">--cl-orange</span>: <span class="code-function">oklch</span>(<span class="code-number">0.8 0.15 60</span>);</span>
+<span class="code-line">  <span class="code-property">--cl-blue</span>: <span class="code-function">oklch</span>(<span class="code-number">0.8 0.08 200</span>);</span>
+<span class="code-line">  <span class="code-property">--cl-pink</span>: <span class="code-function">oklch</span>(<span class="code-number">0.8 0.1 340</span>);</span>
+<span class="code-line">  <span class="code-property">--cl-green</span>: <span class="code-function">oklch</span>(<span class="code-number">0.85 0.15 140</span>);</span>
+<span class="code-line">  <span class="code-property">--cl-red</span>: <span class="code-function">oklch</span>(<span class="code-number">0.7 0.2 25</span>);</span>
+<span class="code-line">  <span class="code-property">--cl-brown</span>: <span class="code-function">oklch</span>(<span class="code-number">0.6 0.1 60</span>);</span>
+            </code></pre>
+          </div>
+          <div class="translation-english">
+            <span class="translation-label">PLAIN ENGLISH</span>
+            <div class="translation-lines">
+              <p class="tl">Seven named colours, each stored in a
+                <span class="term" data-definition="A CSS custom property (also called a CSS variable) is a named colour or size defined once and referred to everywhere else. Change the definition and everything using it changes at once.">CSS variable</span>
+                — a name you define once and use everywhere.</p>
+              <p class="tl">The names are the point: <code>--cl-yellow</code>, not <code>#F5D442</code>. Nothing in this app hardcodes a
+                <span class="term" data-definition="A hex code is the six-character way of writing a colour, like #D94F30. Precise, universal, and completely meaningless to read.">hex code</span>.</p>
+              <p class="tl"><span class="term" data-definition="oklch is a newer way of writing colours as lightness, colourfulness and hue. Unlike hex codes, the numbers mean something a human can reason about — raise the first number and the colour genuinely looks lighter.">oklch</span>
+                is a newer colour notation: lightness, then colourfulness, then hue. Raise the first number and the colour actually looks lighter — which hex codes never let you do.</p>
+              <p class="tl">Dark mode is this exact same list of names, redefined with different values. Nothing else in the app has to know it happened.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="callout callout-info">
+          <div class="callout-icon">🎨</div>
+          <div class="callout-content">
+            <strong class="callout-title">Why &quot;Make the Whole Site More Orange&quot; Is a One-Line Change</strong>
+            <p>Because there is exactly one place a colour is decided, and thirty-seven components that only ever refer to it by name. When you brief an AI assistant on styling, this is the shape to insist on:
+              <span class="term" data-definition="To hardcode a value is to write it directly wherever it is used, instead of defining it once and referring to it. Hardcoded values are the reason a simple change turns into finding and editing 200 files.">hardcoded</span>
+              colours scattered through components are how a five-minute rebrand becomes a two-week one.</p>
+          </div>
+        </div>
+
+        <h2 class="screen-heading" style="margin-top: var(--space-12)">Check Your Understanding</h2>
+        <p>Four scenarios about who has to do the work, and where the work lives.</p>
+
+        <div class="quiz-container" id="quiz-module6">
+
+          <div class="quiz-question-block"
+               data-correct="q1-c"
+               data-explanation-right="Exactly — the headline is a text field in a JSON data file. Anyone who can edit a text file can change it, in both languages, without touching a single component. That is the whole payoff of separating structure from content."
+               data-explanation-wrong="Have another look at where page content lives in this app. It is not written inside the component, and it is not in the database — it is a plain data file, one per language.">
+            <h3 class="quiz-question">The marketing team wants to change the headline on the home page. Do they need a developer?</h3>
+            <div class="quiz-options">
+              <button class="quiz-option" data-value="q1-a" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>Yes — the headline is written inside the hero component</span>
+              </button>
+              <button class="quiz-option" data-value="q1-b" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>Yes — it is a row in the database and needs a query to change</span>
+              </button>
+              <button class="quiz-option" data-value="q1-c" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>No — it is a text field in a JSON data file, one per language</span>
+              </button>
+            </div>
+            <div class="quiz-feedback"></div>
+          </div>
+
+          <div class="quiz-question-block"
+               data-correct="q2-b"
+               data-explanation-right="Exactly — add fr to the locale list, add a name for it in the switcher, and write the JSON files. Not one component gets duplicated, because no component contains any words. Whether the translation is any good is a separate and much harder problem."
+               data-explanation-wrong="Think about what a component actually contains in this app. It asks for keys and receives words. So what would you have to change for a new language, and what could stay completely untouched?">
+            <h3 class="quiz-question">You add a French version. What do you have to create, and what do you <em>not</em> have to touch?</h3>
+            <div class="quiz-options">
+              <button class="quiz-option" data-value="q2-a" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>A French copy of every page component, plus the translation files</span>
+              </button>
+              <button class="quiz-option" data-value="q2-b" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>Add <code>fr</code> to the locale list and add the JSON files — no component is duplicated</span>
+              </button>
+              <button class="quiz-option" data-value="q2-c" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>A whole second deployment of the app on a French domain</span>
+              </button>
+            </div>
+            <div class="quiz-feedback"></div>
+          </div>
+
+          <div class="quiz-question-block"
+               data-correct="q3-a"
+               data-explanation-right="Exactly — they get English. The loader tries the German file, fails, logs a warning for whoever is watching, and hands back English. A visitor seeing a page in the wrong language can still use your product; a visitor seeing a crash cannot."
+               data-explanation-wrong="Look again at the try/catch in the loader. Failing to find a file is treated as a normal, expected event with a planned answer — not as an emergency.">
+            <h3 class="quiz-question">A visitor in Germany arrives and the app has no German. What do they see?</h3>
+            <div class="quiz-options">
+              <button class="quiz-option" data-value="q3-a" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>The site in English — the fallback, with a warning quietly written to the log</span>
+              </button>
+              <button class="quiz-option" data-value="q3-b" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>An error page saying the language is unsupported</span>
+              </button>
+              <button class="quiz-option" data-value="q3-c" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>A blank page with the layout but no text in it</span>
+              </button>
+            </div>
+            <div class="quiz-feedback"></div>
+          </div>
+
+          <div class="scenario-block">
+            <div class="scenario-context">
+              <span class="scenario-label">Scenario</span>
+              <p>You ask an AI assistant to add a new &quot;Danger&quot; button style for a page that deletes account data. It offers to write the styling directly onto the button on that page.</p>
+            </div>
+            <div class="quiz-question-block"
+                 data-correct="q4-b"
+                 data-explanation-right="Exactly — it belongs as a new variant in the one button file. Then every Danger button on the site is identical, someone can change all of them at once later, and nobody has to guess which shade of red is the official one. Styling written onto one page is how design systems quietly rot."
+                 data-explanation-wrong="Think about what happens six months later when there are nine Danger buttons across the app and someone wants to change the red. Where would you want that colour to have been defined?">
+              <h3 class="quiz-question">Where should it go, and why does that matter?</h3>
+              <div class="quiz-options">
+                <button class="quiz-option" data-value="q4-a" onclick="selectOption(this)">
+                  <div class="quiz-option-radio"></div>
+                  <span>Directly on that page — it is only needed once</span>
+                </button>
+                <button class="quiz-option" data-value="q4-b" onclick="selectOption(this)">
+                  <div class="quiz-option-radio"></div>
+                  <span>As a new variant in the one button file, so every Danger button stays identical and can be changed in one place</span>
+                </button>
+                <button class="quiz-option" data-value="q4-c" onclick="selectOption(this)">
+                  <div class="quiz-option-radio"></div>
+                  <span>In the translation files, next to the button&apos;s label</span>
+                </button>
+              </div>
+              <div class="quiz-feedback"></div>
+            </div>
+          </div>
+
+          <button class="quiz-check-btn" onclick="checkQuiz('quiz-module6')">Check Answers</button>
+          <button class="quiz-reset-btn" onclick="resetQuiz('quiz-module6')">Try Again</button>
+        </div>
+
+        <p style="margin-top: var(--space-10)">Six modules of <em>how it works</em>. The last one is <em>what to do when it does not</em> — and how any of this gets from a laptop onto the real internet. That is <strong>When It Breaks</strong>.</p>
+      </section>
+
+    </div>
+  </div>
+</section>
+<section class="module" id="module-7" style="background: var(--color-bg-warm)">
+  <div class="module-content">
+    <header class="module-header animate-in">
+      <span class="module-number">07</span>
+      <h1 class="module-title">When It Breaks</h1>
+      <p class="module-subtitle">Six modules of how it works. Here is the part nobody writes down: what to do at 11pm when a user emails &quot;it&apos;s broken&quot; and you have no idea where to start.</p>
+    </header>
+
+    <div class="module-body">
+
+      <!-- SCREEN 1: The flight recorder -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">Nobody Guesses in Aviation</h2>
+        <p>When an aircraft has a bad day, investigators do not sit in a room theorising. They pull the flight recorder and read what the aircraft was actually doing, second by second, until reality stops matching what everyone assumed.</p>
+
+        <div class="callout callout-accent">
+          <div class="callout-icon">💡</div>
+          <div class="callout-content">
+            <strong class="callout-title">You Do Not Debug by Thinking Harder</strong>
+            <p>You debug by <em>getting more instrument readings</em>. Every hour lost to a bug is usually an hour spent theorising instead of looking. <span class="term" data-definition="Debugging is the work of finding out why software is doing something other than what you expected — and it is mostly investigation, not typing.">Debugging</span> is closer to reading a black box recorder than to having a brilliant idea.</p>
+          </div>
+        </div>
+
+        <p>Here is the shape of the whole thing. You already know the route a request takes: <strong>Browser → Server → outside service → Database → back.</strong> A bug is simply the first point on that route where reality stopped matching expectation.</p>
+
+        <p>Every observation you make cuts the remaining search space roughly in half. Engineers call that a
+          <span class="term" data-definition="A binary search is a way of finding something fast by halving the search space each time — like finding a word in a dictionary by opening the middle, then the middle of the correct half, and so on.">binary search</span>,
+          and it turns an unbounded mystery into about five questions.</p>
+
+        <div class="callout callout-info">
+          <div class="callout-icon">🗣️</div>
+          <div class="callout-content">
+            <strong class="callout-title">Why This Is the Most Valuable Module for You</strong>
+            <p>AI assistants are excellent at fixing a problem you can describe <em>precisely</em>, and terrible at finding one you can only describe as &quot;it doesn&apos;t work&quot;. Vague reports send them into loops of speculative rewrites, each one leaving the codebase slightly worse. One precise sentence — <em>&quot;the POST to /api/generate-cyberpunk returns 200 with code -1 and message &apos;Insufficient credits&apos;, even though the balance shows 40&quot;</em> — usually gets fixed on the first try. This module is about how to write that sentence.</p>
+          </div>
+        </div>
+      </section>
+
+      <!-- SCREEN 2: The five-question ladder -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">The Five-Question Ladder</h2>
+        <p>For any bug, in any app, ask these in this order. The order matters — each question is cheap and rules out everything below it.</p>
+
+        <div class="step-cards">
+          <div class="step-card">
+            <div class="step-num">1</div>
+            <div class="step-body">
+              <strong>Did the request even leave the Browser?</strong>
+              <p>Open <span class="term" data-definition="Dev tools are the inspection panels built into every browser — press F12 or right-click and choose Inspect. They show you the page structure, the errors, and every request the page makes.">dev tools</span> and look at the
+                <span class="term" data-definition="The Network tab in dev tools lists every request the page sent and what came back — address, status, timing, and the full reply. It is the single most useful debugging screen there is.">Network tab</span>.
+                No request at all means the bug is in the click handler, not on the server. You have just eliminated the entire backend.</p>
+            </div>
+          </div>
+          <div class="step-card">
+            <div class="step-num">2</div>
+            <div class="step-body">
+              <strong>Did the Server receive it, and what did it answer?</strong>
+              <p>Read the <span class="term" data-definition="A status code is the three-digit number every web response carries: 200 means fine, 404 means not found, 401 means not signed in, 500 means the server itself broke.">status code</span> and the reply body. This app always answers with the same shape — <code>{ code, message, data }</code>, where <code>code: 0</code> means fine and <code>code: -1</code> means an error with a human-readable message sitting right there.</p>
+            </div>
+          </div>
+          <div class="step-card">
+            <div class="step-num">3</div>
+            <div class="step-body">
+              <strong>Did an outside service refuse?</strong>
+              <p>Gemini quota, Stripe signature, storage credentials. Critically: these appear in the <span class="term" data-definition="A log is the running diary a program writes about what it is doing. Server logs live on the server or in your hosting dashboard, and are invisible from the browser.">server logs</span>, never in the browser. If you have not looked at your logs, you have not looked.</p>
+            </div>
+          </div>
+          <div class="step-card">
+            <div class="step-num">4</div>
+            <div class="step-body">
+              <strong>Is the data actually what you think it is?</strong>
+              <p>Go and look. Is there a credits row for that order number? Is the order status still <code>created</code>? Assumptions about data are where confident people lose whole evenings.</p>
+            </div>
+          </div>
+          <div class="step-card">
+            <div class="step-num">5</div>
+            <div class="step-body">
+              <strong>Is it the environment, not the code?</strong>
+              <p>Works locally, fails in
+                <span class="term" data-definition="Production is the live version real customers use. Development is the copy running on your own laptop. They run the same code with different settings, which is exactly why they behave differently.">production</span>?
+                Suspect
+                <span class="term" data-definition="An environment variable is a setting stored outside your code — on the server — that changes how the app behaves. Missing ones are the single most common cause of works-here-not-there.">environment variables</span>
+                first, every single time. Module 3&apos;s missing GitHub sign-in button was exactly this.</p>
+            </div>
+          </div>
+        </div>
+
+        <p>Watch the ladder run on a real complaint.</p>
+
+        <div class="flow-animation" data-steps='[
+          {"highlight":"flow-actor-7-1","label":"A customer emails: I paid, but I have no credits. Resist the urge to guess. Go and take readings."},
+          {"highlight":"flow-actor-7-1","label":"Question 1: did the request leave the Browser at all? Network tab says yes, and the checkout request looks normal."},
+          {"highlight":"flow-actor-7-2","label":"Question 2: what did the Server answer? Status 200, code 0. The checkout was created successfully. Half the pipeline is now ruled out.","packet":true,"from":"actor-7-1","to":"actor-7-2"},
+          {"highlight":"flow-actor-7-3","label":"Question 3: did an outside service refuse? Stripe shows the payment as succeeded. So the money moved.","packet":true,"from":"actor-7-2","to":"actor-7-3"},
+          {"highlight":"flow-actor-7-4","label":"Question 4: is the data what you think? Look at the order row. Status is still created, not paid. And there is no credits row for that order number.","packet":true,"from":"actor-7-2","to":"actor-7-4"},
+          {"highlight":"flow-actor-7-3","label":"That narrows it to one thing: the webhook. Either it never arrived, or it arrived and failed to verify.","packet":true,"from":"actor-7-3","to":"actor-7-2"},
+          {"highlight":"flow-actor-7-2","label":"Question 5: environment, not code. The webhook address registered with Stripe still points at the old test domain. Nothing was ever broken in the code."}
+        ]'>
+          <div class="flow-actors">
+            <div class="flow-actor" id="flow-actor-7-1">
+              <div class="flow-actor-icon" style="background: var(--color-actor-2)">🌐</div>
+              <span>Browser</span>
+            </div>
+            <div class="flow-actor" id="flow-actor-7-2">
+              <div class="flow-actor-icon" style="background: var(--color-accent)">🖥️</div>
+              <span>Server</span>
+            </div>
+            <div class="flow-actor" id="flow-actor-7-3">
+              <div class="flow-actor-icon" style="background: var(--color-actor-3)">💳</div>
+              <span>Stripe</span>
+            </div>
+            <div class="flow-actor" id="flow-actor-7-4">
+              <div class="flow-actor-icon" style="background: var(--color-actor-4)">🗄️</div>
+              <span>Database</span>
+            </div>
+          </div>
+
+          <div class="flow-packet" id="flow-packet-7"></div>
+          <div class="flow-step-label" id="flow-label-7">Click "Next Step" to begin</div>
+
+          <div class="flow-controls">
+            <button class="btn flow-next-btn">Next Step</button>
+            <button class="btn flow-reset-btn">Restart</button>
+            <span class="flow-progress"></span>
+          </div>
+        </div>
+
+        <p>Notice what never happened in that sequence: nobody changed any code, and nobody had a brilliant idea. Seven observations, one cause.</p>
+      </section>
+
+      <!-- SCREEN 3: Three bugs from this codebase -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">Three Bug Shapes, All From This Codebase</h2>
+        <p>The first one is the most teachable seven lines in the whole project. Read it, and ask yourself what a customer sees when the database is unreachable.</p>
+
+        <div class="bug-challenge">
+          <h3>Which line turns a serious outage into a quiet lie?</h3>
+          <div class="bug-code">
+            <div class="bug-line" data-line="1" onclick="checkBugLine(this, false)"
+                 data-hint="That is just tidying up — a negative balance would be nonsense to show anyone. Keep looking, further down.">
+              <span class="line-num">1</span>
+              <code>if (user_credits.left_credits &lt; 0) {</code>
+            </div>
+            <div class="bug-line" data-line="2" onclick="checkBugLine(this, false)"
+                 data-hint="Same idea — clamping a nonsense value to zero. The problem is what happens when the whole function fails.">
+              <span class="line-num">2</span>
+              <code>&nbsp;&nbsp;user_credits.left_credits = 0;</code>
+            </div>
+            <div class="bug-line" data-line="3" onclick="checkBugLine(this, false)"
+                 data-hint="Marking someone as a paying user if they have any credits left. Reasonable. Look at the very bottom.">
+              <span class="line-num">3</span>
+              <code>if (user_credits.left_credits &gt; 0) { user_credits.is_pro = true; }</code>
+            </div>
+            <div class="bug-line" data-line="4" onclick="checkBugLine(this, false)"
+                 data-hint="This is the happy path — the real answer being handed back. The problem is the other exit from this function.">
+              <span class="line-num">4</span>
+              <code>&nbsp;&nbsp;return user_credits;</code>
+            </div>
+            <div class="bug-line" data-line="5" onclick="checkBugLine(this, false)"
+                 data-hint="Catching the error is not the mistake — you are allowed to catch errors. It is what happens in the next two lines.">
+              <span class="line-num">5</span>
+              <code>} catch (e) {</code>
+            </div>
+            <div class="bug-line" data-line="6" onclick="checkBugLine(this, false)"
+                 data-hint="Writing it to the log is the one good thing here. Now look at what gets handed back to the customer.">
+              <span class="line-num">6</span>
+              <code>&nbsp;&nbsp;console.log("get user credits failed: ", e);</code>
+            </div>
+            <div class="bug-line bug-target" data-line="7" onclick="checkBugLine(this, true)"
+                 data-explanation="This returns the <code>user_credits</code> object created at the top of the function — the one still full of zeros. So when the database is unreachable, a paying customer is not told &quot;something went wrong&quot;. They are told, calmly and confidently, that they have <strong>0 credits</strong> — and they conclude they have been robbed. Support gets angry emails about missing credits while the real problem is a database outage nobody noticed. A catch block that swallows an error turns a loud problem into a quiet lie.">
+              <span class="line-num">7</span>
+              <code>&nbsp;&nbsp;return user_credits;</code>
+            </div>
+          </div>
+          <div class="bug-feedback"></div>
+        </div>
+
+        <div class="translation-block animate-in">
+          <div class="translation-code">
+            <span class="translation-label">CODE</span>
+            <pre><code>
+<span class="code-line">    <span class="code-keyword">if</span> (user_credits.left_credits &lt; <span class="code-number">0</span>) {</span>
+<span class="code-line">      user_credits.left_credits = <span class="code-number">0</span>;</span>
+<span class="code-line">    }</span>
+<span class="code-line">&nbsp;</span>
+<span class="code-line">    <span class="code-keyword">if</span> (user_credits.left_credits &gt; <span class="code-number">0</span>) {</span>
+<span class="code-line">      user_credits.is_pro = <span class="code-keyword">true</span>;</span>
+<span class="code-line">    }</span>
+<span class="code-line">&nbsp;</span>
+<span class="code-line">    <span class="code-keyword">return</span> user_credits;</span>
+<span class="code-line">  } <span class="code-keyword">catch</span> (e) {</span>
+<span class="code-line">    console.<span class="code-function">log</span>(<span class="code-string">"get user credits failed: "</span>, e);</span>
+<span class="code-line">    <span class="code-keyword">return</span> user_credits;</span>
+<span class="code-line">  }</span>
+            </code></pre>
+          </div>
+          <div class="translation-english">
+            <span class="translation-label">WHAT THE USER EXPERIENCES</span>
+            <div class="translation-lines">
+              <p class="tl">Never show a negative balance. Fair enough.</p>
+              <p class="tl">Anyone with credits left counts as a paying user.</p>
+              <p class="tl">Hand back the real, correct balance. This is the normal, everything-is-fine path.</p>
+              <p class="tl">And here is the other exit. <code>catch</code> means &quot;if anything at all went wrong above, come here instead&quot;. A database outage lands here.</p>
+              <p class="tl">Write a note in the log, where no customer will ever see it and, realistically, nor will you.</p>
+              <p class="tl">Then hand back the object created at the very top of the function — the one still full of zeros. <strong>The customer is told they have 0 credits.</strong> Not &quot;we could not check&quot;. Zero. Confidently.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="callout callout-warning">
+          <div class="callout-icon">🤫</div>
+          <div class="callout-content">
+            <strong class="callout-title">Say What Should Happen on Failure</strong>
+            <p>When you ask an AI to &quot;add error handling&quot;, this is very often what you get: a
+              <span class="term" data-definition="A try/catch block says: attempt this, and if anything goes wrong, run that instead. It stops a crash — but it does not decide whether stopping the crash was the right thing to do.">try/catch</span>
+              that swallows the problem and returns a plausible-looking default. Be specific instead: <em>&quot;if this fails, surface the error to the caller — do not return a default that looks like real data.&quot;</em> A crash is honest. A confident wrong answer is not.</p>
+          </div>
+        </div>
+
+        <div class="pattern-cards">
+          <div class="pattern-card" style="border-top: 3px solid var(--color-actor-4)">
+            <div class="pattern-icon" style="background: var(--color-actor-4)">🔌</div>
+            <h4 class="pattern-title">The Environment Gap</h4>
+            <p class="pattern-desc">Works on the laptop, not in production. In this app, whole sign-in providers, the entire storage upload and the choice of payment company are all switched on and off by environment variables. Nearly always configuration, nearly never code.</p>
+          </div>
+          <div class="pattern-card" style="border-top: 3px solid var(--color-actor-3)">
+            <div class="pattern-icon" style="background: var(--color-actor-3)">🏷️</div>
+            <h4 class="pattern-title">The Name That Lies</h4>
+            <p class="pattern-desc">The image endpoint is still called <code>/api/generate-cyberpunk</code>, left over from an earlier version of the product. There are <code>.backup</code> copies of route files sitting in the repo too. Real codebases drift — describe <em>behaviour</em> to an AI, not filenames.</p>
+          </div>
+        </div>
+      </section>
+
+      <!-- SCREEN 4: What to log + the invisible ceiling -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">Writing Your Own Flight Recorder</h2>
+        <p>Before every AI call, this app writes down a block of context. Somebody sat and decided what they would want to know at 3am, and it shows.</p>
+
+        <div class="translation-block animate-in">
+          <div class="translation-code">
+            <span class="translation-label">CODE</span>
+            <pre><code>
+<span class="code-line">    console.<span class="code-function">log</span>(<span class="code-string">"=== Charlie and Lola API Request Details ==="</span>);</span>
+<span class="code-line">    console.<span class="code-function">log</span>(<span class="code-string">"Mode:"</span>, mode);</span>
+<span class="code-line">    console.<span class="code-function">log</span>(<span class="code-string">"Model:"</span>, model);</span>
+<span class="code-line">    console.<span class="code-function">log</span>(<span class="code-string">"Aspect Ratio:"</span>, aspectRatio);</span>
+<span class="code-line">    console.<span class="code-function">log</span>(<span class="code-string">"Output Format:"</span>, outputFormat);</span>
+<span class="code-line">    console.<span class="code-function">log</span>(<span class="code-string">"Style:"</span>, style);</span>
+<span class="code-line">    console.<span class="code-function">log</span>(<span class="code-string">"Custom Prompt:"</span>, customPrompt ? <span class="code-string">"Yes"</span> : <span class="code-string">"No"</span>);</span>
+<span class="code-line">    console.<span class="code-function">log</span>(<span class="code-string">"Images uploaded:"</span>, images.length);</span>
+<span class="code-line">    console.<span class="code-function">log</span>(<span class="code-string">"User Registered:"</span>, isRegisteredUser);</span>
+<span class="code-line">    console.<span class="code-function">log</span>(<span class="code-string">"User UUID:"</span>, userUuid || <span class="code-string">"Guest user"</span>);</span>
+<span class="code-line">    console.<span class="code-function">log</span>(<span class="code-string">"==========================================="</span>);</span>
+            </code></pre>
+          </div>
+          <div class="translation-english">
+            <span class="translation-label">PLAIN ENGLISH</span>
+            <div class="translation-lines">
+              <p class="tl">Draw a line in the log so this block is findable by eye among thousands of others.</p>
+              <p class="tl">Record every setting that shaped this request: which mode, which AI model, what shape, what file format, which style.</p>
+              <p class="tl">Note whether the user typed their own instructions — but <strong>not what they typed</strong>. A deliberate choice: yes or no is enough to
+                <span class="term" data-definition="To reproduce a bug is to make it happen again on purpose. A bug you can reproduce is nearly solved; a bug you cannot is mostly guesswork.">reproduce</span>
+                the problem.</p>
+              <p class="tl">How many images came in, whether the person was signed in, and who they were — or the word &quot;Guest&quot;.</p>
+              <p class="tl">Close the block. Everything needed to recreate this exact request, and nothing that would be embarrassing to leak.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="callout callout-info">
+          <div class="callout-icon">📝</div>
+          <div class="callout-content">
+            <strong class="callout-title">Log the Inputs You Would Need to Reproduce It. Never Log Secrets.</strong>
+            <p>Logs get copied into chat messages, support tickets and screenshots. API keys, passwords, tokens and full card details must never appear in them. &quot;Custom prompt: Yes&quot; is a perfect example of the discipline — enough to debug, not enough to expose anyone.</p>
+          </div>
+        </div>
+
+        <p>And then there are the limits you did not choose and cannot see. This is the entire <code>vercel.json</code> file:</p>
+
+        <div class="translation-block animate-in">
+          <div class="translation-code">
+            <span class="translation-label">CODE</span>
+            <pre><code>
+<span class="code-line">{</span>
+<span class="code-line">  <span class="code-property">"functions"</span>: {</span>
+<span class="code-line">    <span class="code-property">"app/api/**/*"</span>: {</span>
+<span class="code-line">      <span class="code-property">"maxDuration"</span>: <span class="code-number">60</span>,</span>
+<span class="code-line">      <span class="code-property">"memory"</span>: <span class="code-number">1024</span></span>
+<span class="code-line">    }</span>
+<span class="code-line">  }</span>
+<span class="code-line">}</span>
+            </code></pre>
+          </div>
+          <div class="translation-english">
+            <span class="translation-label">PLAIN ENGLISH</span>
+            <div class="translation-lines">
+              <p class="tl">Settings for the bits of code that answer requests.</p>
+              <p class="tl">Apply these to every API address in the app — the stars mean &quot;anything nested under here&quot;.</p>
+              <p class="tl">Hard ceiling: 60 seconds. Take longer and the request is killed mid-flight, whatever it was doing.</p>
+              <p class="tl">And about a gigabyte of
+                <span class="term" data-definition="A memory limit caps how much working space a piece of code may use at once. Exceed it and the code is stopped, usually with an unhelpful error.">working memory</span>.
+                Image generation takes around ten seconds, so there is headroom — but a slow day at Google, or a bigger image, eats into it invisibly.</p>
+            </div>
+          </div>
+        </div>
+
+        <p>Name the class of problem: <strong>limits you did not choose and cannot see.</strong> They are exactly why something works perfectly in testing and fails under load.</p>
+      </section>
+
+      <!-- SCREEN 5: Getting it onto the internet -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">Getting It Onto the Internet</h2>
+        <p>First, the thing that surprises everyone: <strong>the code you write is not the code that runs.</strong> A
+          <span class="term" data-definition="A build is the step that turns the code developers write into the packaged, optimised version that actually runs on a server. Nothing you wrote is deleted — a second, machine-friendly copy is produced.">build</span>
+          step turns TypeScript into JavaScript, pre-renders pages, and
+          <span class="term" data-definition="To bundle is to combine many small code files into a few larger ones so a browser can download them quickly, rather than making hundreds of separate requests.">bundles</span>
+          everything into one folder that contains exactly what is needed to run and nothing else.</p>
+
+        <p>This app can be shipped three different ways, and each trade-off is worth knowing.</p>
+
+        <div class="pattern-cards">
+          <div class="pattern-card" style="border-top: 3px solid var(--color-accent)">
+            <div class="pattern-icon" style="background: var(--color-accent)">▲</div>
+            <h4 class="pattern-title">Vercel</h4>
+            <p class="pattern-desc">The default. Push to
+              <span class="term" data-definition="Git is the system that tracks every change to a codebase and lets people work on it together. Pushing means sending your changes up to the shared copy.">git</span>
+              and it builds and deploys itself. Easiest by a mile — and you are on their terms, including that 60-second ceiling.</p>
+          </div>
+          <div class="pattern-card" style="border-top: 3px solid var(--color-actor-4)">
+            <div class="pattern-icon" style="background: var(--color-actor-4)">☁️</div>
+            <h4 class="pattern-title">Cloudflare Workers</h4>
+            <p class="pattern-desc">Lives on its own
+              <span class="term" data-definition="A branch is a parallel version of a codebase where changes can be made without disturbing the main one. Here, a whole deployment variant lives on its own branch.">branch</span>,
+              runs at the
+              <span class="term" data-definition="The edge means running your code in many small data centres physically close to users, rather than one big one far away. Faster, cheaper, and more restricted in what it can do.">edge</span>.
+              Cheap and fast, more constraints — <code>src/db/index.ts</code> literally has an <code>if (isCloudflareWorker)</code> branch that opens exactly one database connection instead of a pool of ten.</p>
+          </div>
+          <div class="pattern-card" style="border-top: 3px solid var(--color-actor-2)">
+            <div class="pattern-icon" style="background: var(--color-actor-2)">🐳</div>
+            <h4 class="pattern-title">Docker</h4>
+            <p class="pattern-desc">A recipe that builds a self-contained box — a
+              <span class="term" data-definition="A container is a sealed box holding your app and everything it needs to run, so it behaves identically on any machine. Docker is the most common tool for making them.">container</span>
+              — that runs identically anywhere. Most portable, most work.</p>
+          </div>
+        </div>
+
+        <p>The Docker recipe is worth one look, because two lines of it are pure professional habit.</p>
+
+        <div class="translation-block animate-in">
+          <div class="translation-code">
+            <span class="translation-label">CODE</span>
+            <pre><code>
+<span class="code-line"><span class="code-keyword">FROM</span> base <span class="code-keyword">AS</span> runner</span>
+<span class="code-line"><span class="code-keyword">WORKDIR</span> /app</span>
+<span class="code-line">&nbsp;</span>
+<span class="code-line"><span class="code-keyword">RUN</span> addgroup --system --gid <span class="code-number">1001</span> nodejs &amp;&amp; \</span>
+<span class="code-line">    adduser --system --uid <span class="code-number">1001</span> nextjs &amp;&amp; \</span>
+<span class="code-line">    mkdir .next &amp;&amp; \</span>
+<span class="code-line">    chown nextjs:nodejs .next</span>
+<span class="code-line">&nbsp;</span>
+<span class="code-line"><span class="code-keyword">COPY</span> --from=builder /app/public ./public</span>
+<span class="code-line"><span class="code-keyword">COPY</span> --from=builder --chown=nextjs:nodejs /app/.next/standalone ./</span>
+<span class="code-line"><span class="code-keyword">COPY</span> --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static</span>
+<span class="code-line">&nbsp;</span>
+<span class="code-line"><span class="code-keyword">USER</span> nextjs</span>
+            </code></pre>
+          </div>
+          <div class="translation-english">
+            <span class="translation-label">PLAIN ENGLISH</span>
+            <div class="translation-lines">
+              <p class="tl">Start a fresh, clean box for actually running the app. The messy box that did the building is thrown away — this is a
+                <span class="term" data-definition="A multi-stage build uses one temporary container to compile the app and a second clean one to run it, so all the build tools are left behind. The result is a much smaller, safer image.">multi-stage build</span>.</p>
+              <p class="tl">Work in a folder called <code>/app</code>.</p>
+              <p class="tl">Create a plain, unprivileged user called <code>nextjs</code> to run everything, and give it ownership of the folder it needs.</p>
+              <p class="tl">Copy in only the finished output from the build box — not the source code, not the build tools, not the notes.</p>
+              <p class="tl">Then switch to that limited user. If someone ever finds a way in, they arrive as <code>nextjs</code>, not as
+                <span class="term" data-definition="The root user is the all-powerful administrator account on a machine, allowed to do anything at all. Running an app as root means a break-in gets total control.">root</span>
+                — so a break-in cannot take the whole machine. Two lines, an enormous difference.</p>
+            </div>
+          </div>
+        </div>
+
+        <h3 class="screen-heading" style="font-size: var(--text-lg); margin-top: var(--space-10)">The Pre-Flight Checklist</h3>
+        <p>Read it aloud before every launch, on any project. &quot;I&apos;m sure it&apos;s fine&quot; is not a check.</p>
+
+        <div class="icon-rows">
+          <div class="icon-row">
+            <div class="icon-circle" style="background: var(--color-actor-4)">🔑</div>
+            <div>
+              <strong>Environment variables set in production?</strong>
+              <p>Not on your laptop — in production. All of them, including the ones you added last week.</p>
+            </div>
+          </div>
+          <div class="icon-row">
+            <div class="icon-circle" style="background: var(--color-actor-2)">🗄️</div>
+            <div>
+              <strong>Database reachable from production?</strong>
+              <p>Reachable from your laptop is not the same test. Firewall rules and connection limits differ.</p>
+            </div>
+          </div>
+          <div class="icon-row">
+            <div class="icon-circle" style="background: var(--color-actor-3)">📩</div>
+            <div>
+              <strong>Webhook registered and pointing at the live domain?</strong>
+              <p>The single most common launch-day payment bug, and you just watched it happen.</p>
+            </div>
+          </div>
+          <div class="icon-row">
+            <div class="icon-circle" style="background: var(--color-error)">🔐</div>
+            <div>
+              <strong>No secrets in the code?</strong>
+              <p>Search the repo for anything that looks like a password or a key before you make it public.</p>
+            </div>
+          </div>
+          <div class="icon-row">
+            <div class="icon-circle" style="background: var(--color-actor-5)">📈</div>
+            <div>
+              <strong>External quotas high enough for launch day?</strong>
+              <p>Free-tier AI limits do not survive a good day on social media.</p>
+            </div>
+          </div>
+          <div class="icon-row">
+            <div class="icon-circle" style="background: var(--color-accent)">🔦</div>
+            <div>
+              <strong>Can you see the logs?</strong>
+              <p>Find out where they are <em>before</em> you need them, not at 11pm with users waiting.</p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- SCREEN 6: The whole picture -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">The Whole Picture</h2>
+        <p>Seven modules in one diagram. Click anything to see what it does and which module covered it.</p>
+
+        <div class="arch-diagram">
+          <div class="arch-zone arch-zone-browser">
+            <h4 class="arch-zone-label">In the Browser — Modules 2 &amp; 6</h4>
+            <div class="arch-component" data-desc="components/ui/ — 37 generic parts: buttons, cards, dialogs, tabs. Copied into the project rather than installed, so any of them can be edited. Module 6.">
+              <div class="arch-icon">🧱</div>
+              <span>ui/ parts</span>
+            </div>
+            <div class="arch-component" data-desc="components/blocks/ — whole page sections assembled from the generic parts: hero, pricing, faq, footer, showcase. Each one filled with text from the translation data files. Module 6.">
+              <div class="arch-icon">🏗️</div>
+              <span>blocks/</span>
+            </div>
+            <div class="arch-component" data-desc="Client components — the interactive pieces that run in your browser: the upload box, the generate button, the language switcher. They can respond to clicks, but they can never be trusted about who you are. Module 2.">
+              <div class="arch-icon">🖱️</div>
+              <span>client components</span>
+            </div>
+          </div>
+
+          <div class="arch-zone">
+            <h4 class="arch-zone-label">On the Server — Modules 1, 2, 3 &amp; 6</h4>
+            <div class="arch-component" data-desc="middleware.ts — the doorman. Runs before every single page request, reads the language out of the address, and routes accordingly. Twelve lines. Module 6.">
+              <div class="arch-icon">🚪</div>
+              <span>Middleware</span>
+            </div>
+            <div class="arch-component" data-desc="Pages and API routes. A page returns HTML for a human; an API route returns data for a program. /api/generate-cyberpunk is the one that makes the cartoons — and it is still named after a previous version of the product. Modules 1 and 2.">
+              <div class="arch-icon">🛣️</div>
+              <span>Routes</span>
+            </div>
+            <div class="arch-component" data-desc="Services — the business rules. Should this person be allowed to do this? What does it cost? updateOrder and decreaseCredits live here. This is where the actual product decisions are written down. Modules 2 and 4.">
+              <div class="arch-icon">⚖️</div>
+              <span>Services</span>
+            </div>
+            <div class="arch-component" data-desc="Models — the only code allowed to talk to the database. Every insert, every query. Keeping this in one layer is why you can change your database without touching your business rules. Module 2.">
+              <div class="arch-icon">📇</div>
+              <span>Models</span>
+            </div>
+            <div class="arch-component" data-desc="Auth — NextAuth, getUserUuid(), the signed session cookie. Identity always comes from the verified session on the server, never from anything the browser typed into a request. Module 3.">
+              <div class="arch-icon">🎫</div>
+              <span>Auth</span>
+            </div>
+          </div>
+
+          <div class="arch-zone arch-zone-external">
+            <h4 class="arch-zone-label">Rented From Other People — Modules 4 &amp; 5</h4>
+            <div class="arch-component" data-desc="PostgreSQL, hosted by Supabase. Eight tables: users, orders, credits, apikeys, posts, categories, affiliates, feedbacks. Described in TypeScript, changed through numbered migration files. And, in this app, deleted. Module 5.">
+              <div class="arch-icon">🗄️</div>
+              <span>Database</span>
+            </div>
+            <div class="arch-component" data-desc="Stripe — takes the money, then calls your server back with a signed webhook to confirm it. The redirect back to your site proves nothing; the webhook is the fact. Module 4.">
+              <div class="arch-icon">💳</div>
+              <span>Stripe</span>
+            </div>
+            <div class="arch-component" data-desc="Google Gemini — makes the cartoon. Reached through a pool of up to six API keys handed out in rotation, with any key that hits its quota benched until tomorrow. Module 5.">
+              <div class="arch-icon">✨</div>
+              <span>Gemini</span>
+            </div>
+            <div class="arch-component" data-desc="Cloudflare R2 — object storage for finished images. If it is not configured, the app falls back to embedding the entire image in the reply as text: worse, but working. Module 5.">
+              <div class="arch-icon">🪣</div>
+              <span>Storage</span>
+            </div>
+          </div>
+
+          <div class="arch-description">Click any piece to see what it does.</div>
+        </div>
+
+        <p>Every arrow in that picture runs the same way: the Browser asks, the Server decides, the outside world answers, the Database remembers.</p>
+      </section>
+
+      <!-- SCREEN 7: The vocabulary -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">The Vocabulary You Now Own</h2>
+        <p>This was the real payoff all along. These are not trivia — they are the words that let you tell an AI assistant precisely what you want, instead of describing it and hoping.</p>
+
+        <div class="badge-list">
+          <div class="badge-item">
+            <code class="badge-code">request / response</code>
+            <span class="badge-desc">One question, one answer. Everything on the web is this.</span>
+          </div>
+          <div class="badge-item">
+            <code class="badge-code">endpoint</code>
+            <span class="badge-desc">One specific address that answers one specific kind of question</span>
+          </div>
+          <div class="badge-item">
+            <code class="badge-code">session / token</code>
+            <span class="badge-desc">The signed wristband that says who you are, checked on every request</span>
+          </div>
+          <div class="badge-item">
+            <code class="badge-code">webhook</code>
+            <span class="badge-desc">Another service calling <em>you</em>, unprompted, when something really happened</span>
+          </div>
+          <div class="badge-item">
+            <code class="badge-code">idempotent</code>
+            <span class="badge-desc">Safe to run twice. Say this word when asking for payment code.</span>
+          </div>
+          <div class="badge-item">
+            <code class="badge-code">append-only ledger</code>
+            <span class="badge-desc">Never overwrite a balance — add a line and sum them</span>
+          </div>
+          <div class="badge-item">
+            <code class="badge-code">schema / migration</code>
+            <span class="badge-desc">The blueprint, and the numbered reviewable permit that changes it</span>
+          </div>
+          <div class="badge-item">
+            <code class="badge-code">connection pool</code>
+            <span class="badge-desc">A few open lines held ready and shared, not a new call every time</span>
+          </div>
+          <div class="badge-item">
+            <code class="badge-code">rate limit / quota</code>
+            <span class="badge-desc">The cap on how much of someone else&apos;s service you may use</span>
+          </div>
+          <div class="badge-item">
+            <code class="badge-code">environment variable</code>
+            <span class="badge-desc">Settings outside the code. The first suspect in every works-here-not-there bug.</span>
+          </div>
+          <div class="badge-item">
+            <code class="badge-code">graceful degradation</code>
+            <span class="badge-desc">When part of it fails, the rest keeps working in a reduced way</span>
+          </div>
+          <div class="badge-item">
+            <code class="badge-code">locale / i18n</code>
+            <span class="badge-desc">Which language and region a visitor gets, and the machinery that serves it</span>
+          </div>
+          <div class="badge-item">
+            <code class="badge-code">component / variant</code>
+            <span class="badge-desc">A reusable interface piece, and its named looks</span>
+          </div>
+          <div class="badge-item">
+            <code class="badge-code">middleware</code>
+            <span class="badge-desc">A checkpoint every request passes through before reaching a page</span>
+          </div>
+          <div class="badge-item">
+            <code class="badge-code">server vs client</code>
+            <span class="badge-desc">Runs privately on their computer vs runs visibly on yours. Trust accordingly.</span>
+          </div>
+        </div>
+      </section>
+
+      <!-- SCREEN 8: Final quiz + send-off -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">One Last Time</h2>
+        <p>Five scenarios drawing on the whole course. Take your time with the fourth one.</p>
+
+        <div class="quiz-container" id="quiz-module7">
+
+          <div class="quiz-question-block"
+               data-correct="q1-b"
+               data-explanation-right="Exactly — and in that order, because each step is cheap and rules out everything after it. Did Stripe send the webhook? Did it verify against the signing secret? Is the order status still created rather than paid? Is there a credits row carrying that order number? The first place reality stops matching expectation is your bug."
+               data-explanation-wrong="Refunding first hides the evidence, and rewriting the credits code assumes you already know where the fault is. Start by taking readings along the pipeline you now know by heart: Stripe, the webhook, the order row, the credits row.">
+            <h3 class="quiz-question">A customer says they paid but have no credits. What do you check, and in what order?</h3>
+            <div class="quiz-options">
+              <button class="quiz-option" data-value="q1-a" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>Refund them immediately, then investigate when there is time</span>
+              </button>
+              <button class="quiz-option" data-value="q1-b" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>Did Stripe send the webhook → did it verify → is the order marked paid → is there a credits row for that order number</span>
+              </button>
+              <button class="quiz-option" data-value="q1-c" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>Ask an AI to rewrite the credits service to be more reliable</span>
+              </button>
+            </div>
+            <div class="quiz-feedback"></div>
+          </div>
+
+          <div class="quiz-question-block"
+               data-correct="q2-c"
+               data-explanation-right="Exactly. Every sign-in provider in this app is wrapped in a check on its environment variables — no variables, no button, no error message. Same code, different settings, different behaviour. Suspect configuration before code, every single time."
+               data-explanation-wrong="The code is identical in both places — you did not write a different version for production. So what else differs between your laptop and the live server? Almost always the settings that live outside the code.">
+            <h3 class="quiz-question">Everything works locally. In production, &quot;Sign in with GitHub&quot; does nothing at all. Best first guess?</h3>
+            <div class="quiz-options">
+              <button class="quiz-option" data-value="q2-a" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>A bug in the sign-in component</span>
+              </button>
+              <button class="quiz-option" data-value="q2-b" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>GitHub is down</span>
+              </button>
+              <button class="quiz-option" data-value="q2-c" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>Missing environment variables in production, so the provider was never added to the list</span>
+              </button>
+            </div>
+            <div class="quiz-feedback"></div>
+          </div>
+
+          <div class="quiz-question-block"
+               data-correct="q3-a"
+               data-explanation-right="Exactly — specify what should happen on failure. Otherwise you get a catch block that returns a plausible default, and a database outage becomes a customer being calmly told they have zero credits. A crash you can see beats a wrong answer you cannot."
+               data-explanation-wrong="Adding a try/catch is easy; deciding what the failure should look like to a human being is the actual work. If you do not say, you will get a default value that is indistinguishable from real data.">
+            <h3 class="quiz-question">An AI assistant offers to &quot;add error handling&quot; to a function that fetches a balance. What should you specify?</h3>
+            <div class="quiz-options">
+              <button class="quiz-option" data-value="q3-a" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>What should happen on failure — surface the error, do not return a default that looks like real data</span>
+              </button>
+              <button class="quiz-option" data-value="q3-b" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>That it should catch every possible error so the app never crashes</span>
+              </button>
+              <button class="quiz-option" data-value="q3-c" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>Which line number to put the try block on</span>
+              </button>
+            </div>
+            <div class="quiz-feedback"></div>
+          </div>
+
+          <div class="scenario-block">
+            <div class="scenario-context">
+              <span class="scenario-label">Capstone Scenario</span>
+              <p>You want users to be able to save their favourite generated images. You are about to brief an AI assistant on it.</p>
+            </div>
+            <div class="quiz-question-block"
+                 data-correct="q4-c"
+                 data-explanation-right="Exactly — and being able to list those layers unprompted is the whole point of this course. A new favourites table plus a migration (Module 5). A model, because only models talk to the database, and a service for the rules about who may favourite what (Module 2). An API route for the browser to call (Modules 1 and 2), which starts by calling getUserUuid() so identity comes from the session and never from the request (Module 3). A component built from the existing ui/ parts (Module 6). And new strings in both en.json and zh.json, because the app is bilingual (Module 6). Brief an AI with that list and you will get something worth keeping."
+                 data-explanation-wrong="Think about the route a request takes through this app, and everything it touches on the way. A single component cannot store anything, and a single table cannot show anything. Trace the whole path — and do not forget that this app speaks two languages.">
+              <h3 class="quiz-question">Which layers would you expect to change?</h3>
+              <div class="quiz-options">
+                <button class="quiz-option" data-value="q4-a" onclick="selectOption(this)">
+                  <div class="quiz-option-radio"></div>
+                  <span>Just a new component with a heart icon on it</span>
+                </button>
+                <button class="quiz-option" data-value="q4-b" onclick="selectOption(this)">
+                  <div class="quiz-option-radio"></div>
+                  <span>A new database table, and nothing else</span>
+                </button>
+                <button class="quiz-option" data-value="q4-c" onclick="selectOption(this)">
+                  <div class="quiz-option-radio"></div>
+                  <span>A table plus a migration, a model, a service, an API route that checks the session, a component — and new strings in both languages</span>
+                </button>
+              </div>
+              <div class="quiz-feedback"></div>
+            </div>
+          </div>
+
+          <div class="quiz-question-block"
+               data-correct="q5-b"
+               data-explanation-right="Exactly — the two invisible ceilings from this module. The 60-second function limit in vercel.json kills any request that runs long, and an exhausted Gemini key pool turns into queueing and retries that push requests towards that limit. Under load they feed each other, which is why a traffic spike breaks things that were fine in testing."
+               data-explanation-wrong="Think about what only bites when there is a lot of traffic: a hard ceiling on how long one request may take, and a daily allowance being consumed much faster than usual. Both of those are in this app right now.">
+            <h3 class="quiz-question">The generation feature starts timing out, but only during a traffic spike. Name two suspects you now know about.</h3>
+            <div class="quiz-options">
+              <button class="quiz-option" data-value="q5-a" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>The translation files and the design system</span>
+              </button>
+              <button class="quiz-option" data-value="q5-b" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>The 60-second function limit, and every key in the Gemini pool being benched on quota</span>
+              </button>
+              <button class="quiz-option" data-value="q5-c" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>The webhook signature and the credits ledger</span>
+              </button>
+            </div>
+            <div class="quiz-feedback"></div>
+          </div>
+
+          <button class="quiz-check-btn" onclick="checkQuiz('quiz-module7')">Check Answers</button>
+          <button class="quiz-reset-btn" onclick="resetQuiz('quiz-module7')">Try Again</button>
+        </div>
+
+        <div class="callout callout-accent" style="margin-top: var(--space-12)">
+          <div class="callout-icon">🎈</div>
+          <div class="callout-content">
+            <strong class="callout-title">You Just Read a Real Production Codebase, End to End</strong>
+            <p>Not a tutorial project — a live app with real customers, real money moving through it, a hardcoded password, a deleted database, and an endpoint named after a product that no longer exists. That is what all of them look like, including the ones built by teams of twenty.</p>
+          </div>
+        </div>
+
+        <p>You do not need to write any of this from scratch. You need to read it, recognise the shapes, and know the words — and you now do. The next time an AI assistant hands you something that smells off, you will be able to say exactly why.</p>
+
+        <p style="margin-top: var(--space-8)"><strong>Go and build something. And when it breaks, you already know which question to ask first.</strong></p>
+      </section>
+
+    </div>
+  </div>
+</section>
+  </main>
+
+</body>
+</html>

--- a/courses/general-course/main.js
+++ b/courses/general-course/main.js
@@ -1,0 +1,498 @@
+/**
+ * CODEBASE-TO-COURSE — COMPLETE JS ENGINE
+ * Copy this file verbatim into the course output directory.
+ * Never regenerate it. It handles all interactivity generically.
+ *
+ * Engines included:
+ *  - Navigation & progress bar
+ *  - Scroll-triggered reveal animations
+ *  - Keyboard navigation
+ *  - Glossary tooltips
+ *  - Quiz (multiple-choice & scenario)
+ *  - Drag-and-drop matching
+ *  - Group chat animation
+ *  - Data flow / message flow animation
+ *  - Architecture diagram
+ *  - "Spot the bug" challenge
+ *  - Layer toggle
+ */
+(function () {
+  'use strict';
+
+  /* ── HELPERS ──────────────────────────────────────────────── */
+  function $(sel, ctx) { return (ctx || document).querySelector(sel); }
+  function $$(sel, ctx) { return Array.from((ctx || document).querySelectorAll(sel)); }
+
+  /* ── NAVIGATION & PROGRESS BAR ────────────────────────────── */
+  const progressBar = $('#progress-bar');
+  const navDots     = $$('.nav-dot');
+  const modules     = $$('.module');
+
+  function updateProgress() {
+    if (!progressBar) return;
+    const scrollTop    = window.scrollY;
+    const scrollHeight = document.documentElement.scrollHeight - window.innerHeight;
+    const pct          = scrollHeight > 0 ? (scrollTop / scrollHeight) * 100 : 0;
+    progressBar.style.width = pct + '%';
+    progressBar.setAttribute('aria-valuenow', Math.round(pct));
+    updateNavDots();
+  }
+
+  function updateNavDots() {
+    const scrollMid = window.scrollY + window.innerHeight / 2;
+    modules.forEach((mod, i) => {
+      const dot = navDots[i];
+      if (!dot) return;
+      const top    = mod.offsetTop;
+      const bottom = top + mod.offsetHeight;
+      if (scrollMid >= top && scrollMid < bottom) {
+        dot.classList.add('active');
+        dot.classList.remove('visited');
+      } else if (window.scrollY + window.innerHeight > top) {
+        dot.classList.remove('active');
+        dot.classList.add('visited');
+      } else {
+        dot.classList.remove('active', 'visited');
+      }
+    });
+  }
+
+  window.addEventListener('scroll', () => requestAnimationFrame(updateProgress), { passive: true });
+  updateProgress();
+
+  // Nav dot click → scroll to module
+  navDots.forEach(dot => {
+    dot.addEventListener('click', () => {
+      const target = $('#' + dot.dataset.target);
+      if (target) target.scrollIntoView({ behavior: 'smooth' });
+    });
+  });
+
+  /* ── KEYBOARD NAVIGATION ───────────────────────────────────── */
+  function currentModuleIndex() {
+    const scrollMid = window.scrollY + window.innerHeight / 2;
+    for (let i = 0; i < modules.length; i++) {
+      const top    = modules[i].offsetTop;
+      const bottom = top + modules[i].offsetHeight;
+      if (scrollMid >= top && scrollMid < bottom) return i;
+    }
+    return 0;
+  }
+
+  document.addEventListener('keydown', e => {
+    if (['INPUT', 'TEXTAREA', 'SELECT'].includes(e.target.tagName)) return;
+    if (e.key === 'ArrowDown' || e.key === 'ArrowRight') {
+      const next = modules[currentModuleIndex() + 1];
+      if (next) { next.scrollIntoView({ behavior: 'smooth' }); e.preventDefault(); }
+    }
+    if (e.key === 'ArrowUp' || e.key === 'ArrowLeft') {
+      const prev = modules[currentModuleIndex() - 1];
+      if (prev) { prev.scrollIntoView({ behavior: 'smooth' }); e.preventDefault(); }
+    }
+  });
+
+  /* ── SCROLL-TRIGGERED REVEAL ───────────────────────────────── */
+  const revealObserver = new IntersectionObserver(entries => {
+    entries.forEach(entry => {
+      if (entry.isIntersecting) {
+        entry.target.classList.add('visible');
+        revealObserver.unobserve(entry.target);
+      }
+    });
+  }, { rootMargin: '0px 0px -8% 0px', threshold: 0.08 });
+
+  $$('.animate-in').forEach(el => revealObserver.observe(el));
+
+  // Stagger children
+  $$('.stagger-children').forEach(parent => {
+    Array.from(parent.children).forEach((child, i) => {
+      child.style.setProperty('--stagger-index', i);
+    });
+  });
+
+  /* ── GLOSSARY TOOLTIPS ─────────────────────────────────────── */
+  let activeTooltip = null;
+
+  function positionTooltip(term, tip) {
+    const rect     = term.getBoundingClientRect();
+    const tipWidth = Math.min(320, Math.max(200, window.innerWidth * 0.8));
+    let left = rect.left + rect.width / 2 - tipWidth / 2;
+    left = Math.max(8, Math.min(left, window.innerWidth - tipWidth - 8));
+    tip.style.left  = left + 'px';
+    tip.style.width = tipWidth + 'px';
+    document.body.appendChild(tip);
+    const tipHeight = tip.offsetHeight;
+    if (rect.top - tipHeight - 12 < 0) {
+      tip.style.top = (rect.bottom + 8) + 'px';
+      tip.classList.add('flip');
+    } else {
+      tip.style.top = (rect.top - tipHeight - 8) + 'px';
+      tip.classList.remove('flip');
+    }
+  }
+
+  function showTooltip(term, tip) {
+    if (activeTooltip && activeTooltip !== tip) {
+      activeTooltip.classList.remove('visible');
+      activeTooltip.remove();
+    }
+    positionTooltip(term, tip);
+    requestAnimationFrame(() => tip.classList.add('visible'));
+    activeTooltip = tip;
+  }
+
+  function hideTooltip(tip) {
+    tip.classList.remove('visible');
+    setTimeout(() => { if (!tip.classList.contains('visible')) tip.remove(); }, 150);
+    if (activeTooltip === tip) activeTooltip = null;
+  }
+
+  $$('.term').forEach(term => {
+    const tip = document.createElement('span');
+    tip.className = 'term-tooltip';
+    tip.textContent = term.dataset.definition;
+
+    term.addEventListener('mouseenter', () => showTooltip(term, tip));
+    term.addEventListener('mouseleave', () => hideTooltip(tip));
+    term.addEventListener('click', e => {
+      e.stopPropagation();
+      tip.classList.contains('visible') ? hideTooltip(tip) : showTooltip(term, tip);
+    });
+  });
+
+  document.addEventListener('click', () => {
+    if (activeTooltip) { activeTooltip.classList.remove('visible'); activeTooltip.remove(); activeTooltip = null; }
+  });
+
+  /* ── QUIZ ENGINE ───────────────────────────────────────────── */
+  window.selectOption = function (btn) {
+    const block = btn.closest('.quiz-question-block');
+    $$('.quiz-option', block).forEach(o => o.classList.remove('selected'));
+    btn.classList.add('selected');
+  };
+
+  window.checkQuiz = function (containerId) {
+    const container = $('#' + containerId);
+    if (!container) return;
+    $$('.quiz-question-block', container).forEach(q => {
+      const selected  = $('.quiz-option.selected', q);
+      const feedback  = $('.quiz-feedback', q);
+      const correct   = q.dataset.correct;
+      const rightExp  = q.dataset.explanationRight  || '';
+      const wrongExp  = q.dataset.explanationWrong  || '';
+
+      if (!selected) {
+        feedback.textContent = 'Pick an answer first!';
+        feedback.className = 'quiz-feedback show warning';
+        return;
+      }
+      $$('.quiz-option', q).forEach(o => o.disabled = true);
+
+      if (selected.dataset.value === correct) {
+        selected.classList.add('correct');
+        feedback.innerHTML = '<strong>Exactly!</strong> ' + rightExp;
+        feedback.className = 'quiz-feedback show success';
+      } else {
+        selected.classList.add('incorrect');
+        const correctBtn = $(`.quiz-option[data-value="${correct}"]`, q);
+        if (correctBtn) correctBtn.classList.add('correct');
+        feedback.innerHTML = '<strong>Not quite.</strong> ' + wrongExp;
+        feedback.className = 'quiz-feedback show error';
+      }
+    });
+  };
+
+  window.resetQuiz = function (containerId) {
+    const container = $('#' + containerId);
+    if (!container) return;
+    $$('.quiz-option', container).forEach(o => {
+      o.classList.remove('selected', 'correct', 'incorrect');
+      o.disabled = false;
+    });
+    $$('.quiz-feedback', container).forEach(f => { f.className = 'quiz-feedback'; f.textContent = ''; });
+  };
+
+  /* ── DRAG-AND-DROP ENGINE ──────────────────────────────────── */
+  function initDnD(containerEl) {
+    if (!containerEl) return;
+    const chips = $$('.dnd-chip', containerEl);
+    const zones = $$('.dnd-zone', containerEl);
+
+    // Mouse (HTML5 Drag API)
+    chips.forEach(chip => {
+      chip.addEventListener('dragstart', e => {
+        e.dataTransfer.setData('text/plain', chip.dataset.answer);
+        chip.classList.add('dragging');
+      });
+      chip.addEventListener('dragend', () => chip.classList.remove('dragging'));
+    });
+
+    zones.forEach(zone => {
+      const target = $('.dnd-zone-target', zone);
+      if (!target) return;
+      target.addEventListener('dragover',  e => { e.preventDefault(); target.classList.add('drag-over'); });
+      target.addEventListener('dragleave', ()  => target.classList.remove('drag-over'));
+      target.addEventListener('drop', e => {
+        e.preventDefault();
+        target.classList.remove('drag-over');
+        const answer = e.dataTransfer.getData('text/plain');
+        const chip   = $(`.dnd-chip[data-answer="${answer}"]`, containerEl);
+        if (!chip) return;
+        target.textContent    = chip.textContent;
+        target.dataset.placed = answer;
+        chip.classList.add('placed');
+      });
+    });
+
+    // Touch
+    chips.forEach(chip => {
+      chip.addEventListener('touchstart', e => {
+        e.preventDefault();
+        const touch = e.touches[0];
+        const ghost = chip.cloneNode(true);
+        ghost.classList.add('touch-ghost');
+        ghost.style.cssText = `position:fixed;z-index:9999;pointer-events:none;left:${touch.clientX - 40}px;top:${touch.clientY - 20}px;`;
+        document.body.appendChild(ghost);
+        chip._ghost  = ghost;
+        chip._answer = chip.dataset.answer;
+      }, { passive: false });
+
+      chip.addEventListener('touchmove', e => {
+        e.preventDefault();
+        const touch = e.touches[0];
+        if (chip._ghost) {
+          chip._ghost.style.left = (touch.clientX - 40) + 'px';
+          chip._ghost.style.top  = (touch.clientY - 20) + 'px';
+        }
+        zones.forEach(z => { const t = $('.dnd-zone-target', z); if (t) t.classList.remove('drag-over'); });
+        const el = document.elementFromPoint(touch.clientX, touch.clientY);
+        const zt = el && el.closest('.dnd-zone-target');
+        if (zt) zt.classList.add('drag-over');
+      }, { passive: false });
+
+      chip.addEventListener('touchend', e => {
+        if (chip._ghost) { chip._ghost.remove(); chip._ghost = null; }
+        const touch = e.changedTouches[0];
+        const el    = document.elementFromPoint(touch.clientX, touch.clientY);
+        const zt    = el && el.closest('.dnd-zone-target');
+        if (zt) {
+          zt.textContent    = chip.textContent;
+          zt.dataset.placed = chip._answer;
+          chip.classList.add('placed');
+        }
+        zones.forEach(z => { const t = $('.dnd-zone-target', z); if (t) t.classList.remove('drag-over'); });
+      });
+    });
+  }
+
+  window.checkDnD = function (containerId) {
+    const container = $('#' + containerId);
+    if (!container) return;
+    $$('.dnd-zone', container).forEach(zone => {
+      const target  = $('.dnd-zone-target', zone);
+      if (!target || !target.dataset.placed) return;
+      if (target.dataset.placed === zone.dataset.correct) {
+        target.classList.add('correct-placed');
+      } else {
+        target.classList.add('incorrect-placed');
+      }
+    });
+  };
+
+  window.resetDnD = function (containerId) {
+    const container = $('#' + containerId);
+    if (!container) return;
+    $$('.dnd-zone-target', container).forEach(t => {
+      t.textContent = 'Drop here';
+      delete t.dataset.placed;
+      t.classList.remove('correct-placed', 'incorrect-placed');
+    });
+    $$('.dnd-chip', container).forEach(c => c.classList.remove('placed', 'dragging'));
+  };
+
+  // Auto-init all dnd containers
+  $$('.dnd-container').forEach(el => initDnD(el));
+
+  /* ── GROUP CHAT ENGINE ─────────────────────────────────────── */
+  function initChat(containerEl) {
+    if (!containerEl) return;
+    const messages    = $$('.chat-message', containerEl);
+    const typingEl    = $('.chat-typing', containerEl);
+    const typingAvEl  = $('#' + containerEl.id + '-typing-avatar') || $('.chat-avatar', typingEl);
+    const progressEl  = $('.chat-progress', containerEl);
+    let index = 0;
+
+    // Build actor map from messages
+    const actors = {};
+    messages.forEach(msg => {
+      const sender = msg.dataset.sender;
+      const avatar = $('.chat-avatar', msg);
+      if (avatar && !actors[sender]) {
+        actors[sender] = { initial: avatar.textContent.trim(), style: avatar.style.background };
+      }
+    });
+
+    function updateProgress() {
+      if (progressEl) progressEl.textContent = index + ' / ' + messages.length + ' messages';
+    }
+
+    function showNext() {
+      if (index >= messages.length) return;
+      const msg    = messages[index];
+      const sender = msg.dataset.sender;
+
+      if (typingEl && actors[sender]) {
+        if (typingAvEl) {
+          typingAvEl.textContent       = actors[sender].initial;
+          typingAvEl.style.background  = actors[sender].style;
+        }
+        typingEl.style.display = 'flex';
+      }
+
+      setTimeout(() => {
+        if (typingEl) typingEl.style.display = 'none';
+        msg.style.display = 'flex';
+        msg.style.animation = 'fadeSlideUp 0.3s var(--ease-out)';
+        index++;
+        updateProgress();
+      }, 800);
+    }
+
+    function showAll() {
+      const iv = setInterval(() => {
+        if (index >= messages.length) { clearInterval(iv); return; }
+        showNext();
+      }, 1200);
+    }
+
+    function reset() {
+      index = 0;
+      messages.forEach(m => { m.style.display = 'none'; m.style.animation = ''; });
+      if (typingEl) typingEl.style.display = 'none';
+      updateProgress();
+    }
+
+    // Bind controls
+    const nextBtn  = $('.chat-next-btn',  containerEl);
+    const allBtn   = $('.chat-all-btn',   containerEl);
+    const resetBtn = $('.chat-reset-btn', containerEl);
+    if (nextBtn)  nextBtn.addEventListener('click',  showNext);
+    if (allBtn)   allBtn.addEventListener('click',   showAll);
+    if (resetBtn) resetBtn.addEventListener('click', reset);
+
+    updateProgress();
+  }
+
+  $$('.chat-window').forEach(el => initChat(el));
+
+  /* ── FLOW ANIMATION ENGINE ─────────────────────────────────── */
+  function initFlow(containerEl) {
+    if (!containerEl) return;
+    const stepsData  = JSON.parse(containerEl.dataset.steps || '[]');
+    const labelEl    = $('.flow-step-label', containerEl);
+    const progressEl = $('.flow-progress',   containerEl);
+    const packet     = $('.flow-packet',     containerEl);
+    let step = 0;
+
+    function updateProgress() {
+      if (progressEl) progressEl.textContent = 'Step ' + step + ' / ' + stepsData.length;
+    }
+
+    function animatePacket(fromId, toId) {
+      if (!packet) return;
+      const fromEl = $('#' + fromId);
+      const toEl   = $('#' + toId);
+      if (!fromEl || !toEl) return;
+      const fromR = fromEl.getBoundingClientRect();
+      const toR   = toEl.getBoundingClientRect();
+      const contR = containerEl.getBoundingClientRect();
+      const fx = fromR.left + fromR.width / 2  - contR.left;
+      const fy = fromR.top  + fromR.height / 2 - contR.top;
+      const tx = toR.left   + toR.width / 2    - contR.left;
+      const ty = toR.top    + toR.height / 2   - contR.top;
+      packet.style.setProperty('--packet-from-x', fx + 'px');
+      packet.style.setProperty('--packet-from-y', fy + 'px');
+      packet.style.setProperty('--packet-to-x',   tx + 'px');
+      packet.style.setProperty('--packet-to-y',   ty + 'px');
+      packet.style.display    = 'block';
+      packet.style.animation  = 'none';
+      packet.offsetHeight; // reflow
+      packet.style.animation  = 'packetMove 0.8s var(--ease-in-out) forwards';
+      setTimeout(() => { packet.style.display = 'none'; }, 850);
+    }
+
+    function next() {
+      if (step >= stepsData.length) return;
+      const s = stepsData[step];
+      $$('.flow-actor', containerEl).forEach(a => a.classList.remove('active'));
+      if (s.highlight) {
+        const hEl = $('#' + s.highlight, containerEl) || $('#flow-' + s.highlight);
+        if (hEl) hEl.classList.add('active');
+      }
+      if (s.packet && s.from && s.to) animatePacket('flow-' + s.from, 'flow-' + s.to);
+      if (labelEl) labelEl.textContent = s.label || '';
+      step++;
+      updateProgress();
+    }
+
+    function reset() {
+      step = 0;
+      $$('.flow-actor', containerEl).forEach(a => a.classList.remove('active'));
+      if (labelEl) labelEl.textContent = 'Click "Next Step" to begin';
+      if (packet)  packet.style.display = 'none';
+      updateProgress();
+    }
+
+    const nextBtn  = $('.flow-next-btn',  containerEl);
+    const resetBtn = $('.flow-reset-btn', containerEl);
+    if (nextBtn)  nextBtn.addEventListener('click',  next);
+    if (resetBtn) resetBtn.addEventListener('click', reset);
+
+    updateProgress();
+  }
+
+  $$('.flow-animation').forEach(el => initFlow(el));
+
+  /* ── ARCHITECTURE DIAGRAM ──────────────────────────────────── */
+  $$('.arch-component').forEach(comp => {
+    comp.addEventListener('click', function () {
+      const diagram = this.closest('.arch-diagram');
+      $$('.arch-component', diagram).forEach(c => c.classList.remove('active'));
+      this.classList.add('active');
+      const descEl = $('.arch-description', diagram);
+      if (descEl) descEl.textContent = this.dataset.desc || '';
+    });
+  });
+
+  /* ── BUG CHALLENGE ─────────────────────────────────────────── */
+  window.checkBugLine = function (el, isCorrect) {
+    const challenge = el.closest('.bug-challenge');
+    const feedback  = $('.bug-feedback', challenge);
+    if (isCorrect) {
+      el.classList.add('correct');
+      feedback.innerHTML  = '<strong>Found it!</strong> ' + (el.dataset.explanation || '');
+      feedback.className  = 'bug-feedback show success';
+      $$('.bug-line', challenge).forEach(l => l.style.pointerEvents = 'none');
+    } else {
+      el.classList.add('incorrect');
+      feedback.innerHTML  = (el.dataset.hint || 'Not this line — keep looking...');
+      feedback.className  = 'bug-feedback show error';
+      setTimeout(() => {
+        el.classList.remove('incorrect');
+        feedback.className = 'bug-feedback';
+      }, 1800);
+    }
+  };
+
+  /* ── LAYER TOGGLE ──────────────────────────────────────────── */
+  window.showLayer = function (layerId, btn) {
+    const demo = btn ? btn.closest('.layer-demo') : null;
+    if (!demo) return;
+    $$('.layer', demo).forEach(l => l.style.display = 'none');
+    $$('.layer-tab', demo).forEach(t => t.classList.remove('active'));
+    const layer = $('#' + layerId);
+    if (layer) layer.style.display = 'block';
+    btn.classList.add('active');
+  };
+
+})();

--- a/courses/general-course/modules/01-the-click.html
+++ b/courses/general-course/modules/01-the-click.html
@@ -1,0 +1,516 @@
+<section class="module" id="module-1" style="background: var(--color-bg-warm)">
+  <div class="module-content">
+    <header class="module-header animate-in">
+      <span class="module-number">01</span>
+      <h1 class="module-title">What Happens When You Click "Generate"</h1>
+      <p class="module-subtitle">Ten seconds, five pieces of code, one message traveling there and back.</p>
+    </header>
+
+    <div class="module-body">
+
+      <!-- SCREEN 1 — What this app even is -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">What This App Even Is</h2>
+        <p>You pick a photo of yourself, hit Generate, watch a spinner for about ten seconds, and a cartoon version of you appears in the Charlie &amp; Lola style. Those ten seconds are basically this whole course, running in miniature — let's slow them down.</p>
+
+        <div class="icon-rows">
+          <div class="icon-row">
+            <div class="icon-circle" style="background: var(--color-actor-1)">📷</div>
+            <div>
+              <strong><span class="term" data-definition="To upload is to send a file from your device to a server somewhere else on the internet. Uploading is the opposite of downloading.">Upload</span> a photo</strong>
+              <p>Any selfie or portrait, straight from your camera roll.</p>
+            </div>
+          </div>
+          <div class="icon-row">
+            <div class="icon-circle" style="background: var(--color-actor-3)">🎨</div>
+            <div>
+              <strong>Get a cartoon</strong>
+              <p>A Charlie &amp; Lola style version, drawn by an AI <span class="term" data-definition="In AI, a model is the trained system that actually does the work — recognizing images, generating text, or in this case, drawing a cartoon. Different models are good at different tasks.">model</span>.</p>
+            </div>
+          </div>
+          <div class="icon-row">
+            <div class="icon-circle" style="background: var(--color-actor-4)">🆓</div>
+            <div>
+              <strong>Free to try</strong>
+              <p>No account needed just to see a preview.</p>
+            </div>
+          </div>
+          <div class="icon-row">
+            <div class="icon-circle" style="background: var(--color-actor-2)">💳</div>
+            <div>
+              <strong>Sign in for credits</strong>
+              <p>Downloading full resolution and generating more costs credits.</p>
+            </div>
+          </div>
+        </div>
+
+        <p>Under the hood this is a full commercial product — payments, accounts, two languages, an AI model — packed into roughly 330 <span class="term" data-definition="TypeScript is a version of JavaScript that adds strict rules about what type of data (text, number, etc.) each piece of code expects, which helps catch mistakes before the code even runs.">TypeScript</span> files. That's more machinery than it looks like from the outside.</p>
+      </section>
+
+      <!-- SCREEN 2 — The photo lab metaphor -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">The Envelope You Never See Behind</h2>
+        <p>Picture a one-hour photo lab. You slide your film into a paper envelope, write "matte finish, 4x6" on the outside, and post it through a slot in the wall. You never see what happens back there.</p>
+
+        <div class="step-cards">
+          <div class="step-card">
+            <div class="step-num">1</div>
+            <div class="step-body">
+              <strong>You write your options on the envelope</strong>
+              <p>Your photo, plus the finish and size you want.</p>
+            </div>
+          </div>
+          <div class="step-card">
+            <div class="step-num">2</div>
+            <div class="step-body">
+              <strong>You push it through the slot in the wall</strong>
+              <p>It leaves your hands entirely.</p>
+            </div>
+          </div>
+          <div class="step-card">
+            <div class="step-num">3</div>
+            <div class="step-body">
+              <strong>The back room develops it</strong>
+              <p>You cannot see this part happening — you just wait.</p>
+            </div>
+          </div>
+          <div class="step-card">
+            <div class="step-num">4</div>
+            <div class="step-body">
+              <strong>An envelope of prints comes back out</strong>
+              <p>The finished result, handed back to you.</p>
+            </div>
+          </div>
+        </div>
+
+        <p>Your <span class="term" data-definition="The browser is the app running on your own computer or phone — Chrome, Safari, and so on. It's the 'client': the one asking for things, as opposed to the server that provides them.">browser</span> and the <span class="term" data-definition="A server is a computer sitting somewhere else, waiting to receive requests and act on them. In this app, it validates your photo, talks to the AI, and hands back a cartoon.">server</span> are two separate computers that can only pass each other messages — nothing more. Everything an app does is really just: package a message, send it, wait, unpack the reply.</p>
+
+        <p>In this app: the envelope is your <span class="term" data-definition="A request is a message sent from one computer to another asking it to do something, like a note passed through a mail slot. It carries data plus instructions about what you want back.">request</span>; the slot is the <span class="term" data-definition="API stands for Application Programming Interface — a defined way for one piece of software to ask another for something, like a menu of requests a computer will accept. When instructing an AI, you might say 'call the API' to mean 'ask the server for this.'">API</span> <span class="term" data-definition="An endpoint is one specific address a server listens on, like a numbered door in a building. Each endpoint handles one kind of request — this app's image endpoint is /api/generate-cyberpunk.">endpoint</span>; the back room is the server; and the prints coming back are the <span class="term" data-definition="A response is the message a server sends back after handling a request — the reply to your note. It carries the result, or an explanation of what went wrong.">response</span>.</p>
+
+        <div class="callout callout-accent">
+          <div class="callout-icon">💡</div>
+          <div class="callout-content">
+            <strong class="callout-title">Key Insight</strong>
+            <p>The entire internet is just this loop, over and over: package a message, send it, wait, unpack the reply. Once you can see that loop, nothing on the internet is actually mysterious — just message after message.</p>
+          </div>
+        </div>
+      </section>
+
+      <!-- SCREEN 3 — The envelope (Snippet A) -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">The Envelope</h2>
+        <p>When you click Generate, the browser doesn't send your photo file all by itself — it builds a <span class="term" data-definition="FormData is a browser feature for bundling a file (like your photo) together with other form fields into one package ready to send. Think of it as a box you can drop files and labels into before mailing it.">FormData</span> package first: your photo, plus every option you picked.</p>
+
+        <p>The photo itself started life as a giant <span class="term" data-definition="Base64 is a way of turning a photo's raw bytes into a long string of letters and numbers, so it can be stored or sent as plain text. It isn't compression — it just repackages the same picture as text.">base64</span> text string, sitting quietly in memory and <span class="term" data-definition="localStorage is a small storage locker inside your browser that keeps data on your device even after you close the tab, until something clears it.">localStorage</span> the moment you dropped it in — long before you ever clicked Generate.</p>
+
+        <p>This whole exchange is powered by a single JavaScript command called <span class="term" data-definition="fetch() is the browser's built-in tool for sending a request to a server and waiting for the reply. It's the JavaScript equivalent of typing a URL and hitting enter, but from inside code.">fetch</span>. Here's the actual code that packs and sends the envelope:</p>
+
+        <div class="translation-block animate-in">
+          <div class="translation-code">
+            <span class="translation-label">CODE</span>
+            <pre><code>
+<span class="code-line">      <span class="code-keyword">const</span> formData = <span class="code-keyword">new</span> <span class="code-function">FormData</span>();</span>
+<span class="code-line"></span>
+<span class="code-line">      formData.<span class="code-function">append</span>(<span class="code-string">'mode'</span>, <span class="code-string">'image2image'</span>);</span>
+<span class="code-line">      formData.<span class="code-function">append</span>(<span class="code-string">'style'</span>, <span class="code-string">'charlie-lola'</span>); <span class="code-comment">// Fixed style for Charlie and Lola</span></span>
+<span class="code-line">      formData.<span class="code-function">append</span>(<span class="code-string">'aspectRatio'</span>, aspectRatio);</span>
+<span class="code-line">      formData.<span class="code-function">append</span>(<span class="code-string">'outputFormat'</span>, outputFormat);</span>
+<span class="code-line">      formData.<span class="code-function">append</span>(<span class="code-string">'model'</span>, <span class="code-string">'standard'</span>); <span class="code-comment">// Fixed model</span></span>
+<span class="code-line"></span>
+<span class="code-line">      <span class="code-keyword">if</span> (customPrompt.trim()) {</span>
+<span class="code-line">        formData.<span class="code-function">append</span>(<span class="code-string">'customPrompt'</span>, customPrompt);</span>
+<span class="code-line">      }</span>
+<span class="code-line"></span>
+<span class="code-line">      <span class="code-keyword">for</span> (<span class="code-keyword">let</span> i = 0; i &lt; uploadedImages.length; i++) {</span>
+<span class="code-line">        <span class="code-keyword">const</span> response = <span class="code-keyword">await</span> <span class="code-function">fetch</span>(uploadedImages[i]);</span>
+<span class="code-line">        <span class="code-keyword">const</span> blob = <span class="code-keyword">await</span> response.<span class="code-function">blob</span>();</span>
+<span class="code-line">        formData.<span class="code-function">append</span>(`image_${i}`, blob);</span>
+<span class="code-line">      }</span>
+<span class="code-line"></span>
+<span class="code-line">      formData.<span class="code-function">append</span>(<span class="code-string">'imageCount'</span>, uploadedImages.length.<span class="code-function">toString</span>());</span>
+<span class="code-line"></span>
+<span class="code-line">      <span class="code-keyword">const</span> apiResponse = <span class="code-keyword">await</span> <span class="code-function">fetch</span>(<span class="code-string">'/api/generate-cyberpunk'</span>, {</span>
+<span class="code-line">        method: <span class="code-string">'POST'</span>,</span>
+<span class="code-line">        body: formData,</span>
+<span class="code-line">      });</span>
+            </code></pre>
+          </div>
+          <div class="translation-english">
+            <span class="translation-label">PLAIN ENGLISH</span>
+            <div class="translation-lines">
+              <p class="tl">Create an empty envelope you can put things inside.</p>
+              <p class="tl">Label it: this is a Charlie &amp; Lola image-to-image job.</p>
+              <p class="tl">Note the aspect ratio and file format you asked for.</p>
+              <p class="tl">The model setting is fixed to "standard" — always the same.</p>
+              <p class="tl">If you typed a custom instruction, tuck that in too.</p>
+              <p class="tl">Loop through every photo you uploaded (up to 5) and turn each one into raw bytes.</p>
+              <p class="tl">Drop each photo into the envelope, one by one.</p>
+              <p class="tl">Write down how many photos are inside.</p>
+              <p class="tl">Push the whole envelope through the slot in the wall — a <span class="term" data-definition="POST is a type of request that sends data to the server to create or change something, as opposed to GET, which just asks to read something. Uploading your photo is a POST.">POST</span> request to /api/generate-cyberpunk.</p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- SCREEN 4 — The back room -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">The Back Room</h2>
+        <p>Behind the slot, code called an API route unpacks your envelope and <span class="term" data-definition="To validate something is to check that it meets the rules before acting on it — right size, right format, right permissions. Servers validate requests so they don't waste work on bad data.">validates</span> it before doing anything expensive: valid aspect ratio? a photo actually attached? each under 10 <span class="term" data-definition="MB stands for megabyte, a unit of file size. A typical phone photo is a few MB — this app rejects any single image over 10 MB.">MB</span>? enough credits, if you're signed in? a free AI key available right now?</p>
+
+        <div class="translation-block animate-in">
+          <div class="translation-code">
+            <span class="translation-label">CODE</span>
+            <pre><code>
+<span class="code-line"><span class="code-keyword">export async function</span> <span class="code-function">POST</span>(request: Request) {</span>
+<span class="code-line">  <span class="code-keyword">try</span> {</span>
+<span class="code-line">    <span class="code-keyword">const</span> formData = <span class="code-keyword">await</span> request.<span class="code-function">formData</span>();</span>
+<span class="code-line">    <span class="code-keyword">const</span> style = formData.<span class="code-function">get</span>(<span class="code-string">'style'</span>) <span class="code-keyword">as</span> <span class="code-keyword">string</span> || <span class="code-string">'charlie-lola'</span>;</span>
+<span class="code-line">    <span class="code-keyword">const</span> mode = formData.<span class="code-function">get</span>(<span class="code-string">'mode'</span>) <span class="code-keyword">as</span> <span class="code-keyword">string</span> || <span class="code-string">'image2image'</span>; <span class="code-comment">// Charlie and Lola style transformation</span></span>
+<span class="code-line">    <span class="code-keyword">const</span> customPrompt = formData.<span class="code-function">get</span>(<span class="code-string">'customPrompt'</span>) <span class="code-keyword">as</span> <span class="code-keyword">string</span> || <span class="code-string">''</span>;</span>
+<span class="code-line">    <span class="code-keyword">const</span> aspectRatio = formData.<span class="code-function">get</span>(<span class="code-string">'aspectRatio'</span>) <span class="code-keyword">as</span> <span class="code-keyword">string</span> || <span class="code-string">'4:3'</span>;</span>
+<span class="code-line">    <span class="code-keyword">const</span> outputFormat = formData.<span class="code-function">get</span>(<span class="code-string">'outputFormat'</span>) <span class="code-keyword">as</span> <span class="code-keyword">string</span> || <span class="code-string">'png'</span>;</span>
+<span class="code-line">    <span class="code-keyword">const</span> model = formData.<span class="code-function">get</span>(<span class="code-string">'model'</span>) <span class="code-keyword">as</span> <span class="code-keyword">string</span> || <span class="code-string">'standard'</span>;</span>
+<span class="code-line">    <span class="code-keyword">const</span> imageCount = <span class="code-function">parseInt</span>(formData.<span class="code-function">get</span>(<span class="code-string">'imageCount'</span>) <span class="code-keyword">as</span> <span class="code-keyword">string</span> || <span class="code-string">'0'</span>);</span>
+            </code></pre>
+          </div>
+          <div class="translation-english">
+            <span class="translation-label">PLAIN ENGLISH</span>
+            <div class="translation-lines">
+              <p class="tl">This function runs whenever a POST request hits this address.</p>
+              <p class="tl">Try to open the envelope and read what's inside.</p>
+              <p class="tl">Pull out the style — default to "charlie-lola" if nothing was sent.</p>
+              <p class="tl">Pull out the mode — this is an image-to-image transformation.</p>
+              <p class="tl">Pull out any custom instructions you typed.</p>
+              <p class="tl">Pull out the aspect ratio and file format you chose.</p>
+              <p class="tl">Pull out the model setting.</p>
+              <p class="tl">Pull out how many photos you said you were sending.</p>
+            </div>
+          </div>
+        </div>
+
+        <p>If everything checks out, the server builds the actual instruction for the AI — the <span class="term" data-definition="A prompt is the plain-English instructions sent to an AI model telling it what to do. In this app, it's just a string of text sitting in a code file — anyone who can edit that string can change what the AI produces.">prompt</span>.</p>
+
+        <div class="translation-block animate-in">
+          <div class="translation-code">
+            <span class="translation-label">CODE</span>
+            <pre><code>
+<span class="code-line">    <span class="code-keyword">const</span> imageEditPrompt = [</span>
+<span class="code-line">      { text: charlieLolaPrompt },</span>
+<span class="code-line">      {</span>
+<span class="code-line">        inlineData: {</span>
+<span class="code-line">          mimeType: mimeType,</span>
+<span class="code-line">          data: base64Image,</span>
+<span class="code-line">        },</span>
+<span class="code-line">      },</span>
+<span class="code-line">    ];</span>
+<span class="code-line"></span>
+<span class="code-line">    console.<span class="code-function">log</span>(<span class="code-string">"🔄 Generating Charlie and Lola style image..."</span>);</span>
+<span class="code-line"></span>
+<span class="code-line">    <span class="code-keyword">let</span> response;</span>
+<span class="code-line">    <span class="code-keyword">try</span> {</span>
+<span class="code-line">      <span class="code-comment">// Generate edited image using Gemini 2.5 Flash Image Preview</span></span>
+<span class="code-line">      response = <span class="code-keyword">await</span> ai.models.<span class="code-function">generateContent</span>({</span>
+<span class="code-line">        model: <span class="code-string">"gemini-2.5-flash-image-preview"</span>,</span>
+<span class="code-line">        contents: imageEditPrompt,</span>
+<span class="code-line">      });</span>
+            </code></pre>
+          </div>
+          <div class="translation-english">
+            <span class="translation-label">PLAIN ENGLISH</span>
+            <div class="translation-lines">
+              <p class="tl">Build the actual message to the AI: instructions plus your photo.</p>
+              <p class="tl">The instructions are one big block of English text called charlieLolaPrompt.</p>
+              <p class="tl">The photo rides along too — its file type and its base64 bytes.</p>
+              <p class="tl">Print a log line so developers can see this step happening.</p>
+              <p class="tl">Send it all to Google's Gemini model and wait for the answer.</p>
+            </div>
+          </div>
+        </div>
+
+        <p>Tucked inside that prompt is a whole paragraph of do-nots: <em>"No realistic shading, no detailed rendering, no anime or manga style, no 3D modeling, no photographic textures!"</em> It's just text in a file — anyone who can edit that string can change the entire product.</p>
+
+        <div class="callout callout-warning">
+          <div class="callout-icon">⚠️</div>
+          <div class="callout-content">
+            <strong class="callout-title">The Name Lies</strong>
+            <p>This endpoint is called <code>/api/generate-cyberpunk</code> even though the app makes Charlie &amp; Lola cartoons — a leftover name from an earlier version of the product. Real codebases drift like this constantly, which is exactly why you should describe <em>behavior</em> to an AI assistant, not guess from a filename.</p>
+          </div>
+        </div>
+
+        <p>Here's the whole journey, start to finish. Click through it:</p>
+
+        <div class="flow-animation" data-steps='[
+          {"highlight":"flow-actor-1","label":"Browser packs your photo and chosen options into a FormData envelope."},
+          {"highlight":"flow-actor-2","label":"POST to /api/generate-cyberpunk — the envelope goes through the slot.","packet":true,"from":"actor-1","to":"actor-2"},
+          {"highlight":"flow-actor-2","label":"Server checks the envelope: valid aspect ratio? photo present? under 10MB? enough credits? a free AI key available?"},
+          {"highlight":"flow-actor-3","label":"Server sends the prompt plus your photo bytes to Gemini and waits.","packet":true,"from":"actor-2","to":"actor-3"},
+          {"highlight":"flow-actor-2","label":"Gemini finishes drawing and sends back raw image data.","packet":true,"from":"actor-3","to":"actor-2"},
+          {"highlight":"flow-actor-4","label":"Server uploads the image to Cloudflare R2 storage and gets a URL back.","packet":true,"from":"actor-2","to":"actor-4"},
+          {"highlight":"flow-actor-1","label":"Server sends back one JSON reply containing that imageUrl.","packet":true,"from":"actor-2","to":"actor-1"},
+          {"highlight":"flow-actor-1","label":"Browser puts the URL into an image tag and pops up a toast. Done."}
+        ]'>
+          <div class="flow-actors">
+            <div class="flow-actor" id="flow-actor-1">
+              <div class="flow-actor-icon">🌐</div>
+              <span>Browser</span>
+            </div>
+            <div class="flow-actor" id="flow-actor-2">
+              <div class="flow-actor-icon">🖥️</div>
+              <span>Server</span>
+            </div>
+            <div class="flow-actor" id="flow-actor-3">
+              <div class="flow-actor-icon">✨</div>
+              <span>Gemini</span>
+            </div>
+            <div class="flow-actor" id="flow-actor-4">
+              <div class="flow-actor-icon">☁️</div>
+              <span>Storage</span>
+            </div>
+          </div>
+
+          <div class="flow-packet" id="flow-packet"></div>
+
+          <div class="flow-step-label" id="flow-label">Click "Next Step" to begin</div>
+
+          <div class="flow-controls">
+            <button class="btn flow-next-btn">Next Step</button>
+            <button class="btn flow-reset-btn">Restart</button>
+            <span class="flow-progress"></span>
+          </div>
+        </div>
+
+        <p>Notice that the reply gets a <span class="term" data-definition="A URL is a web address — the string you'd paste into a browser bar to go straight to one specific thing, like an image.">URL</span> from <span class="term" data-definition="Cloud storage is a service that keeps files (like your generated cartoon) on someone else's servers permanently, and gives you a URL to fetch them later instead of storing them on your own device.">cloud storage</span> before it ever reaches you — Gemini itself never hands out a link, only raw pixels.</p>
+      </section>
+
+      <!-- SCREEN 5 — The prints come back -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">The Prints Come Back</h2>
+        <p>Gemini's answer arrives as raw image bytes, not a link. So the server uploads it, then packages the whole result as one <span class="term" data-definition="JSON is a plain-text way of packaging data as labeled fields, like a filled-out form: { &quot;name&quot;: &quot;value&quot; }. It's the format almost every API uses to send replies.">JSON</span> object.</p>
+
+        <div class="translation-block animate-in">
+          <div class="translation-code">
+            <span class="translation-label">CODE</span>
+            <pre><code>
+<span class="code-line">    <span class="code-keyword">return</span> <span class="code-function">respData</span>({</span>
+<span class="code-line">      imageUrl: responseImageUrl,</span>
+<span class="code-line">      filename: storedFilename,</span>
+<span class="code-line">      message: <span class="code-string">"Charlie and Lola style transformation completed successfully"</span>,</span>
+<span class="code-line">      provider: <span class="code-string">"google.gemini"</span>,</span>
+<span class="code-line">      model: <span class="code-string">"gemini-2.5-flash-image-preview"</span>,</span>
+<span class="code-line">      creditsUsed: isRegisteredUser ? requiredCredits : 0,</span>
+<span class="code-line">      aspectRatio,</span>
+<span class="code-line">      outputFormat: fileExtension,</span>
+<span class="code-line">      style: style,</span>
+<span class="code-line">      storedLocally: hasStorageConfig &amp;&amp; !finalImageUrl.startsWith(<span class="code-string">'data:'</span>),</span>
+<span class="code-line">      requiresRegistration,</span>
+<span class="code-line">      isPreview: !isRegisteredUser,</span>
+<span class="code-line">      downloadUrl: isRegisteredUser ? responseImageUrl : null,</span>
+<span class="code-line">    });</span>
+            </code></pre>
+          </div>
+          <div class="translation-english">
+            <span class="translation-label">PLAIN ENGLISH</span>
+            <div class="translation-lines">
+              <p class="tl">Package the final reply as one object.</p>
+              <p class="tl">imageUrl is where your cartoon actually lives now.</p>
+              <p class="tl">message and provider are just friendly labels about what happened.</p>
+              <p class="tl">creditsUsed says how many credits this cost — zero if you weren't signed in.</p>
+              <p class="tl">requiresRegistration and downloadUrl are the fields that decide whether you see a Sign In button or a working Download button.</p>
+            </div>
+          </div>
+        </div>
+
+        <p>Watch the same journey play out as a conversation between the three main characters:</p>
+
+        <div class="chat-window" id="chat-module1">
+          <div class="chat-messages">
+            <div class="chat-message" data-msg="0" data-sender="browser" style="display:none">
+              <div class="chat-avatar" style="background: var(--color-actor-1)">🌐</div>
+              <div class="chat-bubble">
+                <span class="chat-sender" style="color: var(--color-actor-1)">Browser</span>
+                <p>Here's a photo and some options — make it Charlie &amp; Lola.</p>
+              </div>
+            </div>
+            <div class="chat-message" data-msg="1" data-sender="server" style="display:none">
+              <div class="chat-avatar" style="background: var(--color-actor-2)">🖥️</div>
+              <div class="chat-bubble">
+                <span class="chat-sender" style="color: var(--color-actor-2)">Server</span>
+                <p>Hold on — aspect ratio valid? image present? under 10MB? ok.</p>
+              </div>
+            </div>
+            <div class="chat-message" data-msg="2" data-sender="server" style="display:none">
+              <div class="chat-avatar" style="background: var(--color-actor-2)">🖥️</div>
+              <div class="chat-bubble">
+                <span class="chat-sender" style="color: var(--color-actor-2)">Server → Gemini</span>
+                <p>Turn this person into a Charlie &amp; Lola character. No 3D, no anime, no photographic textures.</p>
+              </div>
+            </div>
+            <div class="chat-message" data-msg="3" data-sender="gemini" style="display:none">
+              <div class="chat-avatar" style="background: var(--color-actor-3)">✨</div>
+              <div class="chat-bubble">
+                <span class="chat-sender" style="color: var(--color-actor-3)">Gemini</span>
+                <p>...done. Here's the raw pixels.</p>
+              </div>
+            </div>
+            <div class="chat-message" data-msg="4" data-sender="server" style="display:none">
+              <div class="chat-avatar" style="background: var(--color-actor-2)">🖥️</div>
+              <div class="chat-bubble">
+                <span class="chat-sender" style="color: var(--color-actor-2)">Server</span>
+                <p>Filing a copy in storage. Here's your URL.</p>
+              </div>
+            </div>
+            <div class="chat-message" data-msg="5" data-sender="browser" style="display:none">
+              <div class="chat-avatar" style="background: var(--color-actor-1)">🌐</div>
+              <div class="chat-bubble">
+                <span class="chat-sender" style="color: var(--color-actor-1)">Browser</span>
+                <p>🎉</p>
+              </div>
+            </div>
+          </div>
+
+          <div class="chat-typing" id="chat-typing" style="display:none">
+            <div class="chat-avatar" id="typing-avatar">?</div>
+            <div class="chat-typing-dots">
+              <span class="typing-dot"></span>
+              <span class="typing-dot"></span>
+              <span class="typing-dot"></span>
+            </div>
+          </div>
+
+          <div class="chat-controls">
+            <button class="btn chat-next-btn">Next Message</button>
+            <button class="btn chat-all-btn">Play All</button>
+            <button class="btn chat-reset-btn">Replay</button>
+            <span class="chat-progress"></span>
+          </div>
+        </div>
+
+        <p>Now here's the code on the browser's side, unpacking that exact reply:</p>
+
+        <div class="translation-block animate-in">
+          <div class="translation-code">
+            <span class="translation-label">CODE</span>
+            <pre><code>
+<span class="code-line">      <span class="code-keyword">const</span> result = <span class="code-keyword">await</span> apiResponse.<span class="code-function">json</span>();</span>
+<span class="code-line"></span>
+<span class="code-line">      <span class="code-keyword">if</span> (result.code === 0 &amp;&amp; result.data?.imageUrl) {</span>
+<span class="code-line">        <span class="code-function">setGeneratedImage</span>(result.data.imageUrl);</span>
+<span class="code-line"></span>
+<span class="code-line">        <span class="code-comment">// Handle different response types</span></span>
+<span class="code-line">        <span class="code-keyword">if</span> (result.data.requiresRegistration &amp;&amp; !session) {</span>
+<span class="code-line">          toast.<span class="code-function">success</span>(<span class="code-string">"Image generated! Sign in to download full resolution image."</span>);</span>
+<span class="code-line">        } <span class="code-keyword">else if</span> (result.msg === <span class="code-string">'QUEUE_REQUIRED'</span>) {</span>
+<span class="code-line">          toast.<span class="code-function">warning</span>(<span class="code-string">"🚧 Service is busy. You're in the queue. Upgrade to premium to skip the queue!"</span>);</span>
+<span class="code-line">        } <span class="code-keyword">else</span> {</span>
+<span class="code-line">          toast.<span class="code-function">success</span>(t.messages.success.generated);</span>
+<span class="code-line">          <span class="code-keyword">if</span> (session) {</span>
+<span class="code-line">            <span class="code-function">refreshCredits</span>();</span>
+<span class="code-line">          }</span>
+<span class="code-line">        }</span>
+            </code></pre>
+          </div>
+          <div class="translation-english">
+            <span class="translation-label">PLAIN ENGLISH</span>
+            <div class="translation-lines">
+              <p class="tl">Read the server's reply and unpack the JSON.</p>
+              <p class="tl">If the reply says code 0 and there's an imageUrl, save that URL into this component's <span class="term" data-definition="State is the data a piece of the interface currently remembers, like 'which image is showing right now.' When state changes, the screen updates to match it.">state</span> — the picture appears immediately.</p>
+              <p class="tl">If you're not signed in, a <span class="term" data-definition="A toast is the small pop-up notification that briefly appears on screen (like 'Image generated!') and then fades away on its own.">toast</span> reminds you that signing in unlocks the full download.</p>
+              <p class="tl">Otherwise, if the service is busy, a different toast tells you you're in a queue.</p>
+              <p class="tl">Otherwise, celebrate: show a success toast and refresh your credit balance.</p>
+            </div>
+          </div>
+        </div>
+
+        <p>That JSON became <span class="term" data-definition="React is the JavaScript library this app's interface is built with. It lets the page update itself automatically whenever the underlying state changes.">React</span> state the instant it arrived — that single change is what makes the picture appear and the toast slide in.</p>
+
+        <h2 class="screen-heading" style="margin-top: var(--space-12)">Quick Check</h2>
+        <div class="quiz-container" id="quiz-module1">
+
+          <div class="quiz-question-block"
+               data-correct="check-request"
+               data-explanation-right="Exactly — open the browser's Network tab and see how far the envelope actually got. That one question turns 'it's broken' into a specific, fixable claim."
+               data-explanation-wrong="Not quite. Rewriting the prompt or the button color assumes you already know where the problem is — but you don't yet. The first move is always to trace the message.">
+            <h3 class="quiz-question">A user says "I clicked Generate and nothing happened — the spinner just spins forever." Where do you look FIRST, and why?</h3>
+            <div class="quiz-options">
+              <button class="quiz-option" data-value="rewrite-prompt" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>Rewrite the AI prompt</span>
+              </button>
+              <button class="quiz-option" data-value="check-request" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>Check whether the request left the browser, and what the server replied</span>
+              </button>
+              <button class="quiz-option" data-value="change-color" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>Change the button's color</span>
+              </button>
+              <button class="quiz-option" data-value="reinstall" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>Reinstall the app</span>
+              </button>
+            </div>
+            <div class="quiz-feedback"></div>
+          </div>
+
+          <div class="quiz-question-block"
+               data-correct="edit-prompt"
+               data-explanation-right="Exactly! The prompt is just an English string sitting in the API route. No new AI model, no database change — you'd just tell the AI to keep the background instead of dropping it."
+               data-explanation-wrong="Not quite. Nothing about swapping backgrounds needs a different model or a new database table — the instructions the AI follows are plain text, and that text is the only thing that has to change.">
+            <h3 class="quiz-question">You want the cartoon characters to keep a background instead of a transparent one. What actually has to change?</h3>
+            <div class="quiz-options">
+              <button class="quiz-option" data-value="new-model" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>Swap in a different AI model</span>
+              </button>
+              <button class="quiz-option" data-value="edit-prompt" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>Edit the prompt text inside the API route</span>
+              </button>
+              <button class="quiz-option" data-value="new-db-table" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>Add a new database table</span>
+              </button>
+              <button class="quiz-option" data-value="change-css" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>Change the button's CSS color</span>
+              </button>
+            </div>
+            <div class="quiz-feedback"></div>
+          </div>
+
+          <div class="quiz-question-block"
+               data-correct="requiresregistration-field"
+               data-explanation-right="Exactly — requiresRegistration and downloadUrl (which is null for guests) are what the button checks. The image itself is already there; it's these two fields that gate the download."
+               data-explanation-wrong="Not quite. imageUrl, creditsUsed, and provider are all present for everyone, guest or not — they don't distinguish who gets to download. Look at the fields that are specifically about registration.">
+            <h3 class="quiz-question">Guests see the generated image, but the download button asks them to sign in. Based on the JSON reply from Screen 5, which fields is the app checking?</h3>
+            <div class="quiz-options">
+              <button class="quiz-option" data-value="imageurl-field" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>The imageUrl field</span>
+              </button>
+              <button class="quiz-option" data-value="creditsused-field" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>The creditsUsed field</span>
+              </button>
+              <button class="quiz-option" data-value="requiresregistration-field" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>requiresRegistration, and downloadUrl being null</span>
+              </button>
+              <button class="quiz-option" data-value="provider-field" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>The provider field</span>
+              </button>
+            </div>
+            <div class="quiz-feedback"></div>
+          </div>
+
+          <button class="quiz-check-btn" onclick="checkQuiz('quiz-module1')">Check Answers</button>
+          <button class="quiz-reset-btn" onclick="resetQuiz('quiz-module1')">Try Again</button>
+        </div>
+
+        <p style="margin-top: var(--space-10)">We just watched a message travel through five different pieces of code without ever asking <em>who</em> those pieces are, or why the code is split up the way it is. That's next, in <strong>Meet the Cast</strong>.</p>
+      </section>
+
+    </div>
+  </div>
+</section>

--- a/courses/general-course/modules/02-meet-the-cast.html
+++ b/courses/general-course/modules/02-meet-the-cast.html
@@ -1,0 +1,560 @@
+<section class="module" id="module-2" style="background: var(--color-bg)">
+  <div class="module-content">
+    <header class="module-header animate-in">
+      <span class="module-number">02</span>
+      <h1 class="module-title">Meet the Cast — How the Code Is Organised</h1>
+      <p class="module-subtitle">Every file has a job. Once you know the roles, you know exactly where to tell an AI to make a change.</p>
+    </header>
+
+    <div class="module-body">
+
+      <!-- SCREEN 1: The metaphor -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">A Codebase Is a Film Production</h2>
+        <p>In Module 1, a message travelled through five different pieces of code — and nobody introduced them. Time to meet the cast, because the single most useful thing you can tell an AI coding assistant is <strong>where</strong> a change belongs.</p>
+
+        <div class="pattern-cards">
+          <div class="pattern-card" style="border-top: 3px solid var(--color-actor-1)">
+            <div class="pattern-icon" style="background: var(--color-actor-1)">🎭</div>
+            <h4 class="pattern-title">The Cast</h4>
+            <p class="pattern-desc">The parts you actually see — buttons, upload boxes, preview panels. In code, these are
+              <span class="term" data-definition="A framework for building user interfaces out of small, reusable pieces called components. It's the toolkit that turns 'a button and a box' into an actual interactive webpage.">React</span>
+              <span class="term" data-definition="A reusable building block of a web page — like a Lego brick other Lego bricks snap onto. Big apps are just many small components combined.">components</span>
+              living in <code>src/components/blocks/</code>.</p>
+          </div>
+          <div class="pattern-card" style="border-top: 3px solid var(--color-actor-2)">
+            <div class="pattern-icon" style="background: var(--color-actor-2)">🎬</div>
+            <h4 class="pattern-title">The Crew</h4>
+            <p class="pattern-desc">They work behind the camera and never appear in the shot:
+              <span class="term" data-definition="Short for Application Programming Interface — a defined way one piece of code asks another piece of code to do something, usually over the network.">API</span> routes, services, models, and the
+              <span class="term" data-definition="Where all the app's permanent data lives — user accounts, credit balances, orders. Think of it as a giant, always-available filing cabinet.">database</span>.
+              This is where the actual <span class="term" data-definition="The real rules of how the app is supposed to behave — 'new users get 30 credits' — as opposed to how something looks on screen.">business logic</span> lives.</p>
+          </div>
+          <div class="pattern-card" style="border-top: 3px solid var(--color-actor-3)">
+            <div class="pattern-icon" style="background: var(--color-actor-3)">🪑</div>
+            <h4 class="pattern-title">Props Department</h4>
+            <p class="pattern-desc">A shelf of generic, reusable objects any scene can borrow — a chair, a mug, a lamp. In code: 37 small pieces like buttons, cards, and dialogs in <code>src/components/ui/</code>.</p>
+          </div>
+          <div class="pattern-card" style="border-top: 3px solid var(--color-actor-4)">
+            <div class="pattern-icon" style="background: var(--color-actor-4)">🪜</div>
+            <h4 class="pattern-title">Chain of Command</h4>
+            <p class="pattern-desc">An actor doesn't wander into the accounts office to rewrite the budget. Requests travel up a strict chain, one step at a time — nobody skips ahead.</p>
+          </div>
+        </div>
+
+        <p>When you tell an AI "add a rule that Pro users get 3 free generations a day," it has to put that rule <em>somewhere</em>. Knowing which department owns that rule is often the difference between a
+          <span class="term" data-definition="All the code that makes up a project, taken together — every file, every folder.">codebase</span> that survives a year of changes and one that quietly falls apart before you even
+          <span class="term" data-definition="To publish a new version of the app so real users can actually access it.">deploy</span> it again.</p>
+      </section>
+
+      <!-- SCREEN 2: The map -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">The Map: Who Lives Where</h2>
+        <p>Here's the real top-level
+          <span class="term" data-definition="A container for organizing files on a computer — the same folders you see in Finder or File Explorer, just holding code instead of photos.">folder</span>
+          structure of <code>src/</code> — annotated with each department's film-crew role.</p>
+
+        <div class="file-tree">
+          <div class="ft-folder open">
+            <span class="ft-name">app/</span>
+            <span class="ft-desc"><strong>The stage.</strong> Every page and every
+              <span class="term" data-definition="A specific web address (like /pricing) and the code that responds when someone visits it.">route</span>
+              — an
+              <span class="term" data-definition="One specific address an API responds to, like a single phone extension in a large office.">endpoint</span> — lives here. The folder path IS the address.</span>
+          </div>
+          <div class="ft-folder">
+            <span class="ft-name">components/blocks/</span>
+            <span class="ft-desc"><strong>The cast.</strong> Big page sections: hero, pricing, faq, footer, imagen-wrapper.</span>
+          </div>
+          <div class="ft-folder">
+            <span class="ft-name">components/ui/</span>
+            <span class="ft-desc"><strong>Props department.</strong> 37 small generic pieces: button.tsx, card.tsx, dialog.tsx, tabs.tsx.</span>
+          </div>
+          <div class="ft-folder">
+            <span class="ft-name">services/</span>
+            <span class="ft-desc"><strong>The crew chiefs.</strong> Business rules: credit.ts, order.ts, user.ts, stripe.ts, affiliate.ts.</span>
+          </div>
+          <div class="ft-folder">
+            <span class="ft-name">models/</span>
+            <span class="ft-desc"><strong>The records office.</strong> The only files allowed to touch the database: user.ts, credit.ts, order.ts, post.ts.</span>
+          </div>
+          <div class="ft-folder">
+            <span class="ft-name">db/</span>
+            <span class="ft-desc"><strong>The filing cabinet itself.</strong></span>
+            <div class="ft-children">
+              <div class="ft-file">
+                <span class="ft-name">schema.ts</span>
+                <span class="ft-desc">The <span class="term" data-definition="The blueprint for a database table — which columns exist and what kind of data each one holds.">schema</span> — table shapes.</span>
+              </div>
+              <div class="ft-file">
+                <span class="ft-name">index.ts</span>
+                <span class="ft-desc">The live connection to the database.</span>
+              </div>
+            </div>
+          </div>
+          <div class="ft-folder">
+            <span class="ft-name">auth/</span>
+            <span class="ft-desc"><strong>Security.</strong> Who you are — covered in Module 3.</span>
+          </div>
+          <div class="ft-folder">
+            <span class="ft-name">i18n/</span>
+            <span class="ft-desc"><strong>Translation department.</strong> English and Chinese text — Module 6.</span>
+          </div>
+          <div class="ft-folder">
+            <span class="ft-name">lib/</span>
+            <span class="ft-desc"><strong>The toolbox.</strong> Small helpers used by everyone: hash.ts, time.ts, resp.ts, storage.ts.</span>
+          </div>
+          <div class="ft-folder">
+            <span class="ft-name">aisdk/</span>
+            <span class="ft-desc"><strong>The specialist rig.</strong> A hand-built adapter for the Kling video-generation service.</span>
+          </div>
+        </div>
+      </section>
+
+      <!-- SCREEN 3: folders become URLs -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">Folders Become Web Addresses</h2>
+        <p>In
+          <span class="term" data-definition="A framework built on top of React that adds routing, server rendering, and API endpoints — the production company running the whole show.">Next.js</span>
+          — the
+          <span class="term" data-definition="A pre-built structure of rules and tools an app is built on top of, so you don't reinvent the basics every time.">framework</span>
+          this app runs on — folders under <code>src/app/</code> literally become the
+          <span class="term" data-definition="The part of a web address after the domain name — the '/pricing' in charlieandlola.net/pricing.">URL path</span> in your browser bar.</p>
+
+        <div class="badge-list">
+          <div class="badge-item">
+            <code class="badge-code">[locale]/(default)/pricing/page.tsx</code>
+            <span class="badge-desc">becomes <strong>charlieandlola.net/en/pricing</strong></span>
+          </div>
+          <div class="badge-item">
+            <code class="badge-code">api/checkout/route.ts</code>
+            <span class="badge-desc">becomes <strong>charlieandlola.net/api/checkout</strong></span>
+          </div>
+          <div class="badge-item">
+            <code class="badge-code">(admin)/admin/orders/page.tsx</code>
+            <span class="badge-desc">becomes <strong>charlieandlola.net/admin/orders</strong></span>
+          </div>
+        </div>
+
+        <p>Two notations make this readable once you know the trick:</p>
+
+        <div class="icon-rows">
+          <div class="icon-row">
+            <div class="icon-circle" style="background: var(--color-actor-2)">[ ]</div>
+            <div>
+              <strong>[locale] — square brackets</strong>
+              <p>Means "anything goes here, and tell me what it was." That's how /en/pricing and /zh/pricing are the same one file.</p>
+            </div>
+          </div>
+          <div class="icon-row">
+            <div class="icon-circle" style="background: var(--color-actor-3)">( )</div>
+            <div>
+              <strong>(default), (admin), (console) — round brackets</strong>
+              <p>Mean "this folder is for organizing only." It does <strong>not</strong> appear in the URL at all — genuinely confusing the first time you see it.</p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- SCREEN 4: chain of command -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">The Chain of Command, in Three Files</h2>
+        <p>Remember <code>generate-cyberpunk/route.ts</code> from Module 1? Watch how one request passes through three layers, and how each layer only ever talks to the one directly below it.</p>
+
+        <h3 class="screen-heading" style="font-size: var(--text-lg)">Layer 1 — The Route</h3>
+        <p>Takes the request, checks in with the Service layer, and replies. File: <code>src/app/api/generate-cyberpunk/route.ts</code></p>
+        <div class="translation-block animate-in">
+          <div class="translation-code">
+            <span class="translation-label">CODE</span>
+            <pre><code>
+<span class="code-line"><span class="code-comment">// Get user info</span></span>
+<span class="code-line"><span class="code-keyword">const</span> userUuid = <span class="code-keyword">await</span> <span class="code-function">getUserUuid</span>();</span>
+<span class="code-line"><span class="code-keyword">const</span> isRegisteredUser = !!userUuid;</span>
+<span class="code-line"> </span>
+<span class="code-line"><span class="code-comment">// Check credits for registered users</span></span>
+<span class="code-line"><span class="code-keyword">if</span> (isRegisteredUser) {</span>
+<span class="code-line">  <span class="code-keyword">const</span> userCredits = <span class="code-keyword">await</span> <span class="code-function">getUserCredits</span>(userUuid);</span>
+<span class="code-line">  <span class="code-keyword">if</span> (userCredits.<span class="code-property">left_credits</span> &lt; CreditsAmount.<span class="code-property">ImageGeneration</span>) {</span>
+<span class="code-line">    <span class="code-keyword">return</span> <span class="code-function">respErr</span>(<span class="code-string">`Insufficient credits. You need ${CreditsAmount.ImageGeneration} credits but only have ${userCredits.left_credits}. Please recharge to continue.`</span>, <span class="code-string">'INSUFFICIENT_CREDITS'</span>);</span>
+<span class="code-line">  }</span>
+<span class="code-line">}</span>
+            </code></pre>
+          </div>
+          <div class="translation-english">
+            <span class="translation-label">PLAIN ENGLISH</span>
+            <div class="translation-lines">
+              <p class="tl">Ask Security who's making this request — their <span class="term" data-definition="The record that keeps you 'logged in' as you move between pages, without re-entering your password every click.">session</span> (Module 3 opens this box).</p>
+              <p class="tl">Turn that into a plain yes/no: are they signed in at all?</p>
+              <p class="tl">If they ARE signed in, check their <span class="term" data-definition="The app's internal currency — a countable balance that gets spent whenever someone generates an image.">credits</span> balance before doing anything expensive.</p>
+              <p class="tl">Ask the Model layer how many credits this user actually has left.</p>
+              <p class="tl">Compare it to the price of one image — a number defined in the Service layer, not here.</p>
+              <p class="tl">Not enough? Stop immediately and send back a clear error message.</p>
+            </div>
+          </div>
+        </div>
+
+        <h3 class="screen-heading" style="font-size: var(--text-lg)">Layer 2 — The Service</h3>
+        <p>Knows the business rules. File: <code>src/services/credit.ts</code></p>
+        <div class="translation-block animate-in">
+          <div class="translation-code">
+            <span class="translation-label">CODE</span>
+            <pre><code>
+<span class="code-line"><span class="code-keyword">export</span> <span class="code-keyword">enum</span> CreditsAmount {</span>
+<span class="code-line">  NewUserGet = <span class="code-number">30</span>,</span>
+<span class="code-line">  PingCost = <span class="code-number">1</span>,</span>
+<span class="code-line">  ImageGeneration = <span class="code-number">10</span>,</span>
+<span class="code-line">}</span>
+            </code></pre>
+          </div>
+          <div class="translation-english">
+            <span class="translation-label">PLAIN ENGLISH</span>
+            <div class="translation-lines">
+              <p class="tl">Define a fixed, named menu of credit amounts — an <span class="term" data-definition="Short for 'enumeration' — a fixed, named list of values, like a menu a value must be chosen from.">enum</span> — used everywhere in the app.</p>
+              <p class="tl">New users start with 30 credits, free.</p>
+              <p class="tl">A test "ping" costs 1 credit.</p>
+              <p class="tl">Generating one image costs 10 credits. Change this ONE number and the whole app updates.</p>
+              <p class="tl">End of the list.</p>
+            </div>
+          </div>
+        </div>
+
+        <h3 class="screen-heading" style="font-size: var(--text-lg)">Layer 3 — The Model</h3>
+        <p>The only code allowed to touch the database. File: <code>src/models/credit.ts</code></p>
+        <div class="translation-block animate-in">
+          <div class="translation-code">
+            <span class="translation-label">CODE</span>
+            <pre><code>
+<span class="code-line"><span class="code-keyword">export</span> <span class="code-keyword">async</span> <span class="code-keyword">function</span> <span class="code-function">getAllUserCredits</span>(</span>
+<span class="code-line">  user_uuid: <span class="code-keyword">string</span></span>
+<span class="code-line">): Promise&lt;(<span class="code-keyword">typeof</span> credits.$inferSelect)[] | undefined&gt; {</span>
+<span class="code-line">  <span class="code-keyword">const</span> data = <span class="code-keyword">await</span> <span class="code-function">db</span>()</span>
+<span class="code-line">    .<span class="code-function">select</span>()</span>
+<span class="code-line">    .<span class="code-function">from</span>(credits)</span>
+<span class="code-line">    .<span class="code-function">where</span>(<span class="code-function">eq</span>(credits.<span class="code-property">user_uuid</span>, user_uuid))</span>
+<span class="code-line">    .<span class="code-function">orderBy</span>(<span class="code-function">asc</span>(credits.<span class="code-property">created_at</span>));</span>
+<span class="code-line"> </span>
+<span class="code-line">  <span class="code-keyword">return</span> data;</span>
+<span class="code-line">}</span>
+            </code></pre>
+          </div>
+          <div class="translation-english">
+            <span class="translation-label">PLAIN ENGLISH</span>
+            <div class="translation-lines">
+              <p class="tl">A <span class="term" data-definition="A named, reusable block of code that performs one task — write it once, call it whenever you need that task done.">function</span> that takes one input: which user's records to fetch.</p>
+              <p class="tl"><span class="term" data-definition="A stricter version of JavaScript that catches typos and mismatched data before the code ever runs — spell-check for programming logic.">TypeScript</span> promises the answer will be a list of credit records, or nothing.</p>
+              <p class="tl">Open a connection to the database — this file is the ONLY one in the whole app allowed to do this.</p>
+              <p class="tl">Ask for rows from the credits table, but only the ones belonging to this one user.</p>
+              <p class="tl">Sort them oldest first, then hand the results back up to the Service layer.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="layer-demo">
+          <div class="layer-tabs">
+            <button class="layer-tab active" onclick="showLayer('route')">Route</button>
+            <button class="layer-tab" onclick="showLayer('service')">Service</button>
+            <button class="layer-tab" onclick="showLayer('model')">Model</button>
+            <button class="layer-tab" onclick="showLayer('database')">Database</button>
+          </div>
+          <div class="layer-viewport">
+            <div class="layer" id="layer-route" style="display:block">
+              <div class="icon-row">
+                <div class="icon-circle" style="background: var(--color-actor-1)">📮</div>
+                <div>
+                  <strong>The Route</strong>
+                  <p>Takes the incoming request, asks Security who's asking, and asks the Service layer if the rules allow it. Never touches the database directly.</p>
+                </div>
+              </div>
+            </div>
+            <div class="layer" id="layer-service" style="display:none">
+              <div class="icon-row">
+                <div class="icon-circle" style="background: var(--color-actor-2)">📋</div>
+                <div>
+                  <strong>The Service</strong>
+                  <p>Owns the business rules — prices, limits, permissions. "10 credits per image" is written down here, and only here.</p>
+                </div>
+              </div>
+            </div>
+            <div class="layer" id="layer-model" style="display:none">
+              <div class="icon-row">
+                <div class="icon-circle" style="background: var(--color-actor-3)">🗂️</div>
+                <div>
+                  <strong>The Model</strong>
+                  <p>The only code allowed to run a database query. Every other layer has to ask it — nobody else writes the query themselves.</p>
+                </div>
+              </div>
+            </div>
+            <div class="layer" id="layer-database" style="display:none">
+              <div class="icon-row">
+                <div class="icon-circle" style="background: var(--color-actor-4)">🗄️</div>
+                <div>
+                  <strong>Database</strong>
+                  <p><span class="term" data-definition="A popular, reliable type of database software for storing structured data in tables.">Postgres</span>, accessed through
+                    <span class="term" data-definition="A tool that lets code talk to the database using normal JavaScript/TypeScript instead of writing raw SQL by hand.">Drizzle ORM</span>.
+                    The actual filing cabinet where every credit balance, order, and user record lives.</p>
+                </div>
+              </div>
+            </div>
+          </div>
+          <p class="layer-description" id="layer-desc">Click a tab above. Notice each layer only ever talks to the one directly below it — Route never queries the database, Service never touches SQL.</p>
+        </div>
+
+        <div class="callout callout-accent">
+          <div class="callout-icon">💡</div>
+          <div class="callout-content">
+            <strong class="callout-title">A Rule Should Live in Exactly One Place</strong>
+            <p>Engineers call this <span class="term" data-definition="A design principle: each piece of code should be responsible for exactly one job, and that job should live in exactly one place.">separation of concerns</span>. If "10 credits per image" lived in a button instead of the Service layer, you'd end up with the rule in five places — and four of them wrong within a month.</p>
+          </div>
+        </div>
+      </section>
+
+      <!-- SCREEN 5: cast vs crew, server vs client -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">Cast vs Crew: On Stage and Backstage</h2>
+        <p>Some components run on the company's
+          <span class="term" data-definition="Code that runs on the company's computer before anything is sent to your browser. It can safely use secrets and talk to the database.">server</span>, before the page even reaches you. Others run in your own browser, on the
+          <span class="term" data-definition="Code that runs inside your own browser, after the page loads. It can react to your clicks, but can't be trusted with secrets.">client</span> side — the line is one piece of text at the top of a file: <code>'use client'</code>.</p>
+
+        <div class="icon-rows">
+          <div class="icon-row">
+            <div class="icon-circle" style="background: var(--color-actor-2)">🖥️</div>
+            <div>
+              <strong>Server — index.tsx</strong>
+              <p>Looks up the translated text and hands it down. Can read secrets and databases — but can't respond to a click.</p>
+            </div>
+          </div>
+          <div class="icon-row">
+            <div class="icon-circle" style="background: var(--color-actor-1)">🖱️</div>
+            <div>
+              <strong>Client — imagen-client.tsx</strong>
+              <p>Handles clicks, drag-and-drop, spinners — anything that reacts to a human. Never trusted with secrets, because anything in the browser can be read by the user.</p>
+            </div>
+          </div>
+        </div>
+
+        <p>Server fetches, client interacts — a hand-off pair from the same feature.</p>
+
+        <div class="translation-block animate-in">
+          <div class="translation-code">
+            <span class="translation-label">CODE — server half</span>
+            <pre><code>
+<span class="code-line"><span class="code-keyword">export</span> <span class="code-keyword">default</span> <span class="code-keyword">async</span> <span class="code-keyword">function</span> <span class="code-function">ImagenWrapper</span>({ locale = <span class="code-string">'en'</span> }: ImagenWrapperProps = {}) {</span>
+<span class="code-line">  <span class="code-comment">// Set the request locale for server-side translations</span></span>
+<span class="code-line">  <span class="code-function">setRequestLocale</span>(locale);</span>
+<span class="code-line"> </span>
+<span class="code-line">  <span class="code-comment">// Get the translations on the server side with explicit locale</span></span>
+<span class="code-line">  <span class="code-keyword">const</span> t = <span class="code-keyword">await</span> <span class="code-function">getTranslations</span>({ locale, <span class="code-property">namespace</span>: <span class="code-string">'imagen'</span> });</span>
+<span class="code-line"> </span>
+<span class="code-line">  <span class="code-comment">// Pass translations as props to the client component</span></span>
+<span class="code-line">  <span class="code-keyword">const</span> translations = {</span>
+<span class="code-line">    <span class="code-property">badge</span>: { <span class="code-property">text</span>: t(<span class="code-string">'badge.text'</span>) },</span>
+<span class="code-line">    <span class="code-property">title</span>: { <span class="code-property">main</span>: t(<span class="code-string">'title.main'</span>), <span class="code-property">subtitle</span>: t(<span class="code-string">'title.subtitle'</span>) },</span>
+            </code></pre>
+          </div>
+          <div class="translation-english">
+            <span class="translation-label">PLAIN ENGLISH</span>
+            <div class="translation-lines">
+              <p class="tl">This function runs on the server. It <span class="term" data-definition="To turn code into the actual pixels shown on screen.">renders</span> before your browser ever sees it.</p>
+              <p class="tl">Lock in which language this request is for.</p>
+              <p class="tl">Fetch all the English/Chinese text for the "imagen" section — a
+                <span class="term" data-definition="A named group of text strings for one part of the app, so 'imagen' text and 'pricing' text don't get mixed up across languages.">translation namespace</span>.</p>
+              <p class="tl">Bundle that text up as
+                <span class="term" data-definition="Short for 'properties' — data handed from a parent component down to a child component, like a director handing an actor their lines.">props</span>
+                — ready to pass down to the client component below.</p>
+              <p class="tl">Each piece of on-screen copy gets its own labelled slot.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="translation-block animate-in">
+          <div class="translation-code">
+            <span class="translation-label">CODE — client half</span>
+            <pre><code>
+<span class="code-line"><span class="code-string">'use client'</span>;</span>
+<span class="code-line"> </span>
+<span class="code-line"><span class="code-keyword">import</span> React, { useState, useRef, useEffect } <span class="code-keyword">from</span> <span class="code-string">'react'</span>;</span>
+<span class="code-line"><span class="code-keyword">import</span> { useSession } <span class="code-keyword">from</span> <span class="code-string">'next-auth/react'</span>;</span>
+<span class="code-line"><span class="code-keyword">import</span> { Card, CardContent } <span class="code-keyword">from</span> <span class="code-string">'@/components/ui/card'</span>;</span>
+<span class="code-line"><span class="code-keyword">import</span> { Button } <span class="code-keyword">from</span> <span class="code-string">'@/components/ui/button'</span>;</span>
+<span class="code-line"><span class="code-keyword">import</span> { cn } <span class="code-keyword">from</span> <span class="code-string">'@/lib/utils'</span>;</span>
+<span class="code-line"><span class="code-keyword">import</span> { useUserCredits } <span class="code-keyword">from</span> <span class="code-string">'@/hooks/useUserCredits'</span>;</span>
+<span class="code-line"><span class="code-keyword">import</span> CreditDisplay <span class="code-keyword">from</span> <span class="code-string">'@/components/blocks/credits-display'</span>;</span>
+<span class="code-line"><span class="code-keyword">import</span> { toast } <span class="code-keyword">from</span> <span class="code-string">'sonner'</span>;</span>
+<span class="code-line"><span class="code-keyword">import</span> { convertToCdnUrl } <span class="code-keyword">from</span> <span class="code-string">'@/lib/cdn-url'</span>;</span>
+<span class="code-line"><span class="code-keyword">import</span> { useTheme } <span class="code-keyword">from</span> <span class="code-string">'@/contexts/theme-context'</span>;</span>
+            </code></pre>
+          </div>
+          <div class="translation-english">
+            <span class="translation-label">PLAIN ENGLISH</span>
+            <div class="translation-lines">
+              <p class="tl">This one line flips the switch: everything below runs in the browser, not the server.</p>
+              <p class="tl"><span class="term" data-definition="A line of code that pulls in a tool, component, or function from another file so this file can use it.">Import</span> React's own tools for tracking state and reacting to page loads.</p>
+              <p class="tl">Bring in the tool for checking whether someone is signed in — their session.</p>
+              <p class="tl">Borrow two generic props-department pieces: Card and CardContent.</p>
+              <p class="tl">Borrow the generic Button piece too.</p>
+              <p class="tl">A small helper for combining CSS class names cleanly.</p>
+              <p class="tl">A <span class="term" data-definition="A special React function (its name always starts with 'use') that lets a component tap into features like live data or session state.">hook</span> — a live, always-up-to-date read of this user's credit balance.</p>
+              <p class="tl">The small badge that shows the credit balance on screen.</p>
+              <p class="tl">A library for showing little pop-up notifications.</p>
+              <p class="tl">A helper that rewrites image links to load from a
+                <span class="term" data-definition="A network of servers around the world that deliver files, like images, fast — from a copy stored near you.">CDN</span> instead of one far-away server.</p>
+              <p class="tl">The current light/dark theme setting.</p>
+            </div>
+          </div>
+        </div>
+
+        <h3 class="screen-heading" style="font-size: var(--text-lg)">The Assembled Page</h3>
+        <p>The landing page barely contains content of its own — it's a list of cast members, each handed a slice of data. File: <code>src/app/[locale]/(default)/page.tsx</code></p>
+
+        <div class="translation-block animate-in">
+          <div class="translation-code">
+            <span class="translation-label">CODE</span>
+            <pre><code>
+<span class="code-line">&lt;ImagenWrapper locale={locale} /&gt;</span>
+<span class="code-line">{page.introduce &amp;&amp; &lt;Feature1 section={page.introduce} /&gt;}</span>
+<span class="code-line">{page.benefit &amp;&amp; &lt;Feature2 section={page.benefit} /&gt;}</span>
+<span class="code-line">{page.usage &amp;&amp; &lt;Feature3 section={page.usage} /&gt;}</span>
+<span class="code-line">{page.feature &amp;&amp; &lt;Feature section={page.feature} /&gt;}</span>
+<span class="code-line">{page.showcase &amp;&amp; &lt;Showcase section={page.showcase} /&gt;}</span>
+<span class="code-line">{page.stats &amp;&amp; &lt;Stats section={page.stats} /&gt;}</span>
+<span class="code-line">{page.pricing &amp;&amp; &lt;Pricing pricing={page.pricing} /&gt;}</span>
+<span class="code-line">{page.testimonial &amp;&amp; &lt;Testimonial section={page.testimonial} /&gt;}</span>
+<span class="code-line">{page.faq &amp;&amp; &lt;FAQ section={page.faq} /&gt;}</span>
+<span class="code-line">{page.cta &amp;&amp; &lt;CTA section={page.cta} /&gt;}</span>
+            </code></pre>
+          </div>
+          <div class="translation-english">
+            <span class="translation-label">PLAIN ENGLISH</span>
+            <div class="translation-lines">
+              <p class="tl">Always draw the upload widget — it's always there.</p>
+              <p class="tl">Only draw the "introduce" section if the data file actually has content for it.</p>
+              <p class="tl">Same trick, section by section: benefit, usage, feature, showcase, stats.</p>
+              <p class="tl">…pricing, testimonials, FAQ, and the final call-to-action — each one optional.</p>
+              <p class="tl">The <code>&amp;&amp;</code> means "only draw this if there's something to draw." No content, no section — nothing crashes.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="callout callout-accent">
+          <div class="callout-icon">💡</div>
+          <div class="callout-content">
+            <strong class="callout-title">The Page Is a Template. The Content Is Data.</strong>
+            <p>The landing page component doesn't hard-code a single word of copy. It just asks "does the data file have a pricing section?" — and Module 6 shows you exactly where that data file lives.</p>
+          </div>
+        </div>
+
+        <div class="quiz-container" id="quiz-module2">
+          <div class="quiz-question-block"
+               data-correct="q1-b"
+               data-explanation-right="Exactly — CreditsAmount lives in exactly one place. Change ImageGeneration from 10 to 5 and every route, every check, everywhere in the app updates automatically."
+               data-explanation-wrong="Not quite. Think about the 'one place, one rule' idea — if the price lived in a button or was copy-pasted into every route, you'd have to hunt down every copy and update them all, and you'd inevitably miss one.">
+            <h3 class="quiz-question">You want to change the cost of generating an image from 10 credits to 5. Which file do you edit?</h3>
+            <div class="quiz-options">
+              <button class="quiz-option" data-value="q1-a" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>The button component that starts the generation</span>
+              </button>
+              <button class="quiz-option" data-value="q1-b" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span><code>src/services/credit.ts</code> — the CreditsAmount list</span>
+              </button>
+              <button class="quiz-option" data-value="q1-c" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>The database, directly</span>
+              </button>
+              <button class="quiz-option" data-value="q1-d" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>Every API route that generates images</span>
+              </button>
+            </div>
+            <div class="quiz-feedback"></div>
+          </div>
+
+          <div class="quiz-question-block"
+               data-correct="q2-a"
+               data-explanation-right="Exactly. Once a query lives in a component instead of the Model layer, someone will write a slightly different version of that same query somewhere else — and now the two can quietly disagree."
+               data-explanation-wrong="Not quite — the real risk isn't speed or syntax. It's that the database rule now lives in two places instead of one, and those two places can drift apart over time.">
+            <h3 class="quiz-question">An AI coding assistant writes a database query directly inside a page component. Why should you push back?</h3>
+            <div class="quiz-options">
+              <button class="quiz-option" data-value="q2-a" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>It skips the Service and Model layers, so the rule can now drift out of sync in two places</span>
+              </button>
+              <button class="quiz-option" data-value="q2-b" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>Page components are written in the wrong programming language for database queries</span>
+              </button>
+              <button class="quiz-option" data-value="q2-c" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>It will make the page load slightly slower</span>
+              </button>
+              <button class="quiz-option" data-value="q2-d" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>It's not really a problem — as long as it works, the layers don't matter</span>
+              </button>
+            </div>
+            <div class="quiz-feedback"></div>
+          </div>
+
+          <div class="quiz-question-block"
+               data-correct="q3-b"
+               data-explanation-right="Exactly. A countdown that updates every second has to react to time passing in front of the user's eyes — that's client territory. Telling an AI 'mark it use client' is precise enough that it knows exactly what to build."
+               data-explanation-wrong="Think about what a countdown actually needs to do: update on its own, every second, right in front of the user. That's a job for the client, not the server.">
+            <h3 class="quiz-question">You need a component that shows a live countdown timer, updating every second. Server or client component — and how do you tell the AI?</h3>
+            <div class="quiz-options">
+              <button class="quiz-option" data-value="q3-a" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>Server component — say "keep it on the server"</span>
+              </button>
+              <button class="quiz-option" data-value="q3-b" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>Client component — say "mark it <code>'use client'</code>"</span>
+              </button>
+              <button class="quiz-option" data-value="q3-c" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>Doesn't matter — either works exactly the same</span>
+              </button>
+              <button class="quiz-option" data-value="q3-d" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>Neither — countdown timers can't be built as components</span>
+              </button>
+            </div>
+            <div class="quiz-feedback"></div>
+          </div>
+
+          <div class="quiz-question-block"
+               data-correct="q4-b"
+               data-explanation-right="Exactly. Round brackets like (console) or (admin) tell Next.js 'organize the files this way, but don't put it in the address.' Only square brackets like [locale], and plain folder names, ever show up in the URL."
+               data-explanation-wrong="Round-bracket folders are a Next.js-specific trick for tidying up files without changing the address a visitor types. Try picturing the folder path with (console) simply deleted from it — that's the real URL.">
+            <h3 class="quiz-question">In the URL, where does the folder name <code>(console)</code> show up?</h3>
+            <div class="quiz-options">
+              <button class="quiz-option" data-value="q4-a" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>Right after the domain: charlieandlola.net/(console)/</span>
+              </button>
+              <button class="quiz-option" data-value="q4-b" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>Nowhere — round-bracket folders are for organizing files only</span>
+              </button>
+              <button class="quiz-option" data-value="q4-c" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>Only when the user is signed in</span>
+              </button>
+              <button class="quiz-option" data-value="q4-d" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>At the very end of the address</span>
+              </button>
+            </div>
+            <div class="quiz-feedback"></div>
+          </div>
+
+          <button class="quiz-check-btn" onclick="checkQuiz('quiz-module2')">Check Answers</button>
+          <button class="quiz-reset-btn" onclick="resetQuiz('quiz-module2')">Try Again</button>
+        </div>
+
+        <p>The route in this module called <code>getUserUuid()</code> and we just... trusted it. Next module — <strong>Who Are You?</strong> — opens that box: sign-in, sessions, and how the server knows which account a request belongs to.</p>
+      </section>
+
+    </div>
+  </div>
+</section>

--- a/courses/general-course/modules/03-who-are-you.html
+++ b/courses/general-course/modules/03-who-are-you.html
@@ -1,0 +1,567 @@
+<section class="module" id="module-3" style="background: var(--color-bg-warm)">
+  <div class="module-content">
+    <header class="module-header animate-in">
+      <span class="module-number">03</span>
+      <h1 class="module-title">Who Are You? Sign-In, Sessions, and Trust</h1>
+      <p class="module-subtitle">How a click on "Sign in with Google" turns into a stamped, tamper-evident wristband your Browser carries everywhere.</p>
+    </header>
+
+    <div class="module-body">
+
+      <!-- SCREEN 1: The wristband metaphor -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">Two Very Different Jobs</h2>
+        <p>You can use this app without signing in — you just can't <em>download</em>. Last module we spotted the image route quietly calling <code>getUserUuid()</code> and promised we'd open that box. This is that box.</p>
+
+        <div class="pattern-cards">
+          <div class="pattern-card" style="border-top: 3px solid var(--color-actor-4)">
+            <div class="pattern-icon" style="background: var(--color-actor-4)">🎟️</div>
+            <h4 class="pattern-title">The Gate</h4>
+            <p class="pattern-desc">Once, you queue up and prove who you are the hard way — passport, booking reference, a good look at your face.</p>
+          </div>
+          <div class="pattern-card" style="border-top: 3px solid var(--color-accent)">
+            <div class="pattern-icon" style="background: var(--color-accent)">🎫</div>
+            <h4 class="pattern-title">The Wristband</h4>
+            <p class="pattern-desc">After that, nobody checks your passport again. Every bar, every stage, every backstage door just glances at the wristband.</p>
+          </div>
+          <div class="pattern-card" style="border-top: 3px solid var(--color-actor-3)">
+            <div class="pattern-icon" style="background: var(--color-actor-3)">⏳</div>
+            <h4 class="pattern-title">Tamper-Evident, and It Expires</h4>
+            <p class="pattern-desc">You can't peel it off and hand it to a friend without it showing. And it stops working at the end of the weekend.</p>
+          </div>
+        </div>
+
+        <p>The gate is the sign-in flow. The wristband is a
+          <span class="term" data-definition="A session is the record of you being recognized as logged-in, kept alive as you move around a site or app without having to prove yourself again on every page.">session</span> —
+          a signed
+          <span class="term" data-definition="A cookie is a small piece of data a website asks your Browser to store, which the Browser then automatically sends back on every later visit to that site.">cookie</span>
+          holding a signed
+          <span class="term" data-definition="A token is a piece of data that proves a fact — like who you are — in a way that's very hard to fake, usually because it's digitally signed with a secret key only the server knows.">token</span>.
+          "Show me your wristband" is <code>getUserUuid()</code>.
+        </p>
+
+        <div class="callout callout-accent">
+          <div class="callout-icon">💡</div>
+          <div class="callout-content">
+            <strong class="callout-title">Key Insight</strong>
+            <p><span class="term" data-definition="Authentication is the act of proving who you are — showing ID at the gate, not showing a ticket.">Authenticating</span> you is expensive and happens <em>once</em>. Remembering who you are is cheap and happens on <em>every single request</em>. That's different from <span class="term" data-definition="Authorisation is deciding what someone who's already proven who they are is allowed to do — like a wristband color deciding which backstage areas you can enter.">authorisation</span>, which comes after. Confusing these jobs is where most auth bugs come from — and this app never stores your Google password. It never even sees it.</p>
+          </div>
+        </div>
+      </section>
+
+      <!-- SCREEN 2: Three doors into the same building -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">Three Doors Into the Same Building</h2>
+        <p>The app offers several ways to prove who you are. Every one of them is a different door — but they all lead into the same room.</p>
+
+        <div class="pattern-cards">
+          <div class="pattern-card" style="border-top: 3px solid var(--color-actor-4)">
+            <div class="pattern-icon" style="background: var(--color-actor-4)">G</div>
+            <h4 class="pattern-title">Google</h4>
+            <p class="pattern-desc">Standard <span class="term" data-definition="OAuth is a standard way for one app to let you log in through another service — like Google or GitHub — without ever handing your password to the first app.">OAuth</span> <span class="term" data-definition="A redirect is when a server tells your Browser to load a different page or site instead — like being pointed to a different queue.">redirect</span>. Your Browser leaves for Google and comes back.</p>
+          </div>
+          <div class="pattern-card" style="border-top: 3px solid var(--color-actor-3)">
+            <div class="pattern-icon" style="background: var(--color-actor-3)">🐙</div>
+            <h4 class="pattern-title">GitHub</h4>
+            <p class="pattern-desc">The same redirect pattern, for developers who'd rather use their GitHub account.</p>
+          </div>
+          <div class="pattern-card" style="border-top: 3px solid var(--color-actor-4)">
+            <div class="pattern-icon" style="background: var(--color-actor-4)">⚡</div>
+            <h4 class="pattern-title">Google One Tap</h4>
+            <p class="pattern-desc">The "Continue as…" bubble top-right. It hands over a token the server checks against Google's own <span class="term" data-definition="An endpoint is a specific address on a server designed to answer one particular kind of request — like a numbered counter at a service desk.">tokeninfo endpoint</span>.</p>
+          </div>
+          <div class="pattern-card" style="border-top: 3px solid var(--color-actor-5)">
+            <div class="pattern-icon" style="background: var(--color-actor-5)">🔑</div>
+            <h4 class="pattern-title">Email + Password</h4>
+            <p class="pattern-desc">Only switched on if enabled. The app <em>does</em> store something here — but only a scrambled fingerprint, never the actual password.</p>
+          </div>
+          <div class="pattern-card" style="border-top: 3px solid var(--color-accent)">
+            <div class="pattern-icon" style="background: var(--color-accent)">🧩</div>
+            <h4 class="pattern-title">API Key</h4>
+            <p class="pattern-desc">For developers calling the app by code, not by browser. A key that starts with <code>sk-</code>.</p>
+          </div>
+        </div>
+
+        <p>Here's the clever bit: none of these
+          <span class="term" data-definition="A provider is the outside service vouching for who you are during sign-in — Google, GitHub, or a plain email-and-password check.">providers</span>
+          are hard-coded "on". Each one only exists if the matching
+          <span class="term" data-definition="An environment variable is a setting stored outside your code — like a name tag stuck on the server — that changes how the app behaves without anyone editing the code itself.">environment variables</span>
+          are set. The list of sign-in buttons is literally computed from the server's configuration at startup.
+        </p>
+
+        <div class="translation-block animate-in">
+          <div class="translation-code">
+            <span class="translation-label">CODE</span>
+            <pre><code>
+<span class="code-line"><span class="code-comment">// Google Auth</span></span>
+<span class="code-line"><span class="code-keyword">if</span> (</span>
+<span class="code-line">  process.env.NEXT_PUBLIC_AUTH_GOOGLE_ENABLED === <span class="code-string">"true"</span> &&</span>
+<span class="code-line">  process.env.AUTH_GOOGLE_ID &&</span>
+<span class="code-line">  process.env.AUTH_GOOGLE_SECRET</span>
+<span class="code-line">) {</span>
+<span class="code-line">  providers.push(</span>
+<span class="code-line">    <span class="code-function">GoogleProvider</span>({</span>
+<span class="code-line">      <span class="code-property">clientId</span>: process.env.AUTH_GOOGLE_ID,</span>
+<span class="code-line">      <span class="code-property">clientSecret</span>: process.env.AUTH_GOOGLE_SECRET,</span>
+<span class="code-line">    })</span>
+<span class="code-line">  );</span>
+<span class="code-line">}</span>
+            </code></pre>
+          </div>
+          <div class="translation-english">
+            <span class="translation-label">PLAIN ENGLISH</span>
+            <div class="translation-lines">
+              <p class="tl">Just a label — this chunk of code is about the Google door.</p>
+              <p class="tl">Before doing anything, check three things: is Google sign-in switched on, and are both of Google's secret keys present?</p>
+              <p class="tl">If — and only if — all three checks pass, add Google to the list of sign-in buttons users will see.</p>
+              <p class="tl">Hand Google the two <span class="term" data-definition="Credentials are the pieces of information — like an ID and a secret key, or a username and password — used to prove identity.">credentials</span> it needs to verify people later: an ID and a secret.</p>
+              <p class="tl">Close everything up. Google is now one of the doors — but only because someone set those environment variables.</p>
+            </div>
+          </div>
+        </div>
+
+        <p>Every other provider follows this exact same if-it's-configured pattern:</p>
+        <div class="badge-list">
+          <div class="badge-item">
+            <code class="badge-code">NEXT_PUBLIC_AUTH_GOOGLE_ENABLED</code>
+            <span class="badge-desc">Master switch — must literally be "true" or the Google door doesn't exist</span>
+          </div>
+          <div class="badge-item">
+            <code class="badge-code">AUTH_GOOGLE_ID</code>
+            <span class="badge-desc">The public half of this app's Google credentials</span>
+          </div>
+          <div class="badge-item">
+            <code class="badge-code">AUTH_GOOGLE_SECRET</code>
+            <span class="badge-desc">The private half — miss either one and Google never makes it onto the list</span>
+          </div>
+        </div>
+      </section>
+
+      <!-- SCREEN 3: The gate — flow animation + wristband printed -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">The Gate: Watch a Sign-In Happen</h2>
+        <p>Follow one real click of "Sign in with Google" from the Browser all the way to a cookie sitting in your browser.</p>
+
+        <div class="flow-animation" data-steps='[
+          {"highlight":"flow-actor-1","label":"You click Sign in with Google."},
+          {"highlight":"flow-actor-1","label":"Browser redirects to Google. The app never sees your password.","packet":true,"from":"actor-1","to":"actor-2"},
+          {"highlight":"flow-actor-2","label":"Google verifies you and sends the Browser back with a signed proof.","packet":true,"from":"actor-2","to":"actor-1"},
+          {"highlight":"flow-actor-3","label":"The jwt callback fires on the Server.","packet":true,"from":"actor-1","to":"actor-3"},
+          {"highlight":"flow-actor-3","label":"Server asks the Database: seen this email before?","packet":true,"from":"actor-3","to":"actor-4"},
+          {"highlight":"flow-actor-4","label":"New user? Create a record and grant 30 free credits."},
+          {"highlight":"flow-actor-3","label":"Server packs uuid, email and nickname into a signed token."},
+          {"highlight":"flow-actor-3","label":"Token is stored as a cookie in your Browser. Every later request carries it automatically.","packet":true,"from":"actor-3","to":"actor-1"}
+        ]'>
+          <div class="flow-actors">
+            <div class="flow-actor" id="flow-actor-1">
+              <div class="flow-actor-icon" style="background: var(--color-actor-2)">🌐</div>
+              <span>Browser</span>
+            </div>
+            <div class="flow-actor" id="flow-actor-2">
+              <div class="flow-actor-icon" style="background: var(--color-actor-4)">G</div>
+              <span>Google</span>
+            </div>
+            <div class="flow-actor" id="flow-actor-3">
+              <div class="flow-actor-icon" style="background: var(--color-accent)">🖥️</div>
+              <span>Server</span>
+            </div>
+            <div class="flow-actor" id="flow-actor-4">
+              <div class="flow-actor-icon" style="background: var(--color-actor-3)">🗄️</div>
+              <span>Database</span>
+            </div>
+          </div>
+
+          <div class="flow-packet" id="flow-packet"></div>
+          <div class="flow-step-label" id="flow-label">Click "Next Step" to begin</div>
+
+          <div class="flow-controls">
+            <button class="btn flow-next-btn">Next Step</button>
+            <button class="btn flow-reset-btn">Restart</button>
+            <span class="flow-progress"></span>
+          </div>
+        </div>
+
+        <p>Step 4 is the hinge of the whole module — a
+          <span class="term" data-definition="A callback is a function you hand off to run automatically the moment something else finishes — like leaving your number so the host calls you the second your table is ready.">callback</span>
+          called <code>jwt</code>, short for
+          <span class="term" data-definition="JWT stands for JSON Web Token — a compact, signed token format many apps use to store session data like your user id, in a way that's tamper-evident.">JWT</span>,
+          that fires the instant sign-in succeeds. This is where the wristband gets printed.</p>
+
+        <div class="translation-block animate-in">
+          <div class="translation-code">
+            <span class="translation-label">CODE</span>
+            <pre><code>
+<span class="code-line">    <span class="code-keyword">async</span> <span class="code-function">jwt</span>({ token, user, account }) {</span>
+<span class="code-line">      <span class="code-comment">// Persist the OAuth access_token and or the user id to the token right after signin</span></span>
+<span class="code-line">      <span class="code-keyword">try</span> {</span>
+<span class="code-line">        <span class="code-keyword">if</span> (!user || !account) {</span>
+<span class="code-line">          <span class="code-keyword">return</span> token;</span>
+<span class="code-line">        }</span>
+<span class="code-line">&nbsp;</span>
+<span class="code-line">        <span class="code-keyword">const</span> userInfo = <span class="code-keyword">await</span> <span class="code-function">handleSignInUser</span>(user, account);</span>
+<span class="code-line">        <span class="code-keyword">if</span> (!userInfo) {</span>
+<span class="code-line">          <span class="code-keyword">throw new</span> Error(<span class="code-string">"save user failed"</span>);</span>
+<span class="code-line">        }</span>
+<span class="code-line">&nbsp;</span>
+<span class="code-line">        token.user = {</span>
+<span class="code-line">          <span class="code-property">uuid</span>: userInfo.uuid,</span>
+<span class="code-line">          <span class="code-property">email</span>: userInfo.email,</span>
+<span class="code-line">          <span class="code-property">nickname</span>: userInfo.nickname,</span>
+<span class="code-line">          <span class="code-property">avatar_url</span>: userInfo.avatar_url,</span>
+<span class="code-line">          <span class="code-property">created_at</span>: userInfo.created_at,</span>
+<span class="code-line">        };</span>
+<span class="code-line">&nbsp;</span>
+<span class="code-line">        <span class="code-keyword">return</span> token;</span>
+<span class="code-line">      } <span class="code-keyword">catch</span> (e) {</span>
+            </code></pre>
+          </div>
+          <div class="translation-english">
+            <span class="translation-label">PLAIN ENGLISH</span>
+            <div class="translation-lines">
+              <p class="tl">This function fires the moment someone signs in successfully — the wristband-printing machine turns on.</p>
+              <p class="tl">A note for future readers: this saves the sign-in info onto the token.</p>
+              <p class="tl">If there's no user or account info yet, hand back the token unchanged and stop here.</p>
+              <p class="tl">Call <code>handleSignInUser</code> to look up or create this person's account. If that fails, raise an error.</p>
+              <p class="tl">Stamp five facts onto the token: this person's <span class="term" data-definition="A UUID (Universally Unique Identifier) is a long random ID used to tell every user apart safely, without relying on something guessable like a number that counts up.">uuid</span>, email, nickname, avatar, and join date.</p>
+              <p class="tl">Hand back the freshly-stamped token. The wristband is printed.</p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- SCREEN 4: Your first 30 credits -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">Your First 30 Credits</h2>
+        <p>Inside <code>handleSignInUser</code> is where the app decides: have we met this email before, or not?</p>
+
+        <div class="translation-block animate-in">
+          <div class="translation-code">
+            <span class="translation-label">CODE</span>
+            <pre><code>
+<span class="code-line">    <span class="code-keyword">const</span> existUser = <span class="code-keyword">await</span> <span class="code-function">findUserByEmail</span>(user.email);</span>
+<span class="code-line">&nbsp;</span>
+<span class="code-line">    <span class="code-keyword">if</span> (!existUser) {</span>
+<span class="code-line">      <span class="code-comment">// user not exist, create a new user</span></span>
+<span class="code-line">      <span class="code-keyword">if</span> (!user.uuid) {</span>
+<span class="code-line">        user.uuid = <span class="code-function">getUuid</span>();</span>
+<span class="code-line">      }</span>
+<span class="code-line">&nbsp;</span>
+<span class="code-line">      console.log(<span class="code-string">"user to be inserted:"</span>, user);</span>
+<span class="code-line">&nbsp;</span>
+<span class="code-line">      <span class="code-keyword">const</span> dbUser = <span class="code-keyword">await</span> <span class="code-function">insertUser</span>(user <span class="code-keyword">as</span> <span class="code-keyword">typeof</span> users.$inferInsert);</span>
+<span class="code-line">&nbsp;</span>
+<span class="code-line">      <span class="code-comment">// increase credits for new user, expire in one year</span></span>
+<span class="code-line">      <span class="code-keyword">await</span> <span class="code-function">increaseCredits</span>({</span>
+<span class="code-line">        <span class="code-property">user_uuid</span>: user.uuid,</span>
+<span class="code-line">        <span class="code-property">trans_type</span>: CreditsTransType.NewUser,</span>
+<span class="code-line">        <span class="code-property">credits</span>: CreditsAmount.NewUserGet,</span>
+<span class="code-line">        <span class="code-property">expired_at</span>: <span class="code-function">getOneYearLaterTimestr</span>(),</span>
+<span class="code-line">      });</span>
+            </code></pre>
+          </div>
+          <div class="translation-english">
+            <span class="translation-label">PLAIN ENGLISH</span>
+            <div class="translation-lines">
+              <p class="tl">Ask the Database: does anyone already have this email?</p>
+              <p class="tl">If nobody does, this is a brand-new person — give them a fresh unique id if they don't already have one.</p>
+              <p class="tl">Log what's about to be saved, then insert a new
+                <span class="term" data-definition="A database record is a single saved entry in a database — like one card in a filing cabinet, with fields for name, email, and so on.">database record</span>
+                for them.
+              </p>
+              <p class="tl">Now the reward: hand this brand-new user free starting credits, set to expire exactly one year from today.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="pattern-cards">
+          <div class="pattern-card" style="border-top: 3px solid var(--color-success)">
+            <div class="pattern-icon" style="background: var(--color-success)">✨</div>
+            <h4 class="pattern-title">New Email</h4>
+            <p class="pattern-desc">Create the account, then grant 30 free credits, expiring in one year.</p>
+          </div>
+          <div class="pattern-card" style="border-top: 3px solid var(--color-info)">
+            <div class="pattern-icon" style="background: var(--color-info)">🔁</div>
+            <h4 class="pattern-title">Existing Email</h4>
+            <p class="pattern-desc">Just load their existing record. No new credits — they already have their history.</p>
+          </div>
+        </div>
+      </section>
+
+      <!-- SCREEN 5: Show me your wristband -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">Show Me Your Wristband</h2>
+        <p>Every protected action in the app starts with the same question, asked of the same function.</p>
+
+        <div class="translation-block animate-in">
+          <div class="translation-code">
+            <span class="translation-label">CODE</span>
+            <pre><code>
+<span class="code-line"><span class="code-keyword">export async function</span> <span class="code-function">getUserUuid</span>() {</span>
+<span class="code-line">  <span class="code-keyword">let</span> user_uuid = <span class="code-string">""</span>;</span>
+<span class="code-line">&nbsp;</span>
+<span class="code-line">  <span class="code-keyword">const</span> token = <span class="code-keyword">await</span> <span class="code-function">getBearerToken</span>();</span>
+<span class="code-line">&nbsp;</span>
+<span class="code-line">  <span class="code-keyword">if</span> (token) {</span>
+<span class="code-line">    <span class="code-comment">// api key</span></span>
+<span class="code-line">    <span class="code-keyword">if</span> (token.startsWith(<span class="code-string">"sk-"</span>)) {</span>
+<span class="code-line">      <span class="code-keyword">const</span> user_uuid = <span class="code-keyword">await</span> <span class="code-function">getUserUuidByApiKey</span>(token);</span>
+<span class="code-line">&nbsp;</span>
+<span class="code-line">      <span class="code-keyword">return</span> user_uuid || <span class="code-string">""</span>;</span>
+<span class="code-line">    }</span>
+<span class="code-line">  }</span>
+<span class="code-line">&nbsp;</span>
+<span class="code-line">  <span class="code-keyword">const</span> session = <span class="code-keyword">await</span> <span class="code-function">auth</span>();</span>
+<span class="code-line">  <span class="code-keyword">if</span> (session && session.user && session.user.uuid) {</span>
+<span class="code-line">    user_uuid = session.user.uuid;</span>
+<span class="code-line">  }</span>
+<span class="code-line">&nbsp;</span>
+<span class="code-line">  <span class="code-keyword">return</span> user_uuid;</span>
+<span class="code-line">}</span>
+            </code></pre>
+          </div>
+          <div class="translation-english">
+            <span class="translation-label">PLAIN ENGLISH</span>
+            <div class="translation-lines">
+              <p class="tl">Start by assuming this visitor is a guest: an empty id.</p>
+              <p class="tl">Check whether the request came with a
+                <span class="term" data-definition="A bearer token is a token that works like cash — whoever is holding it can use it, no extra proof of identity required.">bearer token</span>
+                instead of a cookie.
+              </p>
+              <p class="tl">If that token starts with <code>sk-</code>, it's a developer's
+                <span class="term" data-definition="An API key is a secret, password-like string that lets a program — not a person sitting at a keyboard — prove who it is when calling a service.">API key</span>. Look up whose it is and return that.
+              </p>
+              <p class="tl">Otherwise, ask NextAuth for the current
+                <span class="term" data-definition="Server-side means code that runs on the company's own computer, not in your browser — a visitor can't see it or tamper with it.">server-side</span>
+                session — the signed, verified wristband.
+              </p>
+              <p class="tl">If there's a valid session with a user id, use it.</p>
+              <p class="tl">Hand back whatever was found — a real id, or still just an empty string.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="callout callout-info">
+          <div class="callout-icon">🎫</div>
+          <div class="callout-content">
+            <strong class="callout-title">Being a Guest Isn't an Error</strong>
+            <p><code>getUserUuid()</code> never throws, never says "unauthorized". It just returns an empty string for a guest. That single design choice is <em>why</em> this app can let logged-out visitors generate images for free — a guest isn't a failure state, it's just another answer.</p>
+          </div>
+        </div>
+      </section>
+
+      <!-- SCREEN 6: The golden rule + spot the bug -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">The Golden Rule</h2>
+        <p><code>getUserUuid()</code> reads the session <strong>on the Server</strong>. The Browser sends the cookie; the Server checks its signature before believing a single word of it.</p>
+
+        <div class="callout callout-warning">
+          <div class="callout-icon">⚠️</div>
+          <div class="callout-content">
+            <strong class="callout-title">The Server Never Takes the Browser's Word</strong>
+            <p>An AI assistant will happily write
+              <span class="term" data-definition="Client-side means code that runs inside your own browser — fully visible and editable by anyone using dev tools, unlike code that runs privately on the server.">client-side</span>
+              code that reads <code>session.user.uuid</code> and sends it to the server as a plain parameter. Anyone can open dev tools and rewrite that value to someone else's id before it's sent. <strong>Rule: identity comes from the verified session, never from anything the Browser typed into a request.</strong> (Cookies can also be marked "secure", meaning they're only ever sent over <span class="term" data-definition="HTTPS is the secure, encrypted version of the web's HTTP protocol — the padlock icon you see in your browser's address bar.">HTTPS</span>, never plain, unencrypted HTTP.)</p>
+          </div>
+        </div>
+
+        <div class="bug-challenge">
+          <h3>Find the bug in this "download" button:</h3>
+          <div class="bug-code">
+            <div class="bug-line" data-line="1" onclick="checkBugLine(this, false)">
+              <span class="line-num">1</span>
+              <code>'use client';</code>
+            </div>
+            <div class="bug-line" data-line="2" onclick="checkBugLine(this, false)">
+              <span class="line-num">2</span>
+              <code>function DownloadButton({ imageId }) {</code>
+            </div>
+            <div class="bug-line" data-line="3" onclick="checkBugLine(this, false)">
+              <span class="line-num">3</span>
+              <code>&nbsp;&nbsp;const { data: session } = useSession();</code>
+            </div>
+            <div class="bug-line" data-line="4" onclick="checkBugLine(this, false)">
+              <span class="line-num">4</span>
+              <code>&nbsp;&nbsp;async function handleClick() {</code>
+            </div>
+            <div class="bug-line" data-line="5" onclick="checkBugLine(this, false)">
+              <span class="line-num">5</span>
+              <code>&nbsp;&nbsp;&nbsp;&nbsp;await fetch('/api/download', {</code>
+            </div>
+            <div class="bug-line" data-line="6" onclick="checkBugLine(this, false)">
+              <span class="line-num">6</span>
+              <code>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;method: 'POST',</code>
+            </div>
+            <div class="bug-line bug-target" data-line="7" onclick="checkBugLine(this, true)">
+              <span class="line-num">7</span>
+              <code>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;body: JSON.stringify({ user_uuid: session.user.uuid, imageId }),</code>
+            </div>
+            <div class="bug-line" data-line="8" onclick="checkBugLine(this, false)">
+              <span class="line-num">8</span>
+              <code>&nbsp;&nbsp;&nbsp;&nbsp;});</code>
+            </div>
+            <div class="bug-line" data-line="9" onclick="checkBugLine(this, false)">
+              <span class="line-num">9</span>
+              <code>&nbsp;&nbsp;}</code>
+            </div>
+            <div class="bug-line" data-line="10" onclick="checkBugLine(this, false)">
+              <span class="line-num">10</span>
+              <code>&nbsp;&nbsp;return &lt;button onClick={handleClick}&gt;Download&lt;/button&gt;;</code>
+            </div>
+            <div class="bug-line" data-line="11" onclick="checkBugLine(this, false)">
+              <span class="line-num">11</span>
+              <code>}</code>
+            </div>
+          </div>
+          <div class="bug-feedback" id="bug-feedback"></div>
+        </div>
+      </section>
+
+      <!-- SCREEN 7: hashes -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">A One-Way Blender</h2>
+        <p>Sign-in with a password is one of the doors — but the app never stores the password itself, only a
+          <span class="term" data-definition="A hash is a one-way scramble of data — easy to create from the original, but practically impossible to reverse back into it.">hash</span>.
+        </p>
+
+        <div class="translation-block animate-in">
+          <div class="translation-code">
+            <span class="translation-label">CODE</span>
+            <pre><code>
+<span class="code-line">          <span class="code-keyword">if</span> (!user || !user.password_hash) {</span>
+<span class="code-line">            <span class="code-keyword">return null</span>;</span>
+<span class="code-line">          }</span>
+<span class="code-line">&nbsp;</span>
+<span class="code-line">          <span class="code-comment">// Verify password</span></span>
+<span class="code-line">          <span class="code-keyword">const</span> isValidPassword = <span class="code-keyword">await</span> <span class="code-function">verifyPassword</span>(password, user.password_hash);</span>
+<span class="code-line">&nbsp;</span>
+<span class="code-line">          <span class="code-keyword">if</span> (!isValidPassword) {</span>
+<span class="code-line">            <span class="code-keyword">return null</span>;</span>
+<span class="code-line">          }</span>
+            </code></pre>
+          </div>
+          <div class="translation-english">
+            <span class="translation-label">PLAIN ENGLISH</span>
+            <div class="translation-lines">
+              <p class="tl">If there's no matching user, or they have no password hash on file, stop and return nothing.</p>
+              <p class="tl">Blend the password the visitor just typed and compare fingerprints against the one stored on file.</p>
+              <p class="tl">If the fingerprints don't match, stop and return nothing — the exact same response as "no such user".</p>
+            </div>
+          </div>
+        </div>
+
+        <p>You can turn "hunter2" into a fingerprint, but you can't turn the fingerprint back into "hunter2". Notice too: a wrong password and a non-existent account both return the same nothing — the app never tells an attacker which one it was. That's the opposite of storing passwords in
+          <span class="term" data-definition="Plain text means unencrypted, unscrambled data — readable by literally anyone who gets access to it, which is exactly what you never want a password to be.">plain text</span>, the classic disaster.
+        </p>
+      </section>
+
+      <!-- SCREEN 8: Quiz -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">Check Your Understanding</h2>
+        <p>Four scenarios. Think like the engineer who has to actually fix these.</p>
+
+        <div class="quiz-container" id="quiz-module3">
+
+          <div class="quiz-question-block"
+               data-correct="q1-a"
+               data-explanation-right="Exactly — getting signed out on every refresh is almost always a cookie problem: it's not being written, it's expiring immediately, or a secure-cookie setting is rejecting it over plain HTTP."
+               data-explanation-wrong="Not quite. Nothing about a Google account or the Database changes on a page refresh — but the cookie gets re-checked every single time. Start there.">
+            <h3 class="quiz-question">Users report they get signed out every time they refresh the page. Where do you look first?</h3>
+            <div class="quiz-options">
+              <button class="quiz-option" data-value="q1-a" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>The cookie/token setup — is it being set at all, expiring too fast, or blocked because it expects HTTPS on a plain-HTTP site?</span>
+              </button>
+              <button class="quiz-option" data-value="q1-b" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>Their Google account settings</span>
+              </button>
+              <button class="quiz-option" data-value="q1-c" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>The Database</span>
+              </button>
+            </div>
+            <div class="quiz-feedback"></div>
+          </div>
+
+          <div class="scenario-block">
+            <div class="scenario-context">
+              <span class="scenario-label">Scenario</span>
+              <p>An AI assistant writes a client component that reads <code>session.user.uuid</code> in the browser and sends it to the server as part of the request body, so the server can figure out whose data to touch.</p>
+            </div>
+            <div class="quiz-question-block"
+                 data-correct="q2-b"
+                 data-explanation-right="Exactly — the Browser is not a trusted narrator. Anyone can rewrite that request before it leaves their machine. The server must call getUserUuid() itself and read its own verified session — never take a visitor's word for who they are."
+                 data-explanation-wrong="Think about who controls the Browser. If a value the Browser sends decides whose data gets touched, anyone with dev tools can edit it and impersonate someone else.">
+              <h3 class="quiz-question">What is wrong with that approach?</h3>
+              <div class="quiz-options">
+                <button class="quiz-option" data-value="q2-a" onclick="selectOption(this)">
+                  <div class="quiz-option-radio"></div>
+                  <span>Nothing — the id came from their own session, so it's trustworthy</span>
+                </button>
+                <button class="quiz-option" data-value="q2-b" onclick="selectOption(this)">
+                  <div class="quiz-option-radio"></div>
+                  <span>Anyone can open dev tools and edit that value before it's sent, letting a visitor claim to be a different user</span>
+                </button>
+                <button class="quiz-option" data-value="q2-c" onclick="selectOption(this)">
+                  <div class="quiz-option-radio"></div>
+                  <span>It's a performance problem, not a security one</span>
+                </button>
+              </div>
+              <div class="quiz-feedback"></div>
+            </div>
+          </div>
+
+          <div class="quiz-question-block"
+               data-correct="q3-b"
+               data-explanation-right="Exactly — remember, every provider is wrapped in an if that checks its environment variables. Locally you had a .env file with those values; production is missing them, so the provider was silently never added to the list."
+               data-explanation-wrong="GitHub itself being down is very unlikely, and a working local setup rules out a code bug. What's different between your machine and production? Usually: environment variables.">
+            <h3 class="quiz-question">You add a "Sign in with GitHub" button, but nothing happens in production — even though it works fine locally. What's the most likely cause?</h3>
+            <div class="quiz-options">
+              <button class="quiz-option" data-value="q3-a" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>GitHub's servers are down</span>
+              </button>
+              <button class="quiz-option" data-value="q3-b" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>The environment variables gating that provider aren't set on the production server, so it was never added to the list</span>
+              </button>
+              <button class="quiz-option" data-value="q3-c" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>The Database isn't connected</span>
+              </button>
+            </div>
+            <div class="quiz-feedback"></div>
+          </div>
+
+          <div class="quiz-question-block"
+               data-correct="q4-b"
+               data-explanation-right="Exactly — if sign-in fully works, the jwt callback and the Database connection are clearly fine. The credit grant only happens inside the branch that runs for brand-new emails, so it most likely never ran for them."
+               data-explanation-wrong="If sign-in works end to end, the jwt callback and the Database are both clearly fine. The credit grant is one specific branch inside that flow — think about what could make the app believe they weren't actually new.">
+            <h3 class="quiz-question">New signups aren't receiving their 30 free credits, but they <em>can</em> sign in just fine. Which step most likely failed?</h3>
+            <div class="quiz-options">
+              <button class="quiz-option" data-value="q4-a" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>The jwt callback isn't firing at all</span>
+              </button>
+              <button class="quiz-option" data-value="q4-b" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>The branch that only runs for brand-new emails — maybe they'd already signed up under a different provider, so the app treated them as returning</span>
+              </button>
+              <button class="quiz-option" data-value="q4-c" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>The Database is offline</span>
+              </button>
+            </div>
+            <div class="quiz-feedback"></div>
+          </div>
+
+          <button class="quiz-check-btn" onclick="checkQuiz('quiz-module3')">Check Answers</button>
+          <button class="quiz-reset-btn" onclick="resetQuiz('quiz-module3')">Try Again</button>
+        </div>
+
+        <p>New users get 30 credits. An image costs 10. So what happens on the fourth one? That's a payment question — and payments have a plot twist.</p>
+      </section>
+
+    </div>
+  </div>
+</section>

--- a/courses/general-course/modules/04-following-the-money.html
+++ b/courses/general-course/modules/04-following-the-money.html
@@ -1,0 +1,664 @@
+<section class="module" id="module-4" style="background: var(--color-bg)">
+  <div class="module-content">
+    <header class="module-header animate-in">
+      <span class="module-number">04</span>
+      <h1 class="module-title">Following the Money</h1>
+      <p class="module-subtitle">Thirty free credits, ten per image — so the fourth image is where this app has to become a business. The way it handles money is quietly the most carefully-built part of the whole codebase.</p>
+    </header>
+
+    <div class="module-body">
+
+      <!-- SCREEN 1: The chequebook register -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">There Is No Balance</h2>
+        <p>Last module ended on a cliffhanger: new accounts get 30 credits, an image costs 10, so what happens on the fourth one? The honest answer is that you run out — and the app has to know that with total certainty.</p>
+
+        <p>Picture the paper stub in the back of an old chequebook. One line per transaction: date, description, <em>+£200</em> or <em>−£35</em>. The rule that makes it trustworthy is this: <strong>you never rub out the balance and write a new one.</strong> You only ever add a line.</p>
+
+        <div class="badge-list">
+          <div class="badge-item">
+            <code class="badge-code">+30</code>
+            <span class="badge-desc"><strong>new_user</strong> — signed up on 3 March. Expires in one year.</span>
+          </div>
+          <div class="badge-item">
+            <code class="badge-code">−10</code>
+            <span class="badge-desc"><strong>image_generation</strong> — first cartoon</span>
+          </div>
+          <div class="badge-item">
+            <code class="badge-code">−10</code>
+            <span class="badge-desc"><strong>image_generation</strong> — second cartoon</span>
+          </div>
+          <div class="badge-item">
+            <code class="badge-code">+1000</code>
+            <span class="badge-desc"><strong>order_pay</strong> — bought the Premium plan, order #7429</span>
+          </div>
+          <div class="badge-item">
+            <code class="badge-code">−10</code>
+            <span class="badge-desc"><strong>image_generation</strong> — third cartoon</span>
+          </div>
+        </div>
+
+        <p>That list is a real
+          <span class="term" data-definition="A database table is a grid of saved information — columns for the kinds of fact you store, and one row for each thing you have stored. Think of a spreadsheet the app can search instantly.">table</span>
+          in this app&apos;s database, called <code>credits</code>. Look at the columns it does <em>not</em> have: there is no column called <code>balance</code> anywhere. Your balance is not a number the app keeps — it is the sum of those
+          <span class="term" data-definition="A row is one single entry in a database table — one line in the ledger, one card in the filing cabinet.">rows</span>, added up fresh every time anyone asks.</p>
+
+        <div class="callout callout-accent">
+          <div class="callout-icon">💡</div>
+          <div class="callout-content">
+            <strong class="callout-title">Never Overwrite a Balance. Always Append a Line.</strong>
+            <p>Engineers call this an <span class="term" data-definition="An append-only ledger is a record where you can add new entries but never edit or delete old ones — like a chequebook stub or a bank statement. The current total is worked out by adding everything up.">append-only ledger</span>, and it is one of the most valuable instructions you can give an AI assistant. Ask for &quot;add credits&quot; and you will almost certainly get <code>UPDATE users SET credits = credits - 10</code> — a single number being overwritten. That works right up until two requests land at the same moment, or a customer asks where their credits went, and then there is nothing to look at.</p>
+          </div>
+        </div>
+      </section>
+
+      <!-- SCREEN 2: The price never comes from the browser -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">Buying: The Price Does Not Come From You</h2>
+        <p>When you click a plan on the pricing page, your Browser sends the Server a small package of information — a
+          <span class="term" data-definition="POST is one of the standard kinds of web request. A GET request asks for something; a POST request sends something to the server, like a form or an order.">POST</span>
+          request carrying three things: which product, which currency, which language.</p>
+
+        <div class="pattern-cards">
+          <div class="pattern-card" style="border-top: 3px solid var(--color-actor-2)">
+            <div class="pattern-icon" style="background: var(--color-actor-2)">🏷️</div>
+            <h4 class="pattern-title">product_id</h4>
+            <p class="pattern-desc">Which plan you clicked. Just a name, like <code>premium</code>.</p>
+          </div>
+          <div class="pattern-card" style="border-top: 3px solid var(--color-actor-4)">
+            <div class="pattern-icon" style="background: var(--color-actor-4)">💱</div>
+            <h4 class="pattern-title">currency</h4>
+            <p class="pattern-desc">Dollars or yuan — which price list to read from.</p>
+          </div>
+          <div class="pattern-card" style="border-top: 3px solid var(--color-actor-3)">
+            <div class="pattern-icon" style="background: var(--color-actor-3)">🌍</div>
+            <h4 class="pattern-title">locale</h4>
+            <p class="pattern-desc">Which language you are browsing in.</p>
+          </div>
+          <div class="pattern-card" style="border-top: 3px solid var(--color-error)">
+            <div class="pattern-icon" style="background: var(--color-error)">🚫</div>
+            <h4 class="pattern-title">the price</h4>
+            <p class="pattern-desc"><strong>Not sent.</strong> Not now, not ever. The Server looks it up itself.</p>
+          </div>
+        </div>
+
+        <div class="translation-block animate-in">
+          <div class="translation-code">
+            <span class="translation-label">CODE</span>
+            <pre><code>
+<span class="code-line">    <span class="code-comment">// validate checkout params</span></span>
+<span class="code-line">    <span class="code-keyword">const</span> page = <span class="code-keyword">await</span> <span class="code-function">getPricingPage</span>(locale);</span>
+<span class="code-line">    <span class="code-keyword">if</span> (!page || !page.pricing || !page.pricing.items) {</span>
+<span class="code-line">      <span class="code-keyword">return</span> <span class="code-function">respErr</span>(<span class="code-string">"invalid pricing table"</span>);</span>
+<span class="code-line">    }</span>
+<span class="code-line">&nbsp;</span>
+<span class="code-line">    <span class="code-keyword">const</span> item = page.pricing.items.<span class="code-function">find</span>(</span>
+<span class="code-line">      (item: PricingItem) =&gt; item.product_id === product_id</span>
+<span class="code-line">    );</span>
+<span class="code-line">&nbsp;</span>
+<span class="code-line">    <span class="code-keyword">if</span> (!item || !item.amount || !item.interval || !item.currency) {</span>
+<span class="code-line">      <span class="code-keyword">return</span> <span class="code-function">respErr</span>(<span class="code-string">"invalid checkout params"</span>);</span>
+<span class="code-line">    }</span>
+            </code></pre>
+          </div>
+          <div class="translation-english">
+            <span class="translation-label">PLAIN ENGLISH</span>
+            <div class="translation-lines">
+              <p class="tl">A note for future readers: we are about to check that this order makes sense.</p>
+              <p class="tl">Load the Server&apos;s own price list for this language. Not the Browser&apos;s copy — the real one.</p>
+              <p class="tl">If the price list is missing or empty, stop immediately and say so. Never guess.</p>
+              <p class="tl">Search that list for the plan the visitor clicked, matching on its name.</p>
+              <p class="tl">If there is no such plan, or it has no price, no billing period or no currency, refuse the whole request.</p>
+              <p class="tl">Everything after this point uses <code>item.amount</code> — a number that came from the Server&apos;s own files, and never from you.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="callout callout-warning">
+          <div class="callout-icon">⚠️</div>
+          <div class="callout-content">
+            <strong class="callout-title">Never Trust the Client With Anything That Matters</strong>
+            <p>If the price arrived in the request, anyone could open dev tools, change <code>amount</code> to <code>1</code>, and buy the $99 plan for one
+              <span class="term" data-definition="Prices in payment systems are almost always stored in the smallest unit of the currency — cents rather than dollars — because whole numbers avoid the tiny rounding errors that decimals introduce.">cent</span>.
+              The rule generalises far beyond money: the Browser is a place your code runs, not a source of truth. Anything the Server decides must be looked up by the Server.</p>
+          </div>
+        </div>
+      </section>
+
+      <!-- SCREEN 3: The plot twist — webhooks -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">The Plot Twist: Nobody Tells the Server You Paid</h2>
+        <p>The Server creates an <strong>order</strong> row with status <code>created</code>, asks
+          <span class="term" data-definition="Stripe is a company that handles card payments for other businesses. Your app hands the customer over to Stripe, Stripe takes the money, and your app never touches the card details.">Stripe</span>
+          for a payment page, and sends your Browser there. Your card details never touch this app&apos;s servers.</p>
+
+        <p>Then you pay, and Stripe
+          <span class="term" data-definition="A redirect is when one site tells your browser to go and load a different page instead — like being handed a slip of paper and pointed at a different counter.">redirects</span>
+          you back. Here is the part that surprises everyone: <strong>that redirect is not proof of payment.</strong> Anyone could type that return address into their browser bar.</p>
+
+        <p>So Stripe does something separate. Its own servers make a request to <em>your</em> server, at a special address, saying &quot;this actually happened&quot;. That call-back-when-it-is-real message is a
+          <span class="term" data-definition="A webhook is a message one service sends to your server, unprompted, when something happens — like a delivery firm phoning you when the parcel is actually delivered, instead of you standing at the door guessing.">webhook</span>.</p>
+
+        <div class="callout callout-info">
+          <div class="callout-icon">📦</div>
+          <div class="callout-content">
+            <strong class="callout-title">The Delivery Firm Phones You Back</strong>
+            <p>You do not stand at the door guessing whether the parcel arrived. The courier rings you when it is actually delivered. The customer walking back through your door is a hopeful sign; the courier&apos;s phone call is the fact.</p>
+          </div>
+        </div>
+
+        <p>Watch the whole conversation happen. Three participants, and one of them speaks up without being asked.</p>
+
+        <div class="chat-window" id="chat-module4">
+          <div class="chat-messages">
+            <div class="chat-message" data-msg="0" data-sender="browser" style="display:none">
+              <div class="chat-avatar" style="background: var(--color-actor-2)">🌐</div>
+              <div class="chat-bubble">
+                <span class="chat-sender" style="color: var(--color-actor-2)">Browser</span>
+                <p>Hi — I would like the Premium plan, please. In dollars, in English.</p>
+              </div>
+            </div>
+            <div class="chat-message" data-msg="1" data-sender="server" style="display:none">
+              <div class="chat-avatar" style="background: var(--color-accent)">🖥️</div>
+              <div class="chat-bubble">
+                <span class="chat-sender" style="color: var(--color-accent)">Server</span>
+                <p>Let me look up what Premium actually costs. I am not taking your word for it.</p>
+              </div>
+            </div>
+            <div class="chat-message" data-msg="2" data-sender="server" style="display:none">
+              <div class="chat-avatar" style="background: var(--color-accent)">🖥️</div>
+              <div class="chat-bubble">
+                <span class="chat-sender" style="color: var(--color-accent)">Server</span>
+                <p>$0.99. Creating order <strong>#7429</strong>, status: <code>created</code>. Nobody has paid anything yet.</p>
+              </div>
+            </div>
+            <div class="chat-message" data-msg="3" data-sender="server" style="display:none">
+              <div class="chat-avatar" style="background: var(--color-accent)">🖥️</div>
+              <div class="chat-bubble">
+                <span class="chat-sender" style="color: var(--color-accent)">Server</span>
+                <p>Stripe — set me up a checkout for $0.99, and tag it with order 7429 so I know which one it was.</p>
+              </div>
+            </div>
+            <div class="chat-message" data-msg="4" data-sender="stripe" style="display:none">
+              <div class="chat-avatar" style="background: var(--color-actor-3)">💳</div>
+              <div class="chat-bubble">
+                <span class="chat-sender" style="color: var(--color-actor-3)">Stripe</span>
+                <p>Done. Here is a payment page. Send them over to me.</p>
+              </div>
+            </div>
+            <div class="chat-message" data-msg="5" data-sender="browser" style="display:none">
+              <div class="chat-avatar" style="background: var(--color-actor-2)">🌐</div>
+              <div class="chat-bubble">
+                <span class="chat-sender" style="color: var(--color-actor-2)">Browser</span>
+                <p><em>pays on Stripe&apos;s page — the Server never sees the card</em></p>
+              </div>
+            </div>
+            <div class="chat-message" data-msg="6" data-sender="stripe" style="display:none">
+              <div class="chat-avatar" style="background: var(--color-actor-3)">💳</div>
+              <div class="chat-bubble">
+                <span class="chat-sender" style="color: var(--color-actor-3)">Stripe</span>
+                <p>📩 <code>checkout.session.completed</code> for order 7429. Signed, so you can prove it came from me.</p>
+              </div>
+            </div>
+            <div class="chat-message" data-msg="7" data-sender="server" style="display:none">
+              <div class="chat-avatar" style="background: var(--color-accent)">🖥️</div>
+              <div class="chat-bubble">
+                <span class="chat-sender" style="color: var(--color-accent)">Server</span>
+                <p>Signature checks out. Order 7429 was <code>created</code> → now <code>paid</code>. Writing a <strong>+1000</strong> line in the ledger.</p>
+              </div>
+            </div>
+            <div class="chat-message" data-msg="8" data-sender="stripe" style="display:none">
+              <div class="chat-avatar" style="background: var(--color-actor-3)">💳</div>
+              <div class="chat-bubble">
+                <span class="chat-sender" style="color: var(--color-actor-3)">Stripe</span>
+                <p>📩 <code>checkout.session.completed</code> for order 7429.</p>
+              </div>
+            </div>
+            <div class="chat-message" data-msg="9" data-sender="server" style="display:none">
+              <div class="chat-avatar" style="background: var(--color-accent)">🖥️</div>
+              <div class="chat-bubble">
+                <span class="chat-sender" style="color: var(--color-accent)">Server</span>
+                <p>Already paid. Ignoring. 🙂</p>
+              </div>
+            </div>
+          </div>
+
+          <div class="chat-typing" id="chat-module4-typing" style="display:none">
+            <div class="chat-avatar" id="chat-module4-typing-avatar">?</div>
+            <div class="chat-typing-dots">
+              <span class="typing-dot"></span>
+              <span class="typing-dot"></span>
+              <span class="typing-dot"></span>
+            </div>
+          </div>
+
+          <div class="chat-controls">
+            <button class="btn chat-next-btn">Next Message</button>
+            <button class="btn chat-all-btn">Play All</button>
+            <button class="btn chat-reset-btn">Replay</button>
+            <span class="chat-progress"></span>
+          </div>
+        </div>
+
+        <p>Two things in that conversation are worth pulling apart. First, how the Server knows the message really came from Stripe. Second, that last exchange — Stripe said the same thing twice.</p>
+      </section>
+
+      <!-- SCREEN 4: Verifying the signature -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">Proving Who Sent It</h2>
+        <p>The webhook address is a public address on the internet. Anyone can send a message to it claiming a payment succeeded — so every message arrives with a
+          <span class="term" data-definition="A cryptographic signature is a scrambled fingerprint of a message, made using a secret only the sender and receiver know. If even one character of the message changes, the fingerprint stops matching — so it proves both who sent it and that nobody edited it in transit.">cryptographic signature</span>
+          attached, and the Server refuses to believe anything it cannot verify.</p>
+
+        <div class="translation-block animate-in">
+          <div class="translation-code">
+            <span class="translation-label">CODE</span>
+            <pre><code>
+<span class="code-line">    <span class="code-keyword">const</span> sign = req.headers.<span class="code-function">get</span>(<span class="code-string">"stripe-signature"</span>) <span class="code-keyword">as</span> string;</span>
+<span class="code-line">    <span class="code-keyword">const</span> body = <span class="code-keyword">await</span> req.<span class="code-function">text</span>();</span>
+<span class="code-line">    <span class="code-keyword">if</span> (!sign || !body) {</span>
+<span class="code-line">      <span class="code-keyword">throw new</span> Error(<span class="code-string">"invalid notify data"</span>);</span>
+<span class="code-line">    }</span>
+<span class="code-line">&nbsp;</span>
+<span class="code-line">    <span class="code-keyword">const</span> event = <span class="code-keyword">await</span> stripe.webhooks.<span class="code-function">constructEventAsync</span>(</span>
+<span class="code-line">      body,</span>
+<span class="code-line">      sign,</span>
+<span class="code-line">      stripeWebhookSecret</span>
+<span class="code-line">    );</span>
+<span class="code-line">&nbsp;</span>
+<span class="code-line">    console.<span class="code-function">log</span>(<span class="code-string">"stripe notify event: "</span>, event);</span>
+<span class="code-line">&nbsp;</span>
+<span class="code-line">    <span class="code-keyword">switch</span> (event.type) {</span>
+<span class="code-line">      <span class="code-keyword">case</span> <span class="code-string">"checkout.session.completed"</span>: {</span>
+<span class="code-line">        <span class="code-comment">// get checkout session</span></span>
+<span class="code-line">        <span class="code-keyword">const</span> session = event.data.object;</span>
+<span class="code-line">        <span class="code-keyword">await</span> <span class="code-function">handleCheckoutSession</span>(stripe, session);</span>
+<span class="code-line">        <span class="code-keyword">break</span>;</span>
+<span class="code-line">      }</span>
+            </code></pre>
+          </div>
+          <div class="translation-english">
+            <span class="translation-label">PLAIN ENGLISH</span>
+            <div class="translation-lines">
+              <p class="tl">Pull the signature Stripe attached to this message, and the raw text of the message itself.</p>
+              <p class="tl">If either one is missing, stop right here — this is not a message worth reading.</p>
+              <p class="tl">Hand all three to Stripe&apos;s own checking function: the message, the signature, and a shared secret only Stripe and this Server know.</p>
+              <p class="tl">If the fingerprint does not match, this line fails and nothing below it ever runs. A forged message dies here.</p>
+              <p class="tl">Write the verified message into the log, so there is a record if anyone needs to reconstruct what happened.</p>
+              <p class="tl">Stripe sends many kinds of message. Look at which kind this is and pick the matching branch.</p>
+              <p class="tl">If it is &quot;the customer finished checking out&quot;, pull out the details and go do the actual work of marking the order paid.</p>
+            </div>
+          </div>
+        </div>
+
+        <p>Notice where <code>stripeWebhookSecret</code> comes from: an
+          <span class="term" data-definition="An environment variable is a setting stored outside your code — like a name tag stuck on the server — that changes how the app behaves without anyone editing the code itself. Secrets live here, never in the code.">environment variable</span>
+          set on the server, never written into the code. If that secret is wrong, every real payment message gets rejected — and that is a very common launch-day bug.</p>
+      </section>
+
+      <!-- SCREEN 5: Idempotency -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">Safe to Do Twice</h2>
+        <p>Stripe will sometimes send the same webhook more than once. That is deliberate: if a network blip means the first message was not acknowledged, sending it again is far better than losing a payment.</p>
+
+        <p>Which puts the burden on your side. The code has to be safe to run twice — a property with a name worth learning:
+          <span class="term" data-definition="Idempotent means doing something twice has exactly the same result as doing it once. Pressing a lift call button five times is idempotent; pressing a vending machine button five times is not.">idempotent</span>.
+          Say that word to an AI assistant and the payment code you get back is immediately better.</p>
+
+        <div class="translation-block animate-in">
+          <div class="translation-code">
+            <span class="translation-label">CODE</span>
+            <pre><code>
+<span class="code-line">    <span class="code-comment">// order already paied</span></span>
+<span class="code-line">    <span class="code-keyword">if</span> (order.status === OrderStatus.Paid) {</span>
+<span class="code-line">      <span class="code-keyword">return</span>;</span>
+<span class="code-line">    }</span>
+<span class="code-line">&nbsp;</span>
+<span class="code-line">    <span class="code-comment">// only update order status from created to paid</span></span>
+<span class="code-line">    <span class="code-keyword">if</span> (order.status !== OrderStatus.Created) {</span>
+<span class="code-line">      <span class="code-keyword">throw new</span> Error(<span class="code-string">"invalid order status"</span>);</span>
+<span class="code-line">    }</span>
+<span class="code-line">&nbsp;</span>
+<span class="code-line">    <span class="code-keyword">const</span> paid_at = <span class="code-function">getIsoTimestr</span>();</span>
+<span class="code-line">    <span class="code-keyword">await</span> <span class="code-function">updateOrderStatus</span>(</span>
+<span class="code-line">      order_no,</span>
+<span class="code-line">      OrderStatus.Paid,</span>
+<span class="code-line">      paid_at,</span>
+<span class="code-line">      paid_email,</span>
+<span class="code-line">      paid_detail</span>
+<span class="code-line">    );</span>
+<span class="code-line">&nbsp;</span>
+<span class="code-line">    <span class="code-keyword">if</span> (order.user_uuid) {</span>
+<span class="code-line">      <span class="code-keyword">if</span> (order.credits &gt; 0) {</span>
+<span class="code-line">        <span class="code-comment">// increase credits for paied order</span></span>
+<span class="code-line">        <span class="code-keyword">await</span> <span class="code-function">updateCreditForOrder</span>(order <span class="code-keyword">as</span> unknown <span class="code-keyword">as</span> Order);</span>
+<span class="code-line">      }</span>
+            </code></pre>
+          </div>
+          <div class="translation-english">
+            <span class="translation-label">PLAIN ENGLISH</span>
+            <div class="translation-lines">
+              <p class="tl">A note from whoever wrote this — with a typo in it, because real codebases have typos.</p>
+              <p class="tl"><strong>Guard one:</strong> if this order is already marked paid, quietly stop. No error, no fuss, no second helping of credits.</p>
+              <p class="tl">If the order is in some other unexpected state — cancelled, say — that is a genuine problem, so raise a loud error instead of continuing.</p>
+              <p class="tl">Record the exact moment of payment.</p>
+              <p class="tl">Flip the order from <code>created</code> to <code>paid</code>, storing who paid and Stripe&apos;s full record of it alongside.</p>
+              <p class="tl">Only if this order belongs to a signed-in account, and only if it actually bought credits…</p>
+              <p class="tl">…add the credits. Which has a guard of its own.</p>
+            </div>
+          </div>
+        </div>
+
+        <p>That second guard lives in the credit service, and it is even simpler: before writing the <code>+1000</code> line, look for a line that already carries this order number.</p>
+
+        <div class="badge-list">
+          <div class="badge-item">
+            <code class="badge-code">order.status === Paid</code>
+            <span class="badge-desc">Guard one — the order itself remembers it was already settled</span>
+          </div>
+          <div class="badge-item">
+            <code class="badge-code">findCreditByOrderNo</code>
+            <span class="badge-desc">Guard two — the ledger already has a line tagged with this order number, so stop</span>
+          </div>
+        </div>
+
+        <p>Two independent guards for the same mistake. That is not paranoia; that is what code touching money should look like.</p>
+      </section>
+
+      <!-- SCREEN 6: Spending — the ledger in motion -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">Spending Is Just a Minus Sign</h2>
+        <p>Generating an image spends 10 credits. Here is the entire mechanism for that — and the whole idea of the module is hiding on one line.</p>
+
+        <div class="translation-block animate-in">
+          <div class="translation-code">
+            <span class="translation-label">CODE</span>
+            <pre><code>
+<span class="code-line">    <span class="code-keyword">const</span> new_credit: <span class="code-keyword">typeof</span> creditsTable.$inferInsert = {</span>
+<span class="code-line">      <span class="code-property">trans_no</span>: <span class="code-function">getSnowId</span>(),</span>
+<span class="code-line">      <span class="code-property">created_at</span>: <span class="code-keyword">new</span> <span class="code-function">Date</span>(<span class="code-function">getIsoTimestr</span>()),</span>
+<span class="code-line">      <span class="code-property">expired_at</span>: <span class="code-keyword">new</span> <span class="code-function">Date</span>(expired_at),</span>
+<span class="code-line">      <span class="code-property">user_uuid</span>: user_uuid,</span>
+<span class="code-line">      <span class="code-property">trans_type</span>: trans_type,</span>
+<span class="code-line">      <span class="code-property">credits</span>: <span class="code-number">0</span> - credits,</span>
+<span class="code-line">      <span class="code-property">order_no</span>: order_no,</span>
+<span class="code-line">    };</span>
+<span class="code-line">    <span class="code-keyword">await</span> <span class="code-function">insertCredit</span>(new_credit);</span>
+            </code></pre>
+          </div>
+          <div class="translation-english">
+            <span class="translation-label">PLAIN ENGLISH</span>
+            <div class="translation-lines">
+              <p class="tl">Build one new ledger line, ready to be written.</p>
+              <p class="tl">Give it a unique reference number of its own, so this exact
+                <span class="term" data-definition="A transaction here means one single movement of value — one line in the ledger. Every grant and every spend is its own transaction with its own reference number.">transaction</span>
+                can always be pointed at.</p>
+              <p class="tl">Stamp it with right now, and with the date it stops counting.</p>
+              <p class="tl">Record whose it is, and what kind of movement it was — a purchase, a signup gift, an image generation.</p>
+              <p class="tl"><strong>Here it is.</strong> Zero minus the amount. That single minus sign is the entire spending mechanism — a spend is just a grant with the sign flipped.</p>
+              <p class="tl">Note which order it relates to, if any.</p>
+              <p class="tl">Write the line. Nothing else in the database changes. Nothing is overwritten.</p>
+            </div>
+          </div>
+        </div>
+
+        <p>And when the app needs your balance, it does exactly what you would do with a chequebook stub: adds the lines up.</p>
+
+        <div class="translation-block animate-in">
+          <div class="translation-code">
+            <span class="translation-label">CODE</span>
+            <pre><code>
+<span class="code-line">    <span class="code-comment">// Get only valid credits for current balance</span></span>
+<span class="code-line">    <span class="code-keyword">const</span> validCredits = <span class="code-keyword">await</span> <span class="code-function">getUserValidCredits</span>(user_uuid);</span>
+<span class="code-line">    <span class="code-keyword">if</span> (validCredits) {</span>
+<span class="code-line">      validCredits.<span class="code-function">forEach</span>((v) =&gt; {</span>
+<span class="code-line">        user_credits.left_credits += v.credits || <span class="code-number">0</span>;</span>
+<span class="code-line">      });</span>
+<span class="code-line">    }</span>
+            </code></pre>
+          </div>
+          <div class="translation-english">
+            <span class="translation-label">PLAIN ENGLISH</span>
+            <div class="translation-lines">
+              <p class="tl">Ask the Database for this person&apos;s ledger lines — but only the ones that have not expired.</p>
+              <p class="tl">If there are any, walk through them one at a time.</p>
+              <p class="tl">Add each line&apos;s number to a running total. The plus rows push it up, the minus rows pull it down.</p>
+              <p class="tl">Whatever the total ends up being <em>is</em> the balance. It was worked out just now and will be thrown away again immediately.</p>
+            </div>
+          </div>
+        </div>
+
+        <p>Step through it once and watch the balance appear out of nowhere at the end.</p>
+
+        <div class="flow-animation" data-steps='[
+          {"highlight":"flow-actor-4-1","label":"Day one: you sign in. A line is written — plus 30, type new_user, expiring in a year."},
+          {"highlight":"flow-actor-4-2","label":"You generate a cartoon. A NEW line is written: minus 10. The plus-30 line is not touched."},
+          {"highlight":"flow-actor-4-3","label":"Another cartoon, another line: minus 10. Two separate lines, not one number edited twice."},
+          {"highlight":"flow-actor-4-4","label":"You buy the Premium plan. Stripe confirms by webhook, so a line is written: plus 1000, tagged with order 7429."},
+          {"highlight":"flow-actor-4-5","label":"Another cartoon: minus 10. Five lines now, and still no balance stored anywhere."},
+          {"highlight":"flow-actor-4-6","label":"Now the app needs your balance. It has to go and work it out.","packet":true,"from":"actor-4-1","to":"actor-4-6"},
+          {"highlight":"flow-actor-4-6","label":"Plus 30, minus 10 — running total 20.","packet":true,"from":"actor-4-2","to":"actor-4-6"},
+          {"highlight":"flow-actor-4-6","label":"Minus 10 again — running total 10.","packet":true,"from":"actor-4-3","to":"actor-4-6"},
+          {"highlight":"flow-actor-4-6","label":"Plus 1000 from the purchase — running total 1010.","packet":true,"from":"actor-4-4","to":"actor-4-6"},
+          {"highlight":"flow-actor-4-6","label":"Minus 10 for the last cartoon — running total 1000.","packet":true,"from":"actor-4-5","to":"actor-4-6"},
+          {"highlight":"flow-actor-4-6","label":"Balance: 1000 credits. Calculated from the lines, never stored. Expired lines were left out entirely."}
+        ]'>
+          <div class="flow-actors">
+            <div class="flow-actor" id="flow-actor-4-1">
+              <div class="flow-actor-icon" style="background: var(--color-success)">+30</div>
+              <span>new_user</span>
+            </div>
+            <div class="flow-actor" id="flow-actor-4-2">
+              <div class="flow-actor-icon" style="background: var(--color-error)">−10</div>
+              <span>image</span>
+            </div>
+            <div class="flow-actor" id="flow-actor-4-3">
+              <div class="flow-actor-icon" style="background: var(--color-error)">−10</div>
+              <span>image</span>
+            </div>
+            <div class="flow-actor" id="flow-actor-4-4">
+              <div class="flow-actor-icon" style="background: var(--color-success)">+1000</div>
+              <span>order_pay</span>
+            </div>
+            <div class="flow-actor" id="flow-actor-4-5">
+              <div class="flow-actor-icon" style="background: var(--color-error)">−10</div>
+              <span>image</span>
+            </div>
+            <div class="flow-actor" id="flow-actor-4-6">
+              <div class="flow-actor-icon" style="background: var(--color-accent)">Σ</div>
+              <span>Balance</span>
+            </div>
+          </div>
+
+          <div class="flow-packet" id="flow-packet-4"></div>
+          <div class="flow-step-label" id="flow-label-4">Click "Next Step" to begin</div>
+
+          <div class="flow-controls">
+            <button class="btn flow-next-btn">Next Step</button>
+            <button class="btn flow-reset-btn">Restart</button>
+            <span class="flow-progress"></span>
+          </div>
+        </div>
+
+        <div class="callout callout-info">
+          <div class="callout-icon">⏳</div>
+          <div class="callout-content">
+            <strong class="callout-title">Two Business Decisions Hiding in the Code</strong>
+            <p>Every line has an
+              <span class="term" data-definition="To expire means to stop counting after a certain date. An expired credit line stays in the ledger forever as history, but is skipped when the balance is added up.">expiry</span>
+              date — signup credits last a year, purchased credits last until the end of the billing period. And when credits are spent, the lines are read in expiry order, soonest first. Nobody wrote a memo about that; the rule lives in one small phrase, <code>orderBy(asc(credits.expired_at))</code>, and it is as real a piece of company policy as anything in the terms of service.</p>
+          </div>
+        </div>
+      </section>
+
+      <!-- SCREEN 7: The whole price list in one place + quiz -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">Five Kinds of Line, One Price List</h2>
+        <p>Everything a credit line can possibly be, and everything a credit can possibly cost, sits in thirteen lines of code.</p>
+
+        <div class="translation-block animate-in">
+          <div class="translation-code">
+            <span class="translation-label">CODE</span>
+            <pre><code>
+<span class="code-line"><span class="code-keyword">export enum</span> CreditsTransType {</span>
+<span class="code-line">  NewUser = <span class="code-string">"new_user"</span>, <span class="code-comment">// initial credits for new user</span></span>
+<span class="code-line">  OrderPay = <span class="code-string">"order_pay"</span>, <span class="code-comment">// user pay for credits</span></span>
+<span class="code-line">  SystemAdd = <span class="code-string">"system_add"</span>, <span class="code-comment">// system add credits</span></span>
+<span class="code-line">  Ping = <span class="code-string">"ping"</span>, <span class="code-comment">// cost for ping api</span></span>
+<span class="code-line">  ImageGeneration = <span class="code-string">"image_generation"</span>, <span class="code-comment">// cost for image generation</span></span>
+<span class="code-line">}</span>
+<span class="code-line">&nbsp;</span>
+<span class="code-line"><span class="code-keyword">export enum</span> CreditsAmount {</span>
+<span class="code-line">  NewUserGet = <span class="code-number">30</span>,</span>
+<span class="code-line">  PingCost = <span class="code-number">1</span>,</span>
+<span class="code-line">  ImageGeneration = <span class="code-number">10</span>,</span>
+<span class="code-line">}</span>
+            </code></pre>
+          </div>
+          <div class="translation-english">
+            <span class="translation-label">PLAIN ENGLISH</span>
+            <div class="translation-lines">
+              <p class="tl">Here is the complete list of reasons a ledger line can exist — an
+                <span class="term" data-definition="An enum is a fixed, named list of allowed values. Instead of letting any text be written into a field, the code says these five are the only options — so a typo becomes an error rather than a mystery.">enum</span>,
+                which means these five are the <em>only</em> options.</p>
+              <p class="tl">A signup gift, a purchase, a manual top-up from support, a test call, and an image generation.</p>
+              <p class="tl">And here is the whole price list, as plain numbers.</p>
+              <p class="tl">Thirty free on signup. One credit for a test ping. Ten credits per cartoon. Change the number 10 here and the price of the product changes everywhere.</p>
+            </div>
+          </div>
+        </div>
+
+        <p>A few more real facts about how the money side is put together:</p>
+
+        <div class="pattern-cards">
+          <div class="pattern-card" style="border-top: 3px solid var(--color-actor-4)">
+            <div class="pattern-icon" style="background: var(--color-actor-4)">📝</div>
+            <h4 class="pattern-title">Prices Are a Text File</h4>
+            <p class="pattern-desc">All 8 plans live in <code>pricing/en.json</code>, not in a database. The featured plan is Premium at <code>amount: 99</code> — that is 99 cents.</p>
+          </div>
+          <div class="pattern-card" style="border-top: 3px solid var(--color-actor-3)">
+            <div class="pattern-icon" style="background: var(--color-actor-3)">🔀</div>
+            <h4 class="pattern-title">Two Payment Companies</h4>
+            <p class="pattern-desc">Stripe or Creem, chosen by one environment variable. Chinese customers also get WeChat Pay and Alipay.</p>
+          </div>
+          <div class="pattern-card" style="border-top: 3px solid var(--color-actor-5)">
+            <div class="pattern-icon" style="background: var(--color-actor-5)">🤝</div>
+            <h4 class="pattern-title">Someone Else Gets Paid Too</h4>
+            <p class="pattern-desc">A paid order also triggers the
+              <span class="term" data-definition="An affiliate is someone who gets a share of the money when a person they referred makes a purchase — a referral commission.">affiliate</span>
+              payout to whoever invited that customer.</p>
+          </div>
+        </div>
+      </section>
+
+      <!-- SCREEN 8: Quiz -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">Check Your Understanding</h2>
+        <p>Four money scenarios. These are the ones that cost real money and real trust when you get them wrong.</p>
+
+        <div class="quiz-container" id="quiz-module4">
+
+          <div class="quiz-question-block"
+               data-correct="q1-b"
+               data-explanation-right="Exactly — the webhook is a completely separate message from Stripe&apos;s servers to yours. It has nothing to do with the customer&apos;s browser, their tab, their wifi, or whether they ever came back to your site. That is the whole reason the redirect is not used as proof."
+               data-explanation-wrong="Think about who sends what. The redirect happens in the customer&apos;s browser — but the message that actually grants the credits comes from Stripe&apos;s own servers, directly to yours, with nobody in between.">
+            <h3 class="quiz-question">A customer pays on Stripe&apos;s page, then closes the tab before it redirects back to the app. Do they get their credits?</h3>
+            <div class="quiz-options">
+              <button class="quiz-option" data-value="q1-a" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>No — the credits are granted by the page they land on when they come back</span>
+              </button>
+              <button class="quiz-option" data-value="q1-b" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>Yes — the webhook travels server-to-server and does not depend on their browser at all</span>
+              </button>
+              <button class="quiz-option" data-value="q1-c" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>Only if they sign in again within a few minutes</span>
+              </button>
+            </div>
+            <div class="quiz-feedback"></div>
+          </div>
+
+          <div class="quiz-question-block"
+               data-correct="q2-c"
+               data-explanation-right="Exactly — two independent guards. The order refuses to move from paid to paid, and the ledger refuses to write a second line carrying an order number it already has. Either one alone would do the job; having both is what payment code should look like."
+               data-explanation-wrong="Stripe repeating itself is deliberate, not a fault — it is how a payment survives a dropped connection. So the protection has to be on your side, in code that is safe to run twice.">
+            <h3 class="quiz-question">Stripe sends the same &quot;payment complete&quot; message twice. What stops the customer getting double credits?</h3>
+            <div class="quiz-options">
+              <button class="quiz-option" data-value="q2-a" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>Stripe never sends anything twice, so it cannot happen</span>
+              </button>
+              <button class="quiz-option" data-value="q2-b" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>Nothing — support has to notice and take the credits back manually</span>
+              </button>
+              <button class="quiz-option" data-value="q2-c" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>The order is already marked paid, and the ledger already has a line tagged with that order number — so the second run does nothing</span>
+              </button>
+            </div>
+            <div class="quiz-feedback"></div>
+          </div>
+
+          <div class="scenario-block">
+            <div class="scenario-context">
+              <span class="scenario-label">Scenario</span>
+              <p>You ask an AI assistant to add a credits feature. It proposes putting a single <code>credits</code> number on the users table and adding to or subtracting from it whenever something happens.</p>
+            </div>
+            <div class="quiz-question-block"
+                 data-correct="q3-c"
+                 data-explanation-right="Exactly — and it is all three at once. You cannot answer &quot;where did my credits go?&quot;, you cannot expire some credits and not others, and two requests arriving at the same moment can each read the same starting number and overwrite each other. Say the words &quot;append-only ledger&quot; and you get a far better design first time."
+                 data-explanation-wrong="Have another look at what the ledger gives you that a single number cannot: a history you can read, a per-line expiry date, and safety when two things happen at once. This design costs one of those — actually, all of them.">
+              <h3 class="quiz-question">Name what gets worse.</h3>
+              <div class="quiz-options">
+                <button class="quiz-option" data-value="q3-a" onclick="selectOption(this)">
+                  <div class="quiz-option-radio"></div>
+                  <span>Nothing important — it is simpler and does the same job</span>
+                </button>
+                <button class="quiz-option" data-value="q3-b" onclick="selectOption(this)">
+                  <div class="quiz-option-radio"></div>
+                  <span>It is slower to read the balance</span>
+                </button>
+                <button class="quiz-option" data-value="q3-c" onclick="selectOption(this)">
+                  <div class="quiz-option-radio"></div>
+                  <span>You lose the history, you can no longer expire credits selectively, and simultaneous requests can overwrite each other</span>
+                </button>
+              </div>
+              <div class="quiz-feedback"></div>
+            </div>
+          </div>
+
+          <div class="quiz-question-block"
+               data-correct="q4-a"
+               data-explanation-right="Exactly — nothing happens, because the price was never in the request to begin with. The Server reads it from its own pricing file every time. Generalise this instinct: any value that decides money, permissions or identity must be looked up by the Server, never accepted from the Browser."
+               data-explanation-wrong="Look again at what the Browser actually sends: a product name, a currency, and a language. There is no price in that package — the Server finds the price itself, so there is nothing for an attacker to edit.">
+            <h3 class="quiz-question">Someone edits the request in their browser to send <code>amount: 1</code> instead of the real price. What happens?</h3>
+            <div class="quiz-options">
+              <button class="quiz-option" data-value="q4-a" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>Nothing — the Browser never sends a price, so the extra field is simply ignored</span>
+              </button>
+              <button class="quiz-option" data-value="q4-b" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>They buy the plan for one cent</span>
+              </button>
+              <button class="quiz-option" data-value="q4-c" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>Stripe catches it and rejects the payment</span>
+              </button>
+            </div>
+            <div class="quiz-feedback"></div>
+          </div>
+
+          <button class="quiz-check-btn" onclick="checkQuiz('quiz-module4')">Check Answers</button>
+          <button class="quiz-reset-btn" onclick="resetQuiz('quiz-module4')">Try Again</button>
+        </div>
+
+        <p style="margin-top: var(--space-10)">We have written a lot of rows to a database this module without once asking what a database actually <em>is</em> — or what happens when it disappears. It disappeared. Really. That is <strong>Memory and the Outside World</strong>.</p>
+      </section>
+
+    </div>
+  </div>
+</section>

--- a/courses/general-course/modules/05-memory-and-the-outside-world.html
+++ b/courses/general-course/modules/05-memory-and-the-outside-world.html
@@ -1,0 +1,572 @@
+<section class="module" id="module-5" style="background: var(--color-bg-warm)">
+  <div class="module-content">
+    <header class="module-header animate-in">
+      <span class="module-number">05</span>
+      <h1 class="module-title">Memory and the Outside World</h1>
+      <p class="module-subtitle">Every module so far has said &quot;and then it saves it to the database&quot; as if that were one word. It is about six ideas — and the most useful thing about this particular database is that when we went looking for it, it was gone.</p>
+    </header>
+
+    <div class="module-body">
+
+      <!-- SCREEN 1: Blueprints and permits -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">Blueprints and Permits</h2>
+        <p>A
+          <span class="term" data-definition="A database is a program whose whole job is to store information safely and find it again fast. Think of a filing system that never forgets, can be searched instantly, and can be used by thousands of people at once.">database</span>
+          is a program whose entire job is to remember things reliably and find them again instantly. This app uses
+          <span class="term" data-definition="PostgreSQL (usually said Post-gress) is one of the most widely used databases in the world. It is free, open-source, and the default sensible choice for most web apps.">PostgreSQL</span>,
+          rented from a company called
+          <span class="term" data-definition="Supabase is a company that runs PostgreSQL databases for you, so you do not have to own or maintain a server. It has a free tier, which matters later in this module.">Supabase</span>.</p>
+
+        <p>There is a file in this project called <code>schema.ts</code>. It is the building&apos;s blueprint: this building has a Users room with these dimensions, an Orders room with those, a Credits room down the hall.</p>
+
+        <div class="pattern-cards">
+          <div class="pattern-card" style="border-top: 3px solid var(--color-actor-2)">
+            <div class="pattern-icon" style="background: var(--color-actor-2)">📐</div>
+            <h4 class="pattern-title">The Blueprint</h4>
+            <p class="pattern-desc">The <span class="term" data-definition="A schema is the description of what a database contains — which tables exist, what columns each one has, and what kind of value goes in each column.">schema</span>: what rooms exist and what shape they are.</p>
+          </div>
+          <div class="pattern-card" style="border-top: 3px solid var(--color-accent)">
+            <div class="pattern-icon" style="background: var(--color-accent)">📋</div>
+            <h4 class="pattern-title">The Permits</h4>
+            <p class="pattern-desc">Numbered, dated changes: <em>#0004 — add a password column to Users.</em> Applied in order, they build the whole thing.</p>
+          </div>
+          <div class="pattern-card" style="border-top: 3px solid var(--color-actor-4)">
+            <div class="pattern-icon" style="background: var(--color-actor-4)">🏢</div>
+            <h4 class="pattern-title">The Building</h4>
+            <p class="pattern-desc">The live database, with real people living in it right now. You cannot just hand a builder a new blueprint.</p>
+          </div>
+        </div>
+
+        <p>That last card is the whole problem. Redrawing a blueprint is easy. Changing a building people already live in, without knocking it down, is a completely different job — and it is why
+          <span class="term" data-definition="A migration is a small, numbered file describing one change to a database — add this column, rename that table. Run in order, migrations take a database from empty to its current shape, and anyone can read exactly what changed.">migrations</span>
+          exist.</p>
+      </section>
+
+      <!-- SCREEN 2: The eight tables -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">Eight Rooms</h2>
+        <p>Here is the entire product, described as furniture. Eight
+          <span class="term" data-definition="A database table is a grid of saved information — columns for the kinds of fact you store, one row per thing stored. Like a spreadsheet the app can search instantly.">tables</span>,
+          nothing else.</p>
+
+        <div class="badge-list">
+          <div class="badge-item">
+            <code class="badge-code">users</code>
+            <span class="badge-desc">One row per account: uuid, email, nickname, avatar, which service they signed in with, invite code</span>
+          </div>
+          <div class="badge-item">
+            <code class="badge-code">orders</code>
+            <span class="badge-desc">One row per purchase attempt: order number, amount, status, Stripe session id, credits bought</span>
+          </div>
+          <div class="badge-item">
+            <code class="badge-code">credits</code>
+            <span class="badge-desc">The ledger from last module — one row per grant or spend</span>
+          </div>
+          <div class="badge-item">
+            <code class="badge-code">apikeys</code>
+            <span class="badge-desc">Developer keys, the ones starting <code>sk-</code></span>
+          </div>
+          <div class="badge-item">
+            <code class="badge-code">posts</code>
+            <span class="badge-desc">Blog articles</span>
+          </div>
+          <div class="badge-item">
+            <code class="badge-code">categories</code>
+            <span class="badge-desc">Blog categories</span>
+          </div>
+          <div class="badge-item">
+            <code class="badge-code">affiliates</code>
+            <span class="badge-desc">Referral rewards — who invited whom, and what they earned</span>
+          </div>
+          <div class="badge-item">
+            <code class="badge-code">feedbacks</code>
+            <span class="badge-desc">User feedback and ratings</span>
+          </div>
+        </div>
+
+        <p>And here is one of those rooms as the blueprint actually describes it. The surprise for most people: this is not database language, it is ordinary
+          <span class="term" data-definition="TypeScript is a version of JavaScript that also lets you describe what shape your data is. The editor then catches mistakes as you type, before the code ever runs.">TypeScript</span>.</p>
+
+        <div class="translation-block animate-in">
+          <div class="translation-code">
+            <span class="translation-label">CODE</span>
+            <pre><code>
+<span class="code-line"><span class="code-keyword">export const</span> credits = <span class="code-function">pgTable</span>(<span class="code-string">"credits"</span>, {</span>
+<span class="code-line">  <span class="code-property">id</span>: <span class="code-function">integer</span>().<span class="code-function">primaryKey</span>().<span class="code-function">generatedAlwaysAsIdentity</span>(),</span>
+<span class="code-line">  <span class="code-property">trans_no</span>: <span class="code-function">varchar</span>({ <span class="code-property">length</span>: <span class="code-number">255</span> }).<span class="code-function">notNull</span>().<span class="code-function">unique</span>(),</span>
+<span class="code-line">  <span class="code-property">created_at</span>: <span class="code-function">timestamp</span>({ <span class="code-property">withTimezone</span>: <span class="code-keyword">true</span> }),</span>
+<span class="code-line">  <span class="code-property">user_uuid</span>: <span class="code-function">varchar</span>({ <span class="code-property">length</span>: <span class="code-number">255</span> }).<span class="code-function">notNull</span>(),</span>
+<span class="code-line">  <span class="code-property">trans_type</span>: <span class="code-function">varchar</span>({ <span class="code-property">length</span>: <span class="code-number">50</span> }).<span class="code-function">notNull</span>(),</span>
+<span class="code-line">  <span class="code-property">credits</span>: <span class="code-function">integer</span>().<span class="code-function">notNull</span>(),</span>
+<span class="code-line">  <span class="code-property">order_no</span>: <span class="code-function">varchar</span>({ <span class="code-property">length</span>: <span class="code-number">255</span> }),</span>
+<span class="code-line">  <span class="code-property">expired_at</span>: <span class="code-function">timestamp</span>({ <span class="code-property">withTimezone</span>: <span class="code-keyword">true</span> }),</span>
+<span class="code-line">});</span>
+            </code></pre>
+          </div>
+          <div class="translation-english">
+            <span class="translation-label">PLAIN ENGLISH</span>
+            <div class="translation-lines">
+              <p class="tl">Describe a table called <code>credits</code>. Everything in the curly brackets is a
+                <span class="term" data-definition="A column is one kind of fact a table stores — the email column, the amount column. Every row has a value for every column.">column</span>.</p>
+              <p class="tl">A plain counting number that the database fills in itself, and that is the row&apos;s
+                <span class="term" data-definition="A primary key is the one column guaranteed to be unique for every row — the thing you use to point at exactly one record and no other.">primary key</span>:
+                the thing you point at to mean this row and no other.</p>
+              <p class="tl">A reference number, up to 255 characters, that must be present and must never repeat.</p>
+              <p class="tl">When this line was written, stored with its
+                <span class="term" data-definition="A timestamp is a stored moment in time. Storing it with a timezone means the same instant reads correctly whether you are in London or Shanghai.">timezone</span>
+                so it means the same instant everywhere in the world.</p>
+              <p class="tl">Whose line it is, and what kind of movement it was. Both required.</p>
+              <p class="tl">The amount — a whole number, positive or negative. This is the plus and minus from last module.</p>
+              <p class="tl">Which order it relates to, if any, and the date it stops counting. Both optional — a signup gift has no order.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="callout callout-info">
+          <div class="callout-icon">🧩</div>
+          <div class="callout-content">
+            <strong class="callout-title">Why Describe the Database in TypeScript?</strong>
+            <p>A tool called <span class="term" data-definition="Drizzle is an ORM — a translator that turns ordinary code into database instructions, so developers describe what they want in the language they are already writing in.">Drizzle</span> reads that file and generates the real database instructions. The payoff is that your editor now knows the shape of your data: misspell <code>left_credits</code> and you are told immediately, in red, before the code ever runs. Software that catches your mistakes while you type is worth an enormous amount.</p>
+          </div>
+        </div>
+      </section>
+
+      <!-- SCREEN 3: Migrations -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">The Permits</h2>
+        <p>There are five permits in this project, in a folder called <code>migrations</code>, with names generated from a word list. They look absurd and they are completely serious.</p>
+
+        <div class="file-tree">
+          <div class="ft-folder open">
+            <span class="ft-name">src/db/migrations/</span>
+            <span class="ft-desc">Every change ever made to the shape of this database, in order</span>
+            <div class="ft-children">
+              <div class="ft-file"><span class="ft-name">0000_flimsy_toad.sql</span><span class="ft-desc">The empty lot becomes a building</span></div>
+              <div class="ft-file"><span class="ft-name">0001, 0002</span><span class="ft-desc">Two more changes along the way</span></div>
+              <div class="ft-file"><span class="ft-name">0003_steady_toad.sql</span><span class="ft-desc">Add a category column to Posts</span></div>
+              <div class="ft-file"><span class="ft-name">0004_striped_colossus.sql</span><span class="ft-desc">Add a password column to Users</span></div>
+            </div>
+          </div>
+        </div>
+
+        <p>Open <code>0004_striped_colossus.sql</code> and this is the whole file. One line. Its brevity is the point.</p>
+
+        <div class="translation-block animate-in">
+          <div class="translation-code">
+            <span class="translation-label">CODE</span>
+            <pre><code>
+<span class="code-line"><span class="code-keyword">ALTER TABLE</span> <span class="code-string">"users"</span> <span class="code-keyword">ADD COLUMN</span> <span class="code-string">"password_hash"</span> <span class="code-function">varchar</span>(<span class="code-number">255</span>);</span>
+            </code></pre>
+          </div>
+          <div class="translation-english">
+            <span class="translation-label">PLAIN ENGLISH</span>
+            <div class="translation-lines">
+              <p class="tl">Change the existing <code>users</code> table — do not rebuild it, do not empty it, just change it.</p>
+              <p class="tl">Add one new column called <code>password_hash</code>, holding up to 255 characters.</p>
+              <p class="tl">That is the entire permit. This is written in
+                <span class="term" data-definition="SQL (say sequel) is the language databases speak. It is deliberately close to English: SELECT, INSERT, ALTER TABLE, DELETE.">SQL</span>,
+                the language databases actually speak — and you can read it, which is exactly the point.</p>
+              <p class="tl">Module 3&apos;s email-and-password sign-in door needed somewhere to store a scrambled password. This file is the moment that door became possible.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="callout callout-accent">
+          <div class="callout-icon">💡</div>
+          <div class="callout-content">
+            <strong class="callout-title">Ask For the Migration, Not Just the Change</strong>
+            <p>When you tell an AI assistant &quot;add a phone number field to users&quot;, it may edit the blueprint and quietly push the change straight into your database. Say instead: <em>&quot;change the schema and generate a migration for it.&quot;</em> The difference is a file you can read, review, keep in version history, and run identically on your laptop, on the test site and in production. Invisible schema changes are how two copies of the same app drift apart.</p>
+          </div>
+        </div>
+      </section>
+
+      <!-- SCREEN 4: The day the database vanished -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">The Day the Database Vanished</h2>
+        <p>While making this course, we tried to connect to this app&apos;s database. It answered:</p>
+
+        <div class="callout callout-warning">
+          <div class="callout-icon">💀</div>
+          <div class="callout-content">
+            <strong class="callout-title">tenant or user not found</strong>
+            <p>The Supabase project had been deleted — most likely reclaimed as an idle
+              <span class="term" data-definition="A free tier is the no-cost level of a paid service. It usually comes with limits, and often with a rule that unused projects get paused or deleted after a period of inactivity.">free-tier</span>
+              project. Nothing in the code is wrong. The code is fine. The <em>thing the code depends on</em> stopped existing.</p>
+          </div>
+        </div>
+
+        <p>Learn the <em>shape</em> of that error, because you will meet it again. It appeared at the connection stage — before a single one of the app&apos;s
+          <span class="term" data-definition="A query is a single question or instruction sent to a database: find me this, save that, delete the other.">queries</span>
+          ever ran. That timing is the tell.</p>
+
+        <div class="step-cards">
+          <div class="step-card">
+            <div class="step-num">1</div>
+            <div class="step-body">
+              <strong>Errors at the connection stage</strong>
+              <p>&quot;Not found&quot;, &quot;authentication failed&quot;, &quot;could not connect&quot; — before any of your queries run. Almost never your code. Suspect the address, the credentials, or the service itself.</p>
+            </div>
+          </div>
+          <div class="step-card">
+            <div class="step-num">2</div>
+            <div class="step-body">
+              <strong>Errors from a specific query</strong>
+              <p>&quot;column does not exist&quot;, &quot;duplicate key&quot;. The connection is fine — this is your code, or a migration that was never run.</p>
+            </div>
+          </div>
+          <div class="step-card">
+            <div class="step-num">3</div>
+            <div class="step-body">
+              <strong>No error, wrong answer</strong>
+              <p>Everything &quot;works&quot; but the numbers are wrong. The hardest kind. Module 7 is about these.</p>
+            </div>
+          </div>
+        </div>
+
+        <p>Two things would have caught this earlier: a health check that actually touches the database rather than just returning &quot;OK&quot;, and knowing in advance that free tiers reclaim idle projects.</p>
+
+        <p>When the database <em>does</em> exist, the app does not open a new connection for every question it asks. Opening one is slow, so it keeps a small set open and reuses them — a
+          <span class="term" data-definition="A connection pool is a small set of open database connections kept ready and shared between requests, instead of opening a fresh one every time. Like a switchboard with a few permanent phone lines rather than dialling from scratch on every call.">connection pool</span>.</p>
+
+        <div class="badge-list">
+          <div class="badge-item">
+            <code class="badge-code">max: 10</code>
+            <span class="badge-desc">At most ten open lines at once. The eleventh request waits its turn rather than overwhelming the database.</span>
+          </div>
+          <div class="badge-item">
+            <code class="badge-code">idle_timeout: 30</code>
+            <span class="badge-desc">A line sitting unused for 30 seconds gets hung up. Do not pay to hold lines nobody is talking on.</span>
+          </div>
+          <div class="badge-item">
+            <code class="badge-code">connect_timeout: 10</code>
+            <span class="badge-desc">If dialling takes more than 10 seconds, give up and fail loudly instead of hanging forever.</span>
+          </div>
+        </div>
+      </section>
+
+      <!-- SCREEN 5: The password in the code -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">The Password in the Code</h2>
+        <p>There is a patch in <code>src/db/index.ts</code>, written to work around a database password containing a <code>/</code> character that broke the connection address. We have replaced the password with <code>[REDACTED]</code> below. <strong>The real file has it in plain text.</strong></p>
+
+        <div class="bug-challenge">
+          <h3>Two things are wrong here. Click the line that worries you most:</h3>
+          <div class="bug-code">
+            <div class="bug-line" data-line="1" onclick="checkBugLine(this, false)"
+                 data-hint="That is only a comment — a note for human readers. Honest, even. Look at what the next line is comparing against.">
+              <span class="line-num">1</span>
+              <code>// Apply URL encoding for the specific password issue we're seeing</code>
+            </div>
+            <div class="bug-line bug-target" data-line="2" onclick="checkBugLine(this, true)"
+                 data-explanation="Two lessons, and both are worth more than the bug itself. <strong>One:</strong> a real database password is written into the source code. Code gets committed, shared, copied to laptops and screenshotted in chat — a secret in code is a secret that has already leaked. It belongs in an environment variable. <strong>Two:</strong> even if the password were safe here, this is the wrong fix. The problem is that a special character breaks the address; the real solution is to URL-encode the value in the environment variable once, for any password. This patch only ever works for one specific password on one specific day.">
+              <span class="line-num">2</span>
+              <code>if (databaseUrl.includes(':[REDACTED]@')) {</code>
+            </div>
+            <div class="bug-line" data-line="3" onclick="checkBugLine(this, false)"
+                 data-hint="Close — this line has the same problem as the one above it. Look one line higher, at the check that decides whether any of this runs.">
+              <span class="line-num">3</span>
+              <code>&nbsp;&nbsp;databaseUrl = databaseUrl.replace(':[REDACTED]@', ':[REDACTED-ENCODED]@');</code>
+            </div>
+            <div class="bug-line" data-line="4" onclick="checkBugLine(this, false)"
+                 data-hint="Logging that something happened is fine and even helpful. The problem is above.">
+              <span class="line-num">4</span>
+              <code>&nbsp;&nbsp;console.log('Applied URL encoding for database password special character');</code>
+            </div>
+            <div class="bug-line" data-line="5" onclick="checkBugLine(this, false)"
+                 data-hint="A closing bracket has never hurt anyone. Look further up.">
+              <span class="line-num">5</span>
+              <code>}</code>
+            </div>
+          </div>
+          <div class="bug-feedback"></div>
+        </div>
+
+        <p>Nobody should feel bad about this. It is a 2am &quot;just make it work&quot; patch, and it did work. It is also <em>exactly</em> what an AI assistant will write if you say &quot;the database URL is failing&quot; and paste the error — a fix aimed at your one symptom rather than at the cause.</p>
+
+        <div class="callout callout-warning">
+          <div class="callout-icon">🔐</div>
+          <div class="callout-content">
+            <strong class="callout-title">Secrets Never Go in Code</strong>
+            <p>Passwords, API keys and webhook secrets belong in
+              <span class="term" data-definition="An environment variable is a setting stored outside your code — on the server itself — that the app reads at startup. Changing it does not change any code, and it never gets committed alongside the code.">environment variables</span>,
+              set on the server and never committed. And when a fix works only for one exact value, ask what the general version of that fix would be. &quot;Handle any password with special characters&quot; is a different instruction from &quot;handle this password&quot; — and you are the one who has to ask for it.</p>
+          </div>
+        </div>
+      </section>
+
+      <!-- SCREEN 6: The outside world -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">Three Things You Do Not Control</h2>
+        <p>The database is rented. So is the AI, the image storage, and the payments. Each one fails in its own particular way.</p>
+
+        <div class="pattern-cards">
+          <div class="pattern-card" style="border-top: 3px solid var(--color-actor-4)">
+            <div class="pattern-icon" style="background: var(--color-actor-4)">✨</div>
+            <h4 class="pattern-title">Google Gemini</h4>
+            <p class="pattern-desc">Makes the cartoon. Fails with
+              <span class="term" data-definition="A quota is a cap on how much of a service you may use in a period — so many requests per day. Exceed it and the service refuses you until the clock resets.">quota exceeded</span>,
+              which arrives as
+              <span class="term" data-definition="HTTP 429 is the standard web response meaning Too Many Requests — you are being rate-limited. Every service on the internet uses the same number for it.">HTTP 429</span>.</p>
+          </div>
+          <div class="pattern-card" style="border-top: 3px solid var(--color-actor-2)">
+            <div class="pattern-icon" style="background: var(--color-actor-2)">🪣</div>
+            <h4 class="pattern-title">Cloudflare R2</h4>
+            <p class="pattern-desc"><span class="term" data-definition="Object storage is a service for keeping files — images, videos, backups — and handing back a web address for each one. Cheap, enormous, and not a database.">Object storage</span> for finished images. Fails by being unreachable, or by never having been configured at all.</p>
+          </div>
+          <div class="pattern-card" style="border-top: 3px solid var(--color-actor-3)">
+            <div class="pattern-icon" style="background: var(--color-actor-3)">💳</div>
+            <h4 class="pattern-title">Stripe</h4>
+            <p class="pattern-desc">Takes the money. Fails by rejecting a signature, or by having its webhook pointed at the wrong address.</p>
+          </div>
+        </div>
+
+        <div class="callout callout-accent">
+          <div class="callout-icon">💡</div>
+          <div class="callout-content">
+            <strong class="callout-title">Your App Is Mostly a Coordinator</strong>
+            <p>Strip out the rented parts and there is surprisingly little left: some rules about credits, some pages, and a lot of careful arranging. That is normal and it is not a criticism — but it changes what &quot;the app is broken&quot; usually means. More often than not it means <em>an outside service said no</em>, and that is where to look first.</p>
+          </div>
+        </div>
+      </section>
+
+      <!-- SCREEN 7: The key pool -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">A Bank of Phone Lines</h2>
+        <p>Each Gemini
+          <span class="term" data-definition="An API key is a secret, password-like string that lets a program prove which account it belongs to when calling an outside service. Usage and billing are counted against it.">API key</span>
+          has a daily limit. So the app does not have one key — it reads up to six from environment variables and rotates through them like a switchboard rotating through phone lines.</p>
+
+        <div class="badge-list">
+          <div class="badge-item">
+            <code class="badge-code">GEMINI_API_KEY</code>
+            <span class="badge-desc">Line one. The only one that must exist.</span>
+          </div>
+          <div class="badge-item">
+            <code class="badge-code">GEMINI_API_KEY_1 … _5</code>
+            <span class="badge-desc">Five more optional lines. Any that are not set are quietly filtered out of the list at startup — no error, the pool just ends up smaller.</span>
+          </div>
+        </div>
+
+        <p>Step through the switchboard. Watch what happens when one line gets a busy signal.</p>
+
+        <div class="flow-animation" data-steps='[
+          {"highlight":"flow-actor-5-1","label":"Request 1 arrives. The switchboard hands out Key A."},
+          {"highlight":"flow-actor-5-2","label":"Key A calls Gemini. A cartoon comes back. The pool counts one request against Key A for today.","packet":true,"from":"actor-5-2","to":"actor-5-5"},
+          {"highlight":"flow-actor-5-3","label":"Request 2 arrives. Not Key A again — the switchboard rotates to Key B.","packet":true,"from":"actor-5-1","to":"actor-5-3"},
+          {"highlight":"flow-actor-5-4","label":"Request 3 arrives. Rotate again: Key C.","packet":true,"from":"actor-5-1","to":"actor-5-4"},
+          {"highlight":"flow-actor-5-5","label":"Key C calls Gemini and gets back HTTP 429: quota exceeded. That key is done for today.","packet":true,"from":"actor-5-4","to":"actor-5-5"},
+          {"highlight":"flow-actor-5-4","label":"The pool benches Key C — marks it unavailable and stops handing it out."},
+          {"highlight":"flow-actor-5-2","label":"Request 4 arrives. The switchboard skips the benched line and goes back to Key A. The user never knew anything happened.","packet":true,"from":"actor-5-1","to":"actor-5-2"},
+          {"highlight":"flow-actor-5-1","label":"If every line ends up benched, nobody gets a crash — they get an honest message saying the app is at capacity."}
+        ]'>
+          <div class="flow-actors">
+            <div class="flow-actor" id="flow-actor-5-1">
+              <div class="flow-actor-icon" style="background: var(--color-accent)">☎️</div>
+              <span>Switchboard</span>
+            </div>
+            <div class="flow-actor" id="flow-actor-5-2">
+              <div class="flow-actor-icon" style="background: var(--color-actor-2)">A</div>
+              <span>Key A</span>
+            </div>
+            <div class="flow-actor" id="flow-actor-5-3">
+              <div class="flow-actor-icon" style="background: var(--color-actor-3)">B</div>
+              <span>Key B</span>
+            </div>
+            <div class="flow-actor" id="flow-actor-5-4">
+              <div class="flow-actor-icon" style="background: var(--color-actor-4)">C</div>
+              <span>Key C</span>
+            </div>
+            <div class="flow-actor" id="flow-actor-5-5">
+              <div class="flow-actor-icon" style="background: var(--color-actor-5)">✨</div>
+              <span>Gemini</span>
+            </div>
+          </div>
+
+          <div class="flow-packet" id="flow-packet-5"></div>
+          <div class="flow-step-label" id="flow-label-5">Click "Next Step" to begin</div>
+
+          <div class="flow-controls">
+            <button class="btn flow-next-btn">Next Step</button>
+            <button class="btn flow-reset-btn">Restart</button>
+            <span class="flow-progress"></span>
+          </div>
+        </div>
+
+        <p>Here is the benching, and something else worth noticing.</p>
+
+        <div class="translation-block animate-in">
+          <div class="translation-code">
+            <span class="translation-label">CODE</span>
+            <pre><code>
+<span class="code-line">      <span class="code-comment">// Check if it&apos;s a quota/limit error</span></span>
+<span class="code-line">      <span class="code-keyword">if</span> (error.message?.<span class="code-function">includes</span>(<span class="code-string">'quota'</span>) || error.message?.<span class="code-function">includes</span>(<span class="code-string">'limit'</span>) || error.status === <span class="code-number">429</span>) {</span>
+<span class="code-line">        geminiApiPool.<span class="code-function">markKeyAsUnavailable</span>(geminiApiKey, <span class="code-string">'Quota exceeded'</span>);</span>
+<span class="code-line">        <span class="code-keyword">return</span> <span class="code-function">respErr</span>(<span class="code-string">"Too many users online! VIP users get priority access. You're in queue, please wait a moment or upgrade to VIP for instant access."</span>, <span class="code-string">'QUEUE_REQUIRED'</span>);</span>
+<span class="code-line">      }</span>
+            </code></pre>
+          </div>
+          <div class="translation-english">
+            <span class="translation-label">PLAIN ENGLISH</span>
+            <div class="translation-lines">
+              <p class="tl">Something went wrong with the AI call. Work out whether it was a
+                <span class="term" data-definition="A rate limit is a rule capping how often you may call a service — 60 requests a minute, 1,500 a day. Every serious service has them, and hitting one is a normal event, not a disaster.">rate limit</span>
+                by checking three different ways, because different services phrase it differently.</p>
+              <p class="tl">If it was: bench this key. Take it out of rotation so the next request tries a different one instead of hitting the same wall.</p>
+              <p class="tl">Then tell the user. And look closely at what they are told — this is not an error message, it is a sales pitch.</p>
+              <p class="tl">&quot;Too many users online, VIP users get priority access.&quot; A technical limit has been reframed as evidence the product is popular, and as a reason to pay. That is a deliberate product decision, living inside error-handling code.</p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- SCREEN 8: Graceful degradation + quiz -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">Worse, But Working</h2>
+        <p>What if the image storage is not configured at all? The app does not error. It quietly does something worse instead.</p>
+
+        <div class="translation-block animate-in">
+          <div class="translation-code">
+            <span class="translation-label">CODE</span>
+            <pre><code>
+<span class="code-line">    <span class="code-keyword">let</span> finalImageUrl = <span class="code-string">`data:${generatedImageMimeType};base64,${generatedImageData}`</span>;</span>
+<span class="code-line">    <span class="code-keyword">let</span> storedFilename = filename;</span>
+<span class="code-line">&nbsp;</span>
+<span class="code-line">    <span class="code-comment">// Store image if storage is configured</span></span>
+<span class="code-line">    <span class="code-keyword">const</span> hasStorageConfig = process.env.STORAGE_ENDPOINT &amp;&amp;</span>
+<span class="code-line">                            process.env.STORAGE_ACCESS_KEY &amp;&amp;</span>
+<span class="code-line">                            process.env.STORAGE_SECRET_KEY &amp;&amp;</span>
+<span class="code-line">                            process.env.STORAGE_BUCKET;</span>
+            </code></pre>
+          </div>
+          <div class="translation-english">
+            <span class="translation-label">PLAIN ENGLISH</span>
+            <div class="translation-lines">
+              <p class="tl">Start by assuming the worst case: the image address is the entire image, encoded as a gigantic block of text called a
+                <span class="term" data-definition="A data URL is a web address that contains the file itself rather than pointing at one. Instead of a link to a picture, the link IS the picture, spelled out in text — which makes it enormous.">data URL</span>.</p>
+              <p class="tl">Note that this is the <em>default</em>, set before anything is even attempted. The good outcome is the upgrade; the poor outcome is the starting point.</p>
+              <p class="tl">Now check whether proper storage is set up — all four settings must be present. Miss one and storage counts as unconfigured.</p>
+              <p class="tl">If they are all there, upload the image and replace that giant text block with a short, real web address.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="callout callout-info">
+          <div class="callout-icon">🪂</div>
+          <div class="callout-content">
+            <strong class="callout-title">Graceful Degradation</strong>
+            <p>Name the pattern:
+              <span class="term" data-definition="Graceful degradation means that when part of a system fails, the rest keeps working in a reduced way instead of collapsing. An escalator with the power off is still a staircase.">graceful degradation</span>.
+              The user still gets their cartoon. But the reply is now megabytes instead of bytes, the image is saved nowhere, and there is no link they can share. Worse, but working — and worth knowing that this is what &quot;it feels slow today&quot; sometimes actually is.</p>
+          </div>
+        </div>
+
+        <h2 class="screen-heading" style="margin-top: var(--space-12)">Check Your Understanding</h2>
+        <p>Four debugging scenarios. Two of them really happened.</p>
+
+        <div class="quiz-container" id="quiz-module5">
+
+          <div class="quiz-question-block"
+               data-correct="q1-b"
+               data-explanation-right="Exactly — and this is the real story from this codebase. The error appeared before any query ran, which points at the connection itself: wrong address, wrong credentials, or a service that no longer exists. Free tiers reclaim idle projects, and that is what had happened."
+               data-explanation-wrong="Look at the timing. The failure happened before a single query was sent — so nothing about your queries, your schema or your recent code changes can be responsible. What has to be true before any query can run at all?">
+            <h3 class="quiz-question">Your app suddenly returns errors on every page. The log says <code>tenant or user not found</code>, and it appears before any query runs. Most likely cause?</h3>
+            <div class="quiz-options">
+              <button class="quiz-option" data-value="q1-a" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>A bug in the last code change you shipped</span>
+              </button>
+              <button class="quiz-option" data-value="q1-b" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>The database itself is gone or unreachable, or the connection details are wrong — not your application code</span>
+              </button>
+              <button class="quiz-option" data-value="q1-c" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>A missing migration — some column the code expects does not exist</span>
+              </button>
+            </div>
+            <div class="quiz-feedback"></div>
+          </div>
+
+          <div class="quiz-question-block"
+               data-correct="q2-a"
+               data-explanation-right="Exactly. The blueprint change alone only updates the description. The migration is the reviewable, repeatable record that can be run on your laptop, the test site and production and produce the same result every time — and that you can read before it touches anything."
+               data-explanation-wrong="Think about the difference between redrawing the blueprint and issuing a permit. A schema edit describes the new shape; something else has to actually, safely, change the building people are living in — and leave a record of it.">
+            <h3 class="quiz-question">You ask an AI to &quot;add a phone number field to users&quot;. What should you insist it produces alongside the schema change?</h3>
+            <div class="quiz-options">
+              <button class="quiz-option" data-value="q2-a" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>A migration file — so the change is reviewable and repeats identically on every environment</span>
+              </button>
+              <button class="quiz-option" data-value="q2-b" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>A backup of the whole database</span>
+              </button>
+              <button class="quiz-option" data-value="q2-c" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>Nothing — editing the schema file is the change</span>
+              </button>
+            </div>
+            <div class="quiz-feedback"></div>
+          </div>
+
+          <div class="scenario-block">
+            <div class="scenario-context">
+              <span class="scenario-label">Scenario</span>
+              <p>Image generation works for the first few dozen users each morning. By lunchtime, everyone gets &quot;Too many users online! VIP users get priority access.&quot; Overnight it fixes itself, then does the same thing again.</p>
+            </div>
+            <div class="quiz-question-block"
+                 data-correct="q3-b"
+                 data-explanation-right="Exactly — daily quotas reset at midnight, which is why it heals overnight and breaks again by lunchtime. Every key in the pool has been benched. Your levers: add more keys, raise the paid quota, or queue requests so you spend the quota you have on the users who matter most."
+                 data-explanation-wrong="Look at the rhythm of the failure: it heals overnight and returns during the day. Something is being counted, hitting a ceiling, and resetting on a daily clock. What in this module works exactly like that?">
+              <h3 class="quiz-question">What is going on, and what is one lever you could pull?</h3>
+              <div class="quiz-options">
+                <button class="quiz-option" data-value="q3-a" onclick="selectOption(this)">
+                  <div class="quiz-option-radio"></div>
+                  <span>The server runs out of memory during the day and restarts overnight</span>
+                </button>
+                <button class="quiz-option" data-value="q3-b" onclick="selectOption(this)">
+                  <div class="quiz-option-radio"></div>
+                  <span>The daily quota on every key in the pool is exhausted — add more keys, raise the paid quota, or queue requests</span>
+                </button>
+                <button class="quiz-option" data-value="q3-c" onclick="selectOption(this)">
+                  <div class="quiz-option-radio"></div>
+                  <span>The database connection pool is full and never releases connections</span>
+                </button>
+              </div>
+              <div class="quiz-feedback"></div>
+            </div>
+          </div>
+
+          <div class="quiz-question-block"
+               data-correct="q4-c"
+               data-explanation-right="Exactly — graceful degradation in action. Generation still works, but the image comes back embedded in the reply as an enormous block of text, is saved nowhere, and cannot be linked to or shared. Nobody sees an error, which is exactly what makes this kind of fault so easy to miss."
+               data-explanation-wrong="Remember the default value at the top of that code: the giant embedded image is what happens when nothing is configured. The upload is an upgrade on top of it, not a requirement — so nothing crashes.">
+            <h3 class="quiz-question">The storage credentials are missing in production. What does a user actually experience?</h3>
+            <div class="quiz-options">
+              <button class="quiz-option" data-value="q4-a" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>An error page — image generation is unavailable</span>
+              </button>
+              <button class="quiz-option" data-value="q4-b" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>The image generates but appears blank</span>
+              </button>
+              <button class="quiz-option" data-value="q4-c" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>It works, but slower — the image is embedded in the reply, saved nowhere, and cannot be shared as a link</span>
+              </button>
+            </div>
+            <div class="quiz-feedback"></div>
+          </div>
+
+          <button class="quiz-check-btn" onclick="checkQuiz('quiz-module5')">Check Answers</button>
+          <button class="quiz-reset-btn" onclick="resetQuiz('quiz-module5')">Try Again</button>
+        </div>
+
+        <p style="margin-top: var(--space-10)">Every error message we have quoted so far has been in English. But this app runs in two languages — and none of that text lives in the components. That is <strong>Every Language, Every Screen</strong>.</p>
+      </section>
+
+    </div>
+  </div>
+</section>

--- a/courses/general-course/modules/06-every-language-every-screen.html
+++ b/courses/general-course/modules/06-every-language-every-screen.html
@@ -1,0 +1,535 @@
+<section class="module" id="module-6" style="background: var(--color-bg)">
+  <div class="module-content">
+    <header class="module-header animate-in">
+      <span class="module-number">06</span>
+      <h1 class="module-title">Every Language, Every Screen</h1>
+      <p class="module-subtitle">Add <code>/zh</code> to the address bar and the entire app becomes Chinese — same buttons, same layout, same code. Not one component was duplicated to make that happen.</p>
+    </header>
+
+    <div class="module-body">
+
+      <!-- SCREEN 1: The audio guide -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">The Museum Audio Guide</h2>
+        <p>The museum gets built once. The paintings hang where they hang, the corridors run where they run. At the door you pick a language and get a handset — and from then on, every plaque you stand in front of is narrated in <em>your</em> language.</p>
+
+        <p>Nobody built a second museum for Mandarin speakers. That is the entire idea of this module, and it has three parts.</p>
+
+        <div class="pattern-cards">
+          <div class="pattern-card" style="border-top: 3px solid var(--color-actor-2)">
+            <div class="pattern-icon" style="background: var(--color-actor-2)">🏛️</div>
+            <h4 class="pattern-title">The Building</h4>
+            <p class="pattern-desc">The <strong>structure</strong> — components, layout, buttons, the shape of every page. Built once, shared by everyone.</p>
+          </div>
+          <div class="pattern-card" style="border-top: 3px solid var(--color-actor-4)">
+            <div class="pattern-icon" style="background: var(--color-actor-4)">🎧</div>
+            <h4 class="pattern-title">The Handset</h4>
+            <p class="pattern-desc">The <span class="term" data-definition="A locale is the language-and-region setting for a visitor — en for English, zh for Chinese. It decides not just words but also prices, dates and number formats.">locale</span>: which language you picked up at the door. In this app, it is the <code>/zh</code> in the address.</p>
+          </div>
+          <div class="pattern-card" style="border-top: 3px solid var(--color-accent)">
+            <div class="pattern-icon" style="background: var(--color-accent)">📖</div>
+            <h4 class="pattern-title">The Narration</h4>
+            <p class="pattern-desc">The <strong>content</strong> — every word on the site, living in data files rather than inside the code.</p>
+          </div>
+        </div>
+
+        <div class="callout callout-accent">
+          <div class="callout-icon">💡</div>
+          <div class="callout-content">
+            <strong class="callout-title">Separate Structure From Content</strong>
+            <p>The moment text stops living inside your components and starts living in data files, you get translations, marketing experiments, and non-developers editing copy — all for free, all at once. It is the same principle as Module 2&apos;s &quot;the page is a template, the content is data&quot;, now applied to every word on the site. Retro-fitting this later, into an app where text is scattered across two hundred components, is a brutal and expensive job.</p>
+          </div>
+        </div>
+      </section>
+
+      <!-- SCREEN 2: The doorman -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">The Doorman</h2>
+        <p>One file runs before <em>every single page request</em> in this app. It looks at the address, works out which language you want, and routes you accordingly. It is twelve lines long, and it is the only reason <code>/zh/pricing</code> works at all.</p>
+
+        <div class="translation-block animate-in">
+          <div class="translation-code">
+            <span class="translation-label">CODE</span>
+            <pre><code>
+<span class="code-line"><span class="code-keyword">import</span> createMiddleware <span class="code-keyword">from</span> <span class="code-string">"next-intl/middleware"</span>;</span>
+<span class="code-line"><span class="code-keyword">import</span> { routing } <span class="code-keyword">from</span> <span class="code-string">"./i18n/routing"</span>;</span>
+<span class="code-line">&nbsp;</span>
+<span class="code-line"><span class="code-keyword">export default</span> <span class="code-function">createMiddleware</span>(routing);</span>
+<span class="code-line">&nbsp;</span>
+<span class="code-line"><span class="code-keyword">export const</span> config = {</span>
+<span class="code-line">  <span class="code-property">matcher</span>: [</span>
+<span class="code-line">    <span class="code-string">"/"</span>,</span>
+<span class="code-line">    <span class="code-string">"/(en|en-US|zh|zh-CN|zh-TW|zh-HK|zh-MO|ja|ko|ru|fr|de|ar|es|it)/:path*"</span>,</span>
+<span class="code-line">    <span class="code-string">"/((?!privacy-policy|terms-of-service|api/|_next|_vercel|.*\\..*).*)"</span>,</span>
+<span class="code-line">  ],</span>
+<span class="code-line">};</span>
+            </code></pre>
+          </div>
+          <div class="translation-english">
+            <span class="translation-label">PLAIN ENGLISH</span>
+            <div class="translation-lines">
+              <p class="tl">Borrow a ready-made doorman from a library called next-intl, and the rules we want it to follow.</p>
+              <p class="tl">Make that doorman the thing that greets every visitor. That single line is the whole
+                <span class="term" data-definition="Middleware is code that runs in between a request arriving and the page that answers it — a checkpoint every visitor passes through. Language routing, authentication and redirects commonly live here.">middleware</span>.</p>
+              <p class="tl">Now describe which addresses the doorman should stand at.</p>
+              <p class="tl">The home page, for one.</p>
+              <p class="tl">And anything that starts with a language code. Notice this list is far longer than the two languages the app actually supports — the doorman <em>recognises</em> thirteen and the museum only narrates in two.</p>
+              <p class="tl">And everything else, <em>except</em> the legal pages, anything under <code>api/</code>, and files like images. That is a
+                <span class="term" data-definition="A regular expression is a compact notation for describing text patterns — match these addresses but not those. Famously unreadable, genuinely useful, and something you can safely ask an AI to write and explain.">regular expression</span>:
+                dense, unreadable, and doing real work.</p>
+              <p class="tl">API addresses are deliberately excluded — a program calling your app does not need a language prefix on its request.</p>
+            </div>
+          </div>
+        </div>
+
+        <p>And the actual language list is even shorter and even plainer:</p>
+
+        <div class="translation-block animate-in">
+          <div class="translation-code">
+            <span class="translation-label">CODE</span>
+            <pre><code>
+<span class="code-line"><span class="code-keyword">export const</span> locales = [<span class="code-string">"en"</span>, <span class="code-string">"zh"</span>];</span>
+<span class="code-line">&nbsp;</span>
+<span class="code-line"><span class="code-keyword">export const</span> localeNames: <span class="code-keyword">any</span> = {</span>
+<span class="code-line">  <span class="code-property">en</span>: <span class="code-string">"English"</span>,</span>
+<span class="code-line">  <span class="code-property">zh</span>: <span class="code-string">"中文"</span>,</span>
+<span class="code-line">};</span>
+<span class="code-line">&nbsp;</span>
+<span class="code-line"><span class="code-keyword">export const</span> defaultLocale = <span class="code-string">"en"</span>;</span>
+<span class="code-line">&nbsp;</span>
+<span class="code-line"><span class="code-keyword">export const</span> localePrefix = <span class="code-string">"as-needed"</span>;</span>
+            </code></pre>
+          </div>
+          <div class="translation-english">
+            <span class="translation-label">PLAIN ENGLISH</span>
+            <div class="translation-lines">
+              <p class="tl">Two real languages. That is the whole list — adding a third starts here.</p>
+              <p class="tl">What to write in the language switcher menu for each one, in that language.</p>
+              <p class="tl">If we cannot tell what someone wants, assume English.</p>
+              <p class="tl">&quot;As needed&quot; is a small, real product decision: the default language gets the clean address (<code>/pricing</code>), and only other languages carry a
+                <span class="term" data-definition="A URL prefix is a segment added to the front of a web address path — the zh in /zh/pricing. It tells the server something about the request before the page is even chosen.">prefix</span>
+                (<code>/zh/pricing</code>).</p>
+            </div>
+          </div>
+        </div>
+
+        <p>Watch a Chinese visitor and a German visitor go through the same door.</p>
+
+        <div class="flow-animation" data-steps='[
+          {"highlight":"flow-actor-6-1","label":"Someone in Shanghai asks for /zh/pricing."},
+          {"highlight":"flow-actor-6-2","label":"Before any page exists, the request passes the doorman. Every request does.","packet":true,"from":"actor-6-1","to":"actor-6-2"},
+          {"highlight":"flow-actor-6-2","label":"The doorman reads zh out of the address and notes it: this visitor is being narrated in Chinese."},
+          {"highlight":"flow-actor-6-3","label":"The pricing page component is asked to render. The SAME component English visitors get.","packet":true,"from":"actor-6-2","to":"actor-6-3"},
+          {"highlight":"flow-actor-6-4","label":"It goes and fetches two files: messages/zh.json for buttons and labels, pages/pricing/zh.json for the actual page content.","packet":true,"from":"actor-6-3","to":"actor-6-4"},
+          {"highlight":"flow-actor-6-1","label":"Back comes the same page, filled with Chinese text and prices in yuan. Zero components were duplicated.","packet":true,"from":"actor-6-4","to":"actor-6-1"},
+          {"highlight":"flow-actor-6-2","label":"Now someone in Berlin asks for /de/pricing. The doorman recognises de and waves them through."},
+          {"highlight":"flow-actor-6-4","label":"But there is no de.json to load. Instead of an error page, the loader quietly hands back English. Wrong language beats broken page."}
+        ]'>
+          <div class="flow-actors">
+            <div class="flow-actor" id="flow-actor-6-1">
+              <div class="flow-actor-icon" style="background: var(--color-actor-2)">🌐</div>
+              <span>Browser</span>
+            </div>
+            <div class="flow-actor" id="flow-actor-6-2">
+              <div class="flow-actor-icon" style="background: var(--color-accent)">🚪</div>
+              <span>Middleware</span>
+            </div>
+            <div class="flow-actor" id="flow-actor-6-3">
+              <div class="flow-actor-icon" style="background: var(--color-actor-3)">📄</div>
+              <span>Page</span>
+            </div>
+            <div class="flow-actor" id="flow-actor-6-4">
+              <div class="flow-actor-icon" style="background: var(--color-actor-4)">🗂️</div>
+              <span>Text Files</span>
+            </div>
+          </div>
+
+          <div class="flow-packet" id="flow-packet-6"></div>
+          <div class="flow-step-label" id="flow-label-6">Click "Next Step" to begin</div>
+
+          <div class="flow-controls">
+            <button class="btn flow-next-btn">Next Step</button>
+            <button class="btn flow-reset-btn">Restart</button>
+            <span class="flow-progress"></span>
+          </div>
+        </div>
+      </section>
+
+      <!-- SCREEN 3: Two kinds of text -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">Two Kinds of Text, Two Different Homes</h2>
+        <p>Not all words are the same. This app keeps them in two separate places, and the distinction is worth getting right in any project you build.</p>
+
+        <div class="pattern-cards">
+          <div class="pattern-card" style="border-top: 3px solid var(--color-actor-2)">
+            <div class="pattern-icon" style="background: var(--color-actor-2)">🔘</div>
+            <h4 class="pattern-title">Interface Labels</h4>
+            <p class="pattern-desc">Buttons, error messages, form hints. Short, reused everywhere. Home: <code>i18n/messages/en.json</code> and <code>zh.json</code>.</p>
+          </div>
+          <div class="pattern-card" style="border-top: 3px solid var(--color-accent)">
+            <div class="pattern-icon" style="background: var(--color-accent)">📰</div>
+            <h4 class="pattern-title">Page Content</h4>
+            <p class="pattern-desc">The entire marketing page, section by section. Home: <code>i18n/pages/landing/en.json</code> and <code>zh.json</code>.</p>
+          </div>
+        </div>
+
+        <p>The first kind looks like this — a
+          <span class="term" data-definition="JSON is a plain-text format for storing structured information as labels and values. It is the most common way programs exchange data, and it is readable by anyone: no programming needed to edit it.">JSON</span>
+          file of
+          <span class="term" data-definition="A key is the label you look something up by; the value is what you get back. sign_in is the key, Sign In is the value. Same key in every language file, different value.">keys and values</span>,
+          where the key is identical in both languages and only the value changes.</p>
+
+        <div class="pattern-cards">
+          <div class="pattern-card" style="border-top: 3px solid var(--color-actor-2)">
+            <div class="pattern-icon" style="background: var(--color-actor-2)">🇬🇧</div>
+            <h4 class="pattern-title">en.json</h4>
+            <p class="pattern-desc"><code>"sign_in": "Sign In"</code><br><code>"pricing": "Pricing"</code><br><code>"my_credits": "My Credits"</code></p>
+          </div>
+          <div class="pattern-card" style="border-top: 3px solid var(--color-accent)">
+            <div class="pattern-icon" style="background: var(--color-accent)">🔑</div>
+            <h4 class="pattern-title">The Component</h4>
+            <p class="pattern-desc">Asks for the key, never the words:<br><code>t("sign_in")</code><br>One component. One line. Both languages.</p>
+          </div>
+          <div class="pattern-card" style="border-top: 3px solid var(--color-actor-3)">
+            <div class="pattern-icon" style="background: var(--color-actor-3)">🇨🇳</div>
+            <h4 class="pattern-title">zh.json</h4>
+            <p class="pattern-desc"><code>"sign_in": "登录"</code><br><code>"pricing": "价格"</code><br><code>"my_credits": "我的积分"</code></p>
+          </div>
+        </div>
+
+        <p>The second kind is the surprising one. The <em>entire</em> landing page — hero headline, features, testimonials, FAQ, all eight pricing plans — is a data file, with sections named <code>hero</code>, <code>introduce</code>, <code>benefit</code>, <code>usage</code>, <code>feature</code>, <code>stats</code>, <code>testimonial</code>, <code>faq</code>, <code>cta</code>, <code>footer</code>.</p>
+
+        <p>Module 2 showed the page component drawing each section only if the data for it exists. <strong>This is where that data comes from.</strong></p>
+
+        <div class="translation-block animate-in">
+          <div class="translation-code">
+            <span class="translation-label">CODE</span>
+            <pre><code>
+<span class="code-line"><span class="code-keyword">export async function</span> <span class="code-function">getPage</span>(</span>
+<span class="code-line">  name: string,</span>
+<span class="code-line">  locale: string</span>
+<span class="code-line">): Promise&lt;LandingPage | PricingPage | ShowcasePage&gt; {</span>
+<span class="code-line">  <span class="code-keyword">try</span> {</span>
+<span class="code-line">    <span class="code-keyword">if</span> (locale === <span class="code-string">"zh-CN"</span>) {</span>
+<span class="code-line">      locale = <span class="code-string">"zh"</span>;</span>
+<span class="code-line">    }</span>
+<span class="code-line">&nbsp;</span>
+<span class="code-line">    <span class="code-keyword">return await import</span>(</span>
+<span class="code-line">      <span class="code-string">`@/i18n/pages/${name}/${locale.toLowerCase()}.json`</span></span>
+<span class="code-line">    ).<span class="code-function">then</span>((module) =&gt; module.default);</span>
+<span class="code-line">  } <span class="code-keyword">catch</span> (error) {</span>
+<span class="code-line">    console.<span class="code-function">warn</span>(<span class="code-string">`Failed to load ${locale}.json, falling back to en.json`</span>);</span>
+<span class="code-line">&nbsp;</span>
+<span class="code-line">    <span class="code-keyword">return await import</span>(<span class="code-string">`@/i18n/pages/${name}/en.json`</span>).<span class="code-function">then</span>(</span>
+<span class="code-line">      (module) =&gt; module.default</span>
+<span class="code-line">    );</span>
+<span class="code-line">  }</span>
+<span class="code-line">}</span>
+            </code></pre>
+          </div>
+          <div class="translation-english">
+            <span class="translation-label">PLAIN ENGLISH</span>
+            <div class="translation-lines">
+              <p class="tl">Given a page name and a language, go and fetch that page&apos;s content.</p>
+              <p class="tl">Treat &quot;Chinese as spoken in mainland China&quot; as plain Chinese — one file serves both.</p>
+              <p class="tl">Build a file path out of the two pieces and load it. <code>landing</code> + <code>zh</code> becomes <code>pages/landing/zh.json</code>.</p>
+              <p class="tl">Hand back whatever was inside. That object <em>is</em> the marketing page — every headline, every feature, every price.</p>
+              <p class="tl">If loading failed for any reason at all, do not crash. Leave a note in the log so someone can find out why later.</p>
+              <p class="tl">Then load the English file instead and hand that back. The visitor gets a page in the wrong language rather than no page at all.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="callout callout-info">
+          <div class="callout-icon">✍️</div>
+          <div class="callout-content">
+            <strong class="callout-title">The Marketing Team Does Not Need You</strong>
+            <p>Rewriting the entire home page means editing a text file. No component is touched, no logic changes, nothing is redeployed differently. When you are designing a new project, ask for this on day one: <em>&quot;user-facing strings go in the translation files, not inline in components.&quot;</em> It is one sentence, and it saves weeks.</p>
+          </div>
+        </div>
+      </section>
+
+      <!-- SCREEN 4: The fallback chain -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">When There Is No Narration</h2>
+        <p>The same safety net protects the interface labels. Try to load the visitor&apos;s language; if anything at all goes wrong, quietly serve English.</p>
+
+        <div class="translation-block animate-in">
+          <div class="translation-code">
+            <span class="translation-label">CODE</span>
+            <pre><code>
+<span class="code-line">  <span class="code-keyword">try</span> {</span>
+<span class="code-line">    <span class="code-keyword">const</span> messages = (<span class="code-keyword">await import</span>(<span class="code-string">`./messages/${locale.toLowerCase()}.json`</span>))</span>
+<span class="code-line">      .default;</span>
+<span class="code-line">    <span class="code-keyword">return</span> {</span>
+<span class="code-line">      <span class="code-property">locale</span>: locale,</span>
+<span class="code-line">      <span class="code-property">messages</span>: messages,</span>
+<span class="code-line">    };</span>
+<span class="code-line">  } <span class="code-keyword">catch</span> (e) {</span>
+<span class="code-line">    <span class="code-keyword">return</span> {</span>
+<span class="code-line">      <span class="code-property">locale</span>: <span class="code-string">"en"</span>,</span>
+<span class="code-line">      <span class="code-property">messages</span>: (<span class="code-keyword">await import</span>(<span class="code-string">`./messages/en.json`</span>)).default,</span>
+<span class="code-line">    };</span>
+<span class="code-line">  }</span>
+            </code></pre>
+          </div>
+          <div class="translation-english">
+            <span class="translation-label">PLAIN ENGLISH</span>
+            <div class="translation-lines">
+              <p class="tl">Try to load the label file for whatever language this visitor asked for.</p>
+              <p class="tl">If that worked, hand back both the language and its words.</p>
+              <p class="tl">If it failed for <em>any</em> reason — no such file, a typo in the language code, a corrupted file — do not throw an error.</p>
+              <p class="tl">Say the language is English and hand back the English words instead. This is the
+                <span class="term" data-definition="A fallback is the safe alternative a program uses when its first choice is unavailable — a spare tyre. Good fallbacks are quiet and keep the thing usable.">fallback</span>,
+                and it is the same graceful degradation idea from last module wearing a different costume.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="callout callout-accent">
+          <div class="callout-icon">🌏</div>
+          <div class="callout-content">
+            <strong class="callout-title">Localisation Is Adaptation, Not Translation</strong>
+            <p>The Chinese pricing file does not just carry Chinese words — it carries a separate <code>cn_amount</code>, priced for that market, and Chinese checkouts add WeChat Pay and Alipay as payment methods. Words, currency (<span class="term" data-definition="CNY is the international code for Chinese yuan, the way USD is the code for US dollars. Every currency has a three-letter code, and payment systems always use them.">CNY</span> rather than USD), date formats, payment methods, sometimes whole features. Translating the strings is the easy quarter of the job.</p>
+          </div>
+        </div>
+      </section>
+
+      <!-- SCREEN 5: Standard parts -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">Built From Standard Parts</h2>
+        <p>The building itself is not hand-carved either. The interface comes in three layers, smallest to largest.</p>
+
+        <div class="step-cards">
+          <div class="step-card">
+            <div class="step-num">1</div>
+            <div class="step-body">
+              <strong><span class="term" data-definition="Tailwind CSS is a styling approach where instead of writing style rules in a separate file, you attach lots of tiny pre-made class names directly to the element. Divisive among developers, extremely fast in practice.">Tailwind CSS</span> — the raw material</strong>
+              <p>Instead of writing <span class="term" data-definition="CSS is the language that controls how a web page looks — colours, spacing, fonts, layout. HTML says what is on the page; CSS says what it looks like.">style rules</span> in a separate file, you attach tiny
+                <span class="term" data-definition="A class name is a label attached to an element on a page so that styling can be applied to it. flex, rounded-md and gap-2 are each one small instruction.">class names</span>
+                directly to the element: <code>flex items-center gap-2 rounded-md</code>. The payoff is that there is never a mystery about which stylesheet a colour came from.</p>
+            </div>
+          </div>
+          <div class="step-card">
+            <div class="step-num">2</div>
+            <div class="step-body">
+              <strong><code>components/ui/</code> — 37 generic parts</strong>
+              <p>Button, card, dialog, tabs, tooltip, table. This is
+                <span class="term" data-definition="Shadcn UI is a collection of ready-made interface components you copy into your project rather than install. Because the code lives in your repo, you can edit any of it.">Shadcn UI</span>
+                — and crucially it is <em>not</em> an installed
+                <span class="term" data-definition="A component library is a package of ready-made interface pieces — buttons, menus, date pickers — that you install and use. Normally you cannot change how they work internally.">component library</span>.
+                The code was copied <em>into</em> the project, so any of it can be edited. You own the parts.</p>
+            </div>
+          </div>
+          <div class="step-card">
+            <div class="step-num">3</div>
+            <div class="step-body">
+              <strong><code>components/blocks/</code> — whole sections</strong>
+              <p><code>hero</code>, <code>pricing</code>, <code>faq</code>, <code>footer</code>, <code>showcase</code>. Each one assembled from the generic parts, and each one filled with text from the data files you just met.</p>
+            </div>
+          </div>
+        </div>
+
+        <p>A button is not one button. It is a small menu of options, all defined in a single file.</p>
+
+        <div class="translation-block animate-in">
+          <div class="translation-code">
+            <span class="translation-label">CODE</span>
+            <pre><code>
+<span class="code-line">      <span class="code-property">variant</span>: {</span>
+<span class="code-line">        <span class="code-property">default</span>:</span>
+<span class="code-line">          <span class="code-string">"bg-primary text-primary-foreground shadow-xs hover:bg-primary/90"</span>,</span>
+<span class="code-line">        <span class="code-property">destructive</span>:</span>
+<span class="code-line">          <span class="code-string">"bg-destructive text-white shadow-xs hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60"</span>,</span>
+<span class="code-line">        <span class="code-property">outline</span>:</span>
+<span class="code-line">          <span class="code-string">"border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50"</span>,</span>
+<span class="code-line">        <span class="code-property">secondary</span>:</span>
+<span class="code-line">          <span class="code-string">"bg-secondary text-secondary-foreground shadow-xs hover:bg-secondary/80"</span>,</span>
+<span class="code-line">        <span class="code-property">ghost</span>:</span>
+<span class="code-line">          <span class="code-string">"hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50"</span>,</span>
+<span class="code-line">        <span class="code-property">link</span>: <span class="code-string">"text-primary underline-offset-4 hover:underline"</span>,</span>
+<span class="code-line">      },</span>
+            </code></pre>
+          </div>
+          <div class="translation-english">
+            <span class="translation-label">PLAIN ENGLISH</span>
+            <div class="translation-lines">
+              <p class="tl">Here is the complete list of looks a button in this app can have. Each one is called a
+                <span class="term" data-definition="A variant is one named version of a reusable component — a primary button, a danger button, a small button. Choosing a variant is how you pick a look without inventing a new one.">variant</span>.</p>
+              <p class="tl"><strong>default</strong> — the solid brand-coloured button, slightly dimmer when your mouse is over it.</p>
+              <p class="tl"><strong>destructive</strong> — red, for the buttons that delete things. Long, because it also describes how it looks in
+                <span class="term" data-definition="Dark mode is a second colour scheme with a dark background, which many people prefer at night. Well-built apps define both and switch automatically.">dark mode</span>
+                and when keyboard-focused.</p>
+              <p class="tl"><strong>outline</strong> — a border and no fill. <strong>secondary</strong> — quieter than default. <strong>ghost</strong> — invisible until you hover.</p>
+              <p class="tl"><strong>link</strong> — looks like a link, behaves like a button.</p>
+              <p class="tl">Every button anywhere on the site is one of these six. That is what people mean by a
+                <span class="term" data-definition="A design system is an agreed set of reusable parts and rules — the approved buttons, colours, spacings — so that a product looks consistent without anyone having to police it.">design system</span>,
+                in practice.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="badge-list">
+          <div class="badge-item">
+            <code class="badge-code">variant="destructive"</code>
+            <span class="badge-desc">Every delete button on the site, changed in one place, forever</span>
+          </div>
+          <div class="badge-item">
+            <code class="badge-code">size="sm" | "lg" | "icon"</code>
+            <span class="badge-desc">Three sizes plus the default — so nobody invents a fourth by accident</span>
+          </div>
+        </div>
+      </section>
+
+      <!-- SCREEN 6: One palette + quiz -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">One Palette, One File</h2>
+        <p>Every colour in the app is defined once, in <code>theme.css</code>, and named after the cartoon it came from.</p>
+
+        <div class="translation-block animate-in">
+          <div class="translation-code">
+            <span class="translation-label">CODE</span>
+            <pre><code>
+<span class="code-line">  <span class="code-property">--cl-yellow</span>: <span class="code-function">oklch</span>(<span class="code-number">0.9 0.15 85</span>);</span>
+<span class="code-line">  <span class="code-property">--cl-orange</span>: <span class="code-function">oklch</span>(<span class="code-number">0.8 0.15 60</span>);</span>
+<span class="code-line">  <span class="code-property">--cl-blue</span>: <span class="code-function">oklch</span>(<span class="code-number">0.8 0.08 200</span>);</span>
+<span class="code-line">  <span class="code-property">--cl-pink</span>: <span class="code-function">oklch</span>(<span class="code-number">0.8 0.1 340</span>);</span>
+<span class="code-line">  <span class="code-property">--cl-green</span>: <span class="code-function">oklch</span>(<span class="code-number">0.85 0.15 140</span>);</span>
+<span class="code-line">  <span class="code-property">--cl-red</span>: <span class="code-function">oklch</span>(<span class="code-number">0.7 0.2 25</span>);</span>
+<span class="code-line">  <span class="code-property">--cl-brown</span>: <span class="code-function">oklch</span>(<span class="code-number">0.6 0.1 60</span>);</span>
+            </code></pre>
+          </div>
+          <div class="translation-english">
+            <span class="translation-label">PLAIN ENGLISH</span>
+            <div class="translation-lines">
+              <p class="tl">Seven named colours, each stored in a
+                <span class="term" data-definition="A CSS custom property (also called a CSS variable) is a named colour or size defined once and referred to everywhere else. Change the definition and everything using it changes at once.">CSS variable</span>
+                — a name you define once and use everywhere.</p>
+              <p class="tl">The names are the point: <code>--cl-yellow</code>, not <code>#F5D442</code>. Nothing in this app hardcodes a
+                <span class="term" data-definition="A hex code is the six-character way of writing a colour, like #D94F30. Precise, universal, and completely meaningless to read.">hex code</span>.</p>
+              <p class="tl"><span class="term" data-definition="oklch is a newer way of writing colours as lightness, colourfulness and hue. Unlike hex codes, the numbers mean something a human can reason about — raise the first number and the colour genuinely looks lighter.">oklch</span>
+                is a newer colour notation: lightness, then colourfulness, then hue. Raise the first number and the colour actually looks lighter — which hex codes never let you do.</p>
+              <p class="tl">Dark mode is this exact same list of names, redefined with different values. Nothing else in the app has to know it happened.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="callout callout-info">
+          <div class="callout-icon">🎨</div>
+          <div class="callout-content">
+            <strong class="callout-title">Why &quot;Make the Whole Site More Orange&quot; Is a One-Line Change</strong>
+            <p>Because there is exactly one place a colour is decided, and thirty-seven components that only ever refer to it by name. When you brief an AI assistant on styling, this is the shape to insist on:
+              <span class="term" data-definition="To hardcode a value is to write it directly wherever it is used, instead of defining it once and referring to it. Hardcoded values are the reason a simple change turns into finding and editing 200 files.">hardcoded</span>
+              colours scattered through components are how a five-minute rebrand becomes a two-week one.</p>
+          </div>
+        </div>
+
+        <h2 class="screen-heading" style="margin-top: var(--space-12)">Check Your Understanding</h2>
+        <p>Four scenarios about who has to do the work, and where the work lives.</p>
+
+        <div class="quiz-container" id="quiz-module6">
+
+          <div class="quiz-question-block"
+               data-correct="q1-c"
+               data-explanation-right="Exactly — the headline is a text field in a JSON data file. Anyone who can edit a text file can change it, in both languages, without touching a single component. That is the whole payoff of separating structure from content."
+               data-explanation-wrong="Have another look at where page content lives in this app. It is not written inside the component, and it is not in the database — it is a plain data file, one per language.">
+            <h3 class="quiz-question">The marketing team wants to change the headline on the home page. Do they need a developer?</h3>
+            <div class="quiz-options">
+              <button class="quiz-option" data-value="q1-a" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>Yes — the headline is written inside the hero component</span>
+              </button>
+              <button class="quiz-option" data-value="q1-b" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>Yes — it is a row in the database and needs a query to change</span>
+              </button>
+              <button class="quiz-option" data-value="q1-c" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>No — it is a text field in a JSON data file, one per language</span>
+              </button>
+            </div>
+            <div class="quiz-feedback"></div>
+          </div>
+
+          <div class="quiz-question-block"
+               data-correct="q2-b"
+               data-explanation-right="Exactly — add fr to the locale list, add a name for it in the switcher, and write the JSON files. Not one component gets duplicated, because no component contains any words. Whether the translation is any good is a separate and much harder problem."
+               data-explanation-wrong="Think about what a component actually contains in this app. It asks for keys and receives words. So what would you have to change for a new language, and what could stay completely untouched?">
+            <h3 class="quiz-question">You add a French version. What do you have to create, and what do you <em>not</em> have to touch?</h3>
+            <div class="quiz-options">
+              <button class="quiz-option" data-value="q2-a" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>A French copy of every page component, plus the translation files</span>
+              </button>
+              <button class="quiz-option" data-value="q2-b" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>Add <code>fr</code> to the locale list and add the JSON files — no component is duplicated</span>
+              </button>
+              <button class="quiz-option" data-value="q2-c" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>A whole second deployment of the app on a French domain</span>
+              </button>
+            </div>
+            <div class="quiz-feedback"></div>
+          </div>
+
+          <div class="quiz-question-block"
+               data-correct="q3-a"
+               data-explanation-right="Exactly — they get English. The loader tries the German file, fails, logs a warning for whoever is watching, and hands back English. A visitor seeing a page in the wrong language can still use your product; a visitor seeing a crash cannot."
+               data-explanation-wrong="Look again at the try/catch in the loader. Failing to find a file is treated as a normal, expected event with a planned answer — not as an emergency.">
+            <h3 class="quiz-question">A visitor in Germany arrives and the app has no German. What do they see?</h3>
+            <div class="quiz-options">
+              <button class="quiz-option" data-value="q3-a" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>The site in English — the fallback, with a warning quietly written to the log</span>
+              </button>
+              <button class="quiz-option" data-value="q3-b" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>An error page saying the language is unsupported</span>
+              </button>
+              <button class="quiz-option" data-value="q3-c" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>A blank page with the layout but no text in it</span>
+              </button>
+            </div>
+            <div class="quiz-feedback"></div>
+          </div>
+
+          <div class="scenario-block">
+            <div class="scenario-context">
+              <span class="scenario-label">Scenario</span>
+              <p>You ask an AI assistant to add a new &quot;Danger&quot; button style for a page that deletes account data. It offers to write the styling directly onto the button on that page.</p>
+            </div>
+            <div class="quiz-question-block"
+                 data-correct="q4-b"
+                 data-explanation-right="Exactly — it belongs as a new variant in the one button file. Then every Danger button on the site is identical, someone can change all of them at once later, and nobody has to guess which shade of red is the official one. Styling written onto one page is how design systems quietly rot."
+                 data-explanation-wrong="Think about what happens six months later when there are nine Danger buttons across the app and someone wants to change the red. Where would you want that colour to have been defined?">
+              <h3 class="quiz-question">Where should it go, and why does that matter?</h3>
+              <div class="quiz-options">
+                <button class="quiz-option" data-value="q4-a" onclick="selectOption(this)">
+                  <div class="quiz-option-radio"></div>
+                  <span>Directly on that page — it is only needed once</span>
+                </button>
+                <button class="quiz-option" data-value="q4-b" onclick="selectOption(this)">
+                  <div class="quiz-option-radio"></div>
+                  <span>As a new variant in the one button file, so every Danger button stays identical and can be changed in one place</span>
+                </button>
+                <button class="quiz-option" data-value="q4-c" onclick="selectOption(this)">
+                  <div class="quiz-option-radio"></div>
+                  <span>In the translation files, next to the button&apos;s label</span>
+                </button>
+              </div>
+              <div class="quiz-feedback"></div>
+            </div>
+          </div>
+
+          <button class="quiz-check-btn" onclick="checkQuiz('quiz-module6')">Check Answers</button>
+          <button class="quiz-reset-btn" onclick="resetQuiz('quiz-module6')">Try Again</button>
+        </div>
+
+        <p style="margin-top: var(--space-10)">Six modules of <em>how it works</em>. The last one is <em>what to do when it does not</em> — and how any of this gets from a laptop onto the real internet. That is <strong>When It Breaks</strong>.</p>
+      </section>
+
+    </div>
+  </div>
+</section>

--- a/courses/general-course/modules/07-when-it-breaks.html
+++ b/courses/general-course/modules/07-when-it-breaks.html
@@ -1,0 +1,715 @@
+<section class="module" id="module-7" style="background: var(--color-bg-warm)">
+  <div class="module-content">
+    <header class="module-header animate-in">
+      <span class="module-number">07</span>
+      <h1 class="module-title">When It Breaks</h1>
+      <p class="module-subtitle">Six modules of how it works. Here is the part nobody writes down: what to do at 11pm when a user emails &quot;it&apos;s broken&quot; and you have no idea where to start.</p>
+    </header>
+
+    <div class="module-body">
+
+      <!-- SCREEN 1: The flight recorder -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">Nobody Guesses in Aviation</h2>
+        <p>When an aircraft has a bad day, investigators do not sit in a room theorising. They pull the flight recorder and read what the aircraft was actually doing, second by second, until reality stops matching what everyone assumed.</p>
+
+        <div class="callout callout-accent">
+          <div class="callout-icon">💡</div>
+          <div class="callout-content">
+            <strong class="callout-title">You Do Not Debug by Thinking Harder</strong>
+            <p>You debug by <em>getting more instrument readings</em>. Every hour lost to a bug is usually an hour spent theorising instead of looking. <span class="term" data-definition="Debugging is the work of finding out why software is doing something other than what you expected — and it is mostly investigation, not typing.">Debugging</span> is closer to reading a black box recorder than to having a brilliant idea.</p>
+          </div>
+        </div>
+
+        <p>Here is the shape of the whole thing. You already know the route a request takes: <strong>Browser → Server → outside service → Database → back.</strong> A bug is simply the first point on that route where reality stopped matching expectation.</p>
+
+        <p>Every observation you make cuts the remaining search space roughly in half. Engineers call that a
+          <span class="term" data-definition="A binary search is a way of finding something fast by halving the search space each time — like finding a word in a dictionary by opening the middle, then the middle of the correct half, and so on.">binary search</span>,
+          and it turns an unbounded mystery into about five questions.</p>
+
+        <div class="callout callout-info">
+          <div class="callout-icon">🗣️</div>
+          <div class="callout-content">
+            <strong class="callout-title">Why This Is the Most Valuable Module for You</strong>
+            <p>AI assistants are excellent at fixing a problem you can describe <em>precisely</em>, and terrible at finding one you can only describe as &quot;it doesn&apos;t work&quot;. Vague reports send them into loops of speculative rewrites, each one leaving the codebase slightly worse. One precise sentence — <em>&quot;the POST to /api/generate-cyberpunk returns 200 with code -1 and message &apos;Insufficient credits&apos;, even though the balance shows 40&quot;</em> — usually gets fixed on the first try. This module is about how to write that sentence.</p>
+          </div>
+        </div>
+      </section>
+
+      <!-- SCREEN 2: The five-question ladder -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">The Five-Question Ladder</h2>
+        <p>For any bug, in any app, ask these in this order. The order matters — each question is cheap and rules out everything below it.</p>
+
+        <div class="step-cards">
+          <div class="step-card">
+            <div class="step-num">1</div>
+            <div class="step-body">
+              <strong>Did the request even leave the Browser?</strong>
+              <p>Open <span class="term" data-definition="Dev tools are the inspection panels built into every browser — press F12 or right-click and choose Inspect. They show you the page structure, the errors, and every request the page makes.">dev tools</span> and look at the
+                <span class="term" data-definition="The Network tab in dev tools lists every request the page sent and what came back — address, status, timing, and the full reply. It is the single most useful debugging screen there is.">Network tab</span>.
+                No request at all means the bug is in the click handler, not on the server. You have just eliminated the entire backend.</p>
+            </div>
+          </div>
+          <div class="step-card">
+            <div class="step-num">2</div>
+            <div class="step-body">
+              <strong>Did the Server receive it, and what did it answer?</strong>
+              <p>Read the <span class="term" data-definition="A status code is the three-digit number every web response carries: 200 means fine, 404 means not found, 401 means not signed in, 500 means the server itself broke.">status code</span> and the reply body. This app always answers with the same shape — <code>{ code, message, data }</code>, where <code>code: 0</code> means fine and <code>code: -1</code> means an error with a human-readable message sitting right there.</p>
+            </div>
+          </div>
+          <div class="step-card">
+            <div class="step-num">3</div>
+            <div class="step-body">
+              <strong>Did an outside service refuse?</strong>
+              <p>Gemini quota, Stripe signature, storage credentials. Critically: these appear in the <span class="term" data-definition="A log is the running diary a program writes about what it is doing. Server logs live on the server or in your hosting dashboard, and are invisible from the browser.">server logs</span>, never in the browser. If you have not looked at your logs, you have not looked.</p>
+            </div>
+          </div>
+          <div class="step-card">
+            <div class="step-num">4</div>
+            <div class="step-body">
+              <strong>Is the data actually what you think it is?</strong>
+              <p>Go and look. Is there a credits row for that order number? Is the order status still <code>created</code>? Assumptions about data are where confident people lose whole evenings.</p>
+            </div>
+          </div>
+          <div class="step-card">
+            <div class="step-num">5</div>
+            <div class="step-body">
+              <strong>Is it the environment, not the code?</strong>
+              <p>Works locally, fails in
+                <span class="term" data-definition="Production is the live version real customers use. Development is the copy running on your own laptop. They run the same code with different settings, which is exactly why they behave differently.">production</span>?
+                Suspect
+                <span class="term" data-definition="An environment variable is a setting stored outside your code — on the server — that changes how the app behaves. Missing ones are the single most common cause of works-here-not-there.">environment variables</span>
+                first, every single time. Module 3&apos;s missing GitHub sign-in button was exactly this.</p>
+            </div>
+          </div>
+        </div>
+
+        <p>Watch the ladder run on a real complaint.</p>
+
+        <div class="flow-animation" data-steps='[
+          {"highlight":"flow-actor-7-1","label":"A customer emails: I paid, but I have no credits. Resist the urge to guess. Go and take readings."},
+          {"highlight":"flow-actor-7-1","label":"Question 1: did the request leave the Browser at all? Network tab says yes, and the checkout request looks normal."},
+          {"highlight":"flow-actor-7-2","label":"Question 2: what did the Server answer? Status 200, code 0. The checkout was created successfully. Half the pipeline is now ruled out.","packet":true,"from":"actor-7-1","to":"actor-7-2"},
+          {"highlight":"flow-actor-7-3","label":"Question 3: did an outside service refuse? Stripe shows the payment as succeeded. So the money moved.","packet":true,"from":"actor-7-2","to":"actor-7-3"},
+          {"highlight":"flow-actor-7-4","label":"Question 4: is the data what you think? Look at the order row. Status is still created, not paid. And there is no credits row for that order number.","packet":true,"from":"actor-7-2","to":"actor-7-4"},
+          {"highlight":"flow-actor-7-3","label":"That narrows it to one thing: the webhook. Either it never arrived, or it arrived and failed to verify.","packet":true,"from":"actor-7-3","to":"actor-7-2"},
+          {"highlight":"flow-actor-7-2","label":"Question 5: environment, not code. The webhook address registered with Stripe still points at the old test domain. Nothing was ever broken in the code."}
+        ]'>
+          <div class="flow-actors">
+            <div class="flow-actor" id="flow-actor-7-1">
+              <div class="flow-actor-icon" style="background: var(--color-actor-2)">🌐</div>
+              <span>Browser</span>
+            </div>
+            <div class="flow-actor" id="flow-actor-7-2">
+              <div class="flow-actor-icon" style="background: var(--color-accent)">🖥️</div>
+              <span>Server</span>
+            </div>
+            <div class="flow-actor" id="flow-actor-7-3">
+              <div class="flow-actor-icon" style="background: var(--color-actor-3)">💳</div>
+              <span>Stripe</span>
+            </div>
+            <div class="flow-actor" id="flow-actor-7-4">
+              <div class="flow-actor-icon" style="background: var(--color-actor-4)">🗄️</div>
+              <span>Database</span>
+            </div>
+          </div>
+
+          <div class="flow-packet" id="flow-packet-7"></div>
+          <div class="flow-step-label" id="flow-label-7">Click "Next Step" to begin</div>
+
+          <div class="flow-controls">
+            <button class="btn flow-next-btn">Next Step</button>
+            <button class="btn flow-reset-btn">Restart</button>
+            <span class="flow-progress"></span>
+          </div>
+        </div>
+
+        <p>Notice what never happened in that sequence: nobody changed any code, and nobody had a brilliant idea. Seven observations, one cause.</p>
+      </section>
+
+      <!-- SCREEN 3: Three bugs from this codebase -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">Three Bug Shapes, All From This Codebase</h2>
+        <p>The first one is the most teachable seven lines in the whole project. Read it, and ask yourself what a customer sees when the database is unreachable.</p>
+
+        <div class="bug-challenge">
+          <h3>Which line turns a serious outage into a quiet lie?</h3>
+          <div class="bug-code">
+            <div class="bug-line" data-line="1" onclick="checkBugLine(this, false)"
+                 data-hint="That is just tidying up — a negative balance would be nonsense to show anyone. Keep looking, further down.">
+              <span class="line-num">1</span>
+              <code>if (user_credits.left_credits &lt; 0) {</code>
+            </div>
+            <div class="bug-line" data-line="2" onclick="checkBugLine(this, false)"
+                 data-hint="Same idea — clamping a nonsense value to zero. The problem is what happens when the whole function fails.">
+              <span class="line-num">2</span>
+              <code>&nbsp;&nbsp;user_credits.left_credits = 0;</code>
+            </div>
+            <div class="bug-line" data-line="3" onclick="checkBugLine(this, false)"
+                 data-hint="Marking someone as a paying user if they have any credits left. Reasonable. Look at the very bottom.">
+              <span class="line-num">3</span>
+              <code>if (user_credits.left_credits &gt; 0) { user_credits.is_pro = true; }</code>
+            </div>
+            <div class="bug-line" data-line="4" onclick="checkBugLine(this, false)"
+                 data-hint="This is the happy path — the real answer being handed back. The problem is the other exit from this function.">
+              <span class="line-num">4</span>
+              <code>&nbsp;&nbsp;return user_credits;</code>
+            </div>
+            <div class="bug-line" data-line="5" onclick="checkBugLine(this, false)"
+                 data-hint="Catching the error is not the mistake — you are allowed to catch errors. It is what happens in the next two lines.">
+              <span class="line-num">5</span>
+              <code>} catch (e) {</code>
+            </div>
+            <div class="bug-line" data-line="6" onclick="checkBugLine(this, false)"
+                 data-hint="Writing it to the log is the one good thing here. Now look at what gets handed back to the customer.">
+              <span class="line-num">6</span>
+              <code>&nbsp;&nbsp;console.log("get user credits failed: ", e);</code>
+            </div>
+            <div class="bug-line bug-target" data-line="7" onclick="checkBugLine(this, true)"
+                 data-explanation="This returns the <code>user_credits</code> object created at the top of the function — the one still full of zeros. So when the database is unreachable, a paying customer is not told &quot;something went wrong&quot;. They are told, calmly and confidently, that they have <strong>0 credits</strong> — and they conclude they have been robbed. Support gets angry emails about missing credits while the real problem is a database outage nobody noticed. A catch block that swallows an error turns a loud problem into a quiet lie.">
+              <span class="line-num">7</span>
+              <code>&nbsp;&nbsp;return user_credits;</code>
+            </div>
+          </div>
+          <div class="bug-feedback"></div>
+        </div>
+
+        <div class="translation-block animate-in">
+          <div class="translation-code">
+            <span class="translation-label">CODE</span>
+            <pre><code>
+<span class="code-line">    <span class="code-keyword">if</span> (user_credits.left_credits &lt; <span class="code-number">0</span>) {</span>
+<span class="code-line">      user_credits.left_credits = <span class="code-number">0</span>;</span>
+<span class="code-line">    }</span>
+<span class="code-line">&nbsp;</span>
+<span class="code-line">    <span class="code-keyword">if</span> (user_credits.left_credits &gt; <span class="code-number">0</span>) {</span>
+<span class="code-line">      user_credits.is_pro = <span class="code-keyword">true</span>;</span>
+<span class="code-line">    }</span>
+<span class="code-line">&nbsp;</span>
+<span class="code-line">    <span class="code-keyword">return</span> user_credits;</span>
+<span class="code-line">  } <span class="code-keyword">catch</span> (e) {</span>
+<span class="code-line">    console.<span class="code-function">log</span>(<span class="code-string">"get user credits failed: "</span>, e);</span>
+<span class="code-line">    <span class="code-keyword">return</span> user_credits;</span>
+<span class="code-line">  }</span>
+            </code></pre>
+          </div>
+          <div class="translation-english">
+            <span class="translation-label">WHAT THE USER EXPERIENCES</span>
+            <div class="translation-lines">
+              <p class="tl">Never show a negative balance. Fair enough.</p>
+              <p class="tl">Anyone with credits left counts as a paying user.</p>
+              <p class="tl">Hand back the real, correct balance. This is the normal, everything-is-fine path.</p>
+              <p class="tl">And here is the other exit. <code>catch</code> means &quot;if anything at all went wrong above, come here instead&quot;. A database outage lands here.</p>
+              <p class="tl">Write a note in the log, where no customer will ever see it and, realistically, nor will you.</p>
+              <p class="tl">Then hand back the object created at the very top of the function — the one still full of zeros. <strong>The customer is told they have 0 credits.</strong> Not &quot;we could not check&quot;. Zero. Confidently.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="callout callout-warning">
+          <div class="callout-icon">🤫</div>
+          <div class="callout-content">
+            <strong class="callout-title">Say What Should Happen on Failure</strong>
+            <p>When you ask an AI to &quot;add error handling&quot;, this is very often what you get: a
+              <span class="term" data-definition="A try/catch block says: attempt this, and if anything goes wrong, run that instead. It stops a crash — but it does not decide whether stopping the crash was the right thing to do.">try/catch</span>
+              that swallows the problem and returns a plausible-looking default. Be specific instead: <em>&quot;if this fails, surface the error to the caller — do not return a default that looks like real data.&quot;</em> A crash is honest. A confident wrong answer is not.</p>
+          </div>
+        </div>
+
+        <div class="pattern-cards">
+          <div class="pattern-card" style="border-top: 3px solid var(--color-actor-4)">
+            <div class="pattern-icon" style="background: var(--color-actor-4)">🔌</div>
+            <h4 class="pattern-title">The Environment Gap</h4>
+            <p class="pattern-desc">Works on the laptop, not in production. In this app, whole sign-in providers, the entire storage upload and the choice of payment company are all switched on and off by environment variables. Nearly always configuration, nearly never code.</p>
+          </div>
+          <div class="pattern-card" style="border-top: 3px solid var(--color-actor-3)">
+            <div class="pattern-icon" style="background: var(--color-actor-3)">🏷️</div>
+            <h4 class="pattern-title">The Name That Lies</h4>
+            <p class="pattern-desc">The image endpoint is still called <code>/api/generate-cyberpunk</code>, left over from an earlier version of the product. There are <code>.backup</code> copies of route files sitting in the repo too. Real codebases drift — describe <em>behaviour</em> to an AI, not filenames.</p>
+          </div>
+        </div>
+      </section>
+
+      <!-- SCREEN 4: What to log + the invisible ceiling -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">Writing Your Own Flight Recorder</h2>
+        <p>Before every AI call, this app writes down a block of context. Somebody sat and decided what they would want to know at 3am, and it shows.</p>
+
+        <div class="translation-block animate-in">
+          <div class="translation-code">
+            <span class="translation-label">CODE</span>
+            <pre><code>
+<span class="code-line">    console.<span class="code-function">log</span>(<span class="code-string">"=== Charlie and Lola API Request Details ==="</span>);</span>
+<span class="code-line">    console.<span class="code-function">log</span>(<span class="code-string">"Mode:"</span>, mode);</span>
+<span class="code-line">    console.<span class="code-function">log</span>(<span class="code-string">"Model:"</span>, model);</span>
+<span class="code-line">    console.<span class="code-function">log</span>(<span class="code-string">"Aspect Ratio:"</span>, aspectRatio);</span>
+<span class="code-line">    console.<span class="code-function">log</span>(<span class="code-string">"Output Format:"</span>, outputFormat);</span>
+<span class="code-line">    console.<span class="code-function">log</span>(<span class="code-string">"Style:"</span>, style);</span>
+<span class="code-line">    console.<span class="code-function">log</span>(<span class="code-string">"Custom Prompt:"</span>, customPrompt ? <span class="code-string">"Yes"</span> : <span class="code-string">"No"</span>);</span>
+<span class="code-line">    console.<span class="code-function">log</span>(<span class="code-string">"Images uploaded:"</span>, images.length);</span>
+<span class="code-line">    console.<span class="code-function">log</span>(<span class="code-string">"User Registered:"</span>, isRegisteredUser);</span>
+<span class="code-line">    console.<span class="code-function">log</span>(<span class="code-string">"User UUID:"</span>, userUuid || <span class="code-string">"Guest user"</span>);</span>
+<span class="code-line">    console.<span class="code-function">log</span>(<span class="code-string">"==========================================="</span>);</span>
+            </code></pre>
+          </div>
+          <div class="translation-english">
+            <span class="translation-label">PLAIN ENGLISH</span>
+            <div class="translation-lines">
+              <p class="tl">Draw a line in the log so this block is findable by eye among thousands of others.</p>
+              <p class="tl">Record every setting that shaped this request: which mode, which AI model, what shape, what file format, which style.</p>
+              <p class="tl">Note whether the user typed their own instructions — but <strong>not what they typed</strong>. A deliberate choice: yes or no is enough to
+                <span class="term" data-definition="To reproduce a bug is to make it happen again on purpose. A bug you can reproduce is nearly solved; a bug you cannot is mostly guesswork.">reproduce</span>
+                the problem.</p>
+              <p class="tl">How many images came in, whether the person was signed in, and who they were — or the word &quot;Guest&quot;.</p>
+              <p class="tl">Close the block. Everything needed to recreate this exact request, and nothing that would be embarrassing to leak.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="callout callout-info">
+          <div class="callout-icon">📝</div>
+          <div class="callout-content">
+            <strong class="callout-title">Log the Inputs You Would Need to Reproduce It. Never Log Secrets.</strong>
+            <p>Logs get copied into chat messages, support tickets and screenshots. API keys, passwords, tokens and full card details must never appear in them. &quot;Custom prompt: Yes&quot; is a perfect example of the discipline — enough to debug, not enough to expose anyone.</p>
+          </div>
+        </div>
+
+        <p>And then there are the limits you did not choose and cannot see. This is the entire <code>vercel.json</code> file:</p>
+
+        <div class="translation-block animate-in">
+          <div class="translation-code">
+            <span class="translation-label">CODE</span>
+            <pre><code>
+<span class="code-line">{</span>
+<span class="code-line">  <span class="code-property">"functions"</span>: {</span>
+<span class="code-line">    <span class="code-property">"app/api/**/*"</span>: {</span>
+<span class="code-line">      <span class="code-property">"maxDuration"</span>: <span class="code-number">60</span>,</span>
+<span class="code-line">      <span class="code-property">"memory"</span>: <span class="code-number">1024</span></span>
+<span class="code-line">    }</span>
+<span class="code-line">  }</span>
+<span class="code-line">}</span>
+            </code></pre>
+          </div>
+          <div class="translation-english">
+            <span class="translation-label">PLAIN ENGLISH</span>
+            <div class="translation-lines">
+              <p class="tl">Settings for the bits of code that answer requests.</p>
+              <p class="tl">Apply these to every API address in the app — the stars mean &quot;anything nested under here&quot;.</p>
+              <p class="tl">Hard ceiling: 60 seconds. Take longer and the request is killed mid-flight, whatever it was doing.</p>
+              <p class="tl">And about a gigabyte of
+                <span class="term" data-definition="A memory limit caps how much working space a piece of code may use at once. Exceed it and the code is stopped, usually with an unhelpful error.">working memory</span>.
+                Image generation takes around ten seconds, so there is headroom — but a slow day at Google, or a bigger image, eats into it invisibly.</p>
+            </div>
+          </div>
+        </div>
+
+        <p>Name the class of problem: <strong>limits you did not choose and cannot see.</strong> They are exactly why something works perfectly in testing and fails under load.</p>
+      </section>
+
+      <!-- SCREEN 5: Getting it onto the internet -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">Getting It Onto the Internet</h2>
+        <p>First, the thing that surprises everyone: <strong>the code you write is not the code that runs.</strong> A
+          <span class="term" data-definition="A build is the step that turns the code developers write into the packaged, optimised version that actually runs on a server. Nothing you wrote is deleted — a second, machine-friendly copy is produced.">build</span>
+          step turns TypeScript into JavaScript, pre-renders pages, and
+          <span class="term" data-definition="To bundle is to combine many small code files into a few larger ones so a browser can download them quickly, rather than making hundreds of separate requests.">bundles</span>
+          everything into one folder that contains exactly what is needed to run and nothing else.</p>
+
+        <p>This app can be shipped three different ways, and each trade-off is worth knowing.</p>
+
+        <div class="pattern-cards">
+          <div class="pattern-card" style="border-top: 3px solid var(--color-accent)">
+            <div class="pattern-icon" style="background: var(--color-accent)">▲</div>
+            <h4 class="pattern-title">Vercel</h4>
+            <p class="pattern-desc">The default. Push to
+              <span class="term" data-definition="Git is the system that tracks every change to a codebase and lets people work on it together. Pushing means sending your changes up to the shared copy.">git</span>
+              and it builds and deploys itself. Easiest by a mile — and you are on their terms, including that 60-second ceiling.</p>
+          </div>
+          <div class="pattern-card" style="border-top: 3px solid var(--color-actor-4)">
+            <div class="pattern-icon" style="background: var(--color-actor-4)">☁️</div>
+            <h4 class="pattern-title">Cloudflare Workers</h4>
+            <p class="pattern-desc">Lives on its own
+              <span class="term" data-definition="A branch is a parallel version of a codebase where changes can be made without disturbing the main one. Here, a whole deployment variant lives on its own branch.">branch</span>,
+              runs at the
+              <span class="term" data-definition="The edge means running your code in many small data centres physically close to users, rather than one big one far away. Faster, cheaper, and more restricted in what it can do.">edge</span>.
+              Cheap and fast, more constraints — <code>src/db/index.ts</code> literally has an <code>if (isCloudflareWorker)</code> branch that opens exactly one database connection instead of a pool of ten.</p>
+          </div>
+          <div class="pattern-card" style="border-top: 3px solid var(--color-actor-2)">
+            <div class="pattern-icon" style="background: var(--color-actor-2)">🐳</div>
+            <h4 class="pattern-title">Docker</h4>
+            <p class="pattern-desc">A recipe that builds a self-contained box — a
+              <span class="term" data-definition="A container is a sealed box holding your app and everything it needs to run, so it behaves identically on any machine. Docker is the most common tool for making them.">container</span>
+              — that runs identically anywhere. Most portable, most work.</p>
+          </div>
+        </div>
+
+        <p>The Docker recipe is worth one look, because two lines of it are pure professional habit.</p>
+
+        <div class="translation-block animate-in">
+          <div class="translation-code">
+            <span class="translation-label">CODE</span>
+            <pre><code>
+<span class="code-line"><span class="code-keyword">FROM</span> base <span class="code-keyword">AS</span> runner</span>
+<span class="code-line"><span class="code-keyword">WORKDIR</span> /app</span>
+<span class="code-line">&nbsp;</span>
+<span class="code-line"><span class="code-keyword">RUN</span> addgroup --system --gid <span class="code-number">1001</span> nodejs &amp;&amp; \</span>
+<span class="code-line">    adduser --system --uid <span class="code-number">1001</span> nextjs &amp;&amp; \</span>
+<span class="code-line">    mkdir .next &amp;&amp; \</span>
+<span class="code-line">    chown nextjs:nodejs .next</span>
+<span class="code-line">&nbsp;</span>
+<span class="code-line"><span class="code-keyword">COPY</span> --from=builder /app/public ./public</span>
+<span class="code-line"><span class="code-keyword">COPY</span> --from=builder --chown=nextjs:nodejs /app/.next/standalone ./</span>
+<span class="code-line"><span class="code-keyword">COPY</span> --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static</span>
+<span class="code-line">&nbsp;</span>
+<span class="code-line"><span class="code-keyword">USER</span> nextjs</span>
+            </code></pre>
+          </div>
+          <div class="translation-english">
+            <span class="translation-label">PLAIN ENGLISH</span>
+            <div class="translation-lines">
+              <p class="tl">Start a fresh, clean box for actually running the app. The messy box that did the building is thrown away — this is a
+                <span class="term" data-definition="A multi-stage build uses one temporary container to compile the app and a second clean one to run it, so all the build tools are left behind. The result is a much smaller, safer image.">multi-stage build</span>.</p>
+              <p class="tl">Work in a folder called <code>/app</code>.</p>
+              <p class="tl">Create a plain, unprivileged user called <code>nextjs</code> to run everything, and give it ownership of the folder it needs.</p>
+              <p class="tl">Copy in only the finished output from the build box — not the source code, not the build tools, not the notes.</p>
+              <p class="tl">Then switch to that limited user. If someone ever finds a way in, they arrive as <code>nextjs</code>, not as
+                <span class="term" data-definition="The root user is the all-powerful administrator account on a machine, allowed to do anything at all. Running an app as root means a break-in gets total control.">root</span>
+                — so a break-in cannot take the whole machine. Two lines, an enormous difference.</p>
+            </div>
+          </div>
+        </div>
+
+        <h3 class="screen-heading" style="font-size: var(--text-lg); margin-top: var(--space-10)">The Pre-Flight Checklist</h3>
+        <p>Read it aloud before every launch, on any project. &quot;I&apos;m sure it&apos;s fine&quot; is not a check.</p>
+
+        <div class="icon-rows">
+          <div class="icon-row">
+            <div class="icon-circle" style="background: var(--color-actor-4)">🔑</div>
+            <div>
+              <strong>Environment variables set in production?</strong>
+              <p>Not on your laptop — in production. All of them, including the ones you added last week.</p>
+            </div>
+          </div>
+          <div class="icon-row">
+            <div class="icon-circle" style="background: var(--color-actor-2)">🗄️</div>
+            <div>
+              <strong>Database reachable from production?</strong>
+              <p>Reachable from your laptop is not the same test. Firewall rules and connection limits differ.</p>
+            </div>
+          </div>
+          <div class="icon-row">
+            <div class="icon-circle" style="background: var(--color-actor-3)">📩</div>
+            <div>
+              <strong>Webhook registered and pointing at the live domain?</strong>
+              <p>The single most common launch-day payment bug, and you just watched it happen.</p>
+            </div>
+          </div>
+          <div class="icon-row">
+            <div class="icon-circle" style="background: var(--color-error)">🔐</div>
+            <div>
+              <strong>No secrets in the code?</strong>
+              <p>Search the repo for anything that looks like a password or a key before you make it public.</p>
+            </div>
+          </div>
+          <div class="icon-row">
+            <div class="icon-circle" style="background: var(--color-actor-5)">📈</div>
+            <div>
+              <strong>External quotas high enough for launch day?</strong>
+              <p>Free-tier AI limits do not survive a good day on social media.</p>
+            </div>
+          </div>
+          <div class="icon-row">
+            <div class="icon-circle" style="background: var(--color-accent)">🔦</div>
+            <div>
+              <strong>Can you see the logs?</strong>
+              <p>Find out where they are <em>before</em> you need them, not at 11pm with users waiting.</p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- SCREEN 6: The whole picture -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">The Whole Picture</h2>
+        <p>Seven modules in one diagram. Click anything to see what it does and which module covered it.</p>
+
+        <div class="arch-diagram">
+          <div class="arch-zone arch-zone-browser">
+            <h4 class="arch-zone-label">In the Browser — Modules 2 &amp; 6</h4>
+            <div class="arch-component" data-desc="components/ui/ — 37 generic parts: buttons, cards, dialogs, tabs. Copied into the project rather than installed, so any of them can be edited. Module 6.">
+              <div class="arch-icon">🧱</div>
+              <span>ui/ parts</span>
+            </div>
+            <div class="arch-component" data-desc="components/blocks/ — whole page sections assembled from the generic parts: hero, pricing, faq, footer, showcase. Each one filled with text from the translation data files. Module 6.">
+              <div class="arch-icon">🏗️</div>
+              <span>blocks/</span>
+            </div>
+            <div class="arch-component" data-desc="Client components — the interactive pieces that run in your browser: the upload box, the generate button, the language switcher. They can respond to clicks, but they can never be trusted about who you are. Module 2.">
+              <div class="arch-icon">🖱️</div>
+              <span>client components</span>
+            </div>
+          </div>
+
+          <div class="arch-zone">
+            <h4 class="arch-zone-label">On the Server — Modules 1, 2, 3 &amp; 6</h4>
+            <div class="arch-component" data-desc="middleware.ts — the doorman. Runs before every single page request, reads the language out of the address, and routes accordingly. Twelve lines. Module 6.">
+              <div class="arch-icon">🚪</div>
+              <span>Middleware</span>
+            </div>
+            <div class="arch-component" data-desc="Pages and API routes. A page returns HTML for a human; an API route returns data for a program. /api/generate-cyberpunk is the one that makes the cartoons — and it is still named after a previous version of the product. Modules 1 and 2.">
+              <div class="arch-icon">🛣️</div>
+              <span>Routes</span>
+            </div>
+            <div class="arch-component" data-desc="Services — the business rules. Should this person be allowed to do this? What does it cost? updateOrder and decreaseCredits live here. This is where the actual product decisions are written down. Modules 2 and 4.">
+              <div class="arch-icon">⚖️</div>
+              <span>Services</span>
+            </div>
+            <div class="arch-component" data-desc="Models — the only code allowed to talk to the database. Every insert, every query. Keeping this in one layer is why you can change your database without touching your business rules. Module 2.">
+              <div class="arch-icon">📇</div>
+              <span>Models</span>
+            </div>
+            <div class="arch-component" data-desc="Auth — NextAuth, getUserUuid(), the signed session cookie. Identity always comes from the verified session on the server, never from anything the browser typed into a request. Module 3.">
+              <div class="arch-icon">🎫</div>
+              <span>Auth</span>
+            </div>
+          </div>
+
+          <div class="arch-zone arch-zone-external">
+            <h4 class="arch-zone-label">Rented From Other People — Modules 4 &amp; 5</h4>
+            <div class="arch-component" data-desc="PostgreSQL, hosted by Supabase. Eight tables: users, orders, credits, apikeys, posts, categories, affiliates, feedbacks. Described in TypeScript, changed through numbered migration files. And, in this app, deleted. Module 5.">
+              <div class="arch-icon">🗄️</div>
+              <span>Database</span>
+            </div>
+            <div class="arch-component" data-desc="Stripe — takes the money, then calls your server back with a signed webhook to confirm it. The redirect back to your site proves nothing; the webhook is the fact. Module 4.">
+              <div class="arch-icon">💳</div>
+              <span>Stripe</span>
+            </div>
+            <div class="arch-component" data-desc="Google Gemini — makes the cartoon. Reached through a pool of up to six API keys handed out in rotation, with any key that hits its quota benched until tomorrow. Module 5.">
+              <div class="arch-icon">✨</div>
+              <span>Gemini</span>
+            </div>
+            <div class="arch-component" data-desc="Cloudflare R2 — object storage for finished images. If it is not configured, the app falls back to embedding the entire image in the reply as text: worse, but working. Module 5.">
+              <div class="arch-icon">🪣</div>
+              <span>Storage</span>
+            </div>
+          </div>
+
+          <div class="arch-description">Click any piece to see what it does.</div>
+        </div>
+
+        <p>Every arrow in that picture runs the same way: the Browser asks, the Server decides, the outside world answers, the Database remembers.</p>
+      </section>
+
+      <!-- SCREEN 7: The vocabulary -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">The Vocabulary You Now Own</h2>
+        <p>This was the real payoff all along. These are not trivia — they are the words that let you tell an AI assistant precisely what you want, instead of describing it and hoping.</p>
+
+        <div class="badge-list">
+          <div class="badge-item">
+            <code class="badge-code">request / response</code>
+            <span class="badge-desc">One question, one answer. Everything on the web is this.</span>
+          </div>
+          <div class="badge-item">
+            <code class="badge-code">endpoint</code>
+            <span class="badge-desc">One specific address that answers one specific kind of question</span>
+          </div>
+          <div class="badge-item">
+            <code class="badge-code">session / token</code>
+            <span class="badge-desc">The signed wristband that says who you are, checked on every request</span>
+          </div>
+          <div class="badge-item">
+            <code class="badge-code">webhook</code>
+            <span class="badge-desc">Another service calling <em>you</em>, unprompted, when something really happened</span>
+          </div>
+          <div class="badge-item">
+            <code class="badge-code">idempotent</code>
+            <span class="badge-desc">Safe to run twice. Say this word when asking for payment code.</span>
+          </div>
+          <div class="badge-item">
+            <code class="badge-code">append-only ledger</code>
+            <span class="badge-desc">Never overwrite a balance — add a line and sum them</span>
+          </div>
+          <div class="badge-item">
+            <code class="badge-code">schema / migration</code>
+            <span class="badge-desc">The blueprint, and the numbered reviewable permit that changes it</span>
+          </div>
+          <div class="badge-item">
+            <code class="badge-code">connection pool</code>
+            <span class="badge-desc">A few open lines held ready and shared, not a new call every time</span>
+          </div>
+          <div class="badge-item">
+            <code class="badge-code">rate limit / quota</code>
+            <span class="badge-desc">The cap on how much of someone else&apos;s service you may use</span>
+          </div>
+          <div class="badge-item">
+            <code class="badge-code">environment variable</code>
+            <span class="badge-desc">Settings outside the code. The first suspect in every works-here-not-there bug.</span>
+          </div>
+          <div class="badge-item">
+            <code class="badge-code">graceful degradation</code>
+            <span class="badge-desc">When part of it fails, the rest keeps working in a reduced way</span>
+          </div>
+          <div class="badge-item">
+            <code class="badge-code">locale / i18n</code>
+            <span class="badge-desc">Which language and region a visitor gets, and the machinery that serves it</span>
+          </div>
+          <div class="badge-item">
+            <code class="badge-code">component / variant</code>
+            <span class="badge-desc">A reusable interface piece, and its named looks</span>
+          </div>
+          <div class="badge-item">
+            <code class="badge-code">middleware</code>
+            <span class="badge-desc">A checkpoint every request passes through before reaching a page</span>
+          </div>
+          <div class="badge-item">
+            <code class="badge-code">server vs client</code>
+            <span class="badge-desc">Runs privately on their computer vs runs visibly on yours. Trust accordingly.</span>
+          </div>
+        </div>
+      </section>
+
+      <!-- SCREEN 8: Final quiz + send-off -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">One Last Time</h2>
+        <p>Five scenarios drawing on the whole course. Take your time with the fourth one.</p>
+
+        <div class="quiz-container" id="quiz-module7">
+
+          <div class="quiz-question-block"
+               data-correct="q1-b"
+               data-explanation-right="Exactly — and in that order, because each step is cheap and rules out everything after it. Did Stripe send the webhook? Did it verify against the signing secret? Is the order status still created rather than paid? Is there a credits row carrying that order number? The first place reality stops matching expectation is your bug."
+               data-explanation-wrong="Refunding first hides the evidence, and rewriting the credits code assumes you already know where the fault is. Start by taking readings along the pipeline you now know by heart: Stripe, the webhook, the order row, the credits row.">
+            <h3 class="quiz-question">A customer says they paid but have no credits. What do you check, and in what order?</h3>
+            <div class="quiz-options">
+              <button class="quiz-option" data-value="q1-a" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>Refund them immediately, then investigate when there is time</span>
+              </button>
+              <button class="quiz-option" data-value="q1-b" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>Did Stripe send the webhook → did it verify → is the order marked paid → is there a credits row for that order number</span>
+              </button>
+              <button class="quiz-option" data-value="q1-c" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>Ask an AI to rewrite the credits service to be more reliable</span>
+              </button>
+            </div>
+            <div class="quiz-feedback"></div>
+          </div>
+
+          <div class="quiz-question-block"
+               data-correct="q2-c"
+               data-explanation-right="Exactly. Every sign-in provider in this app is wrapped in a check on its environment variables — no variables, no button, no error message. Same code, different settings, different behaviour. Suspect configuration before code, every single time."
+               data-explanation-wrong="The code is identical in both places — you did not write a different version for production. So what else differs between your laptop and the live server? Almost always the settings that live outside the code.">
+            <h3 class="quiz-question">Everything works locally. In production, &quot;Sign in with GitHub&quot; does nothing at all. Best first guess?</h3>
+            <div class="quiz-options">
+              <button class="quiz-option" data-value="q2-a" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>A bug in the sign-in component</span>
+              </button>
+              <button class="quiz-option" data-value="q2-b" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>GitHub is down</span>
+              </button>
+              <button class="quiz-option" data-value="q2-c" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>Missing environment variables in production, so the provider was never added to the list</span>
+              </button>
+            </div>
+            <div class="quiz-feedback"></div>
+          </div>
+
+          <div class="quiz-question-block"
+               data-correct="q3-a"
+               data-explanation-right="Exactly — specify what should happen on failure. Otherwise you get a catch block that returns a plausible default, and a database outage becomes a customer being calmly told they have zero credits. A crash you can see beats a wrong answer you cannot."
+               data-explanation-wrong="Adding a try/catch is easy; deciding what the failure should look like to a human being is the actual work. If you do not say, you will get a default value that is indistinguishable from real data.">
+            <h3 class="quiz-question">An AI assistant offers to &quot;add error handling&quot; to a function that fetches a balance. What should you specify?</h3>
+            <div class="quiz-options">
+              <button class="quiz-option" data-value="q3-a" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>What should happen on failure — surface the error, do not return a default that looks like real data</span>
+              </button>
+              <button class="quiz-option" data-value="q3-b" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>That it should catch every possible error so the app never crashes</span>
+              </button>
+              <button class="quiz-option" data-value="q3-c" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>Which line number to put the try block on</span>
+              </button>
+            </div>
+            <div class="quiz-feedback"></div>
+          </div>
+
+          <div class="scenario-block">
+            <div class="scenario-context">
+              <span class="scenario-label">Capstone Scenario</span>
+              <p>You want users to be able to save their favourite generated images. You are about to brief an AI assistant on it.</p>
+            </div>
+            <div class="quiz-question-block"
+                 data-correct="q4-c"
+                 data-explanation-right="Exactly — and being able to list those layers unprompted is the whole point of this course. A new favourites table plus a migration (Module 5). A model, because only models talk to the database, and a service for the rules about who may favourite what (Module 2). An API route for the browser to call (Modules 1 and 2), which starts by calling getUserUuid() so identity comes from the session and never from the request (Module 3). A component built from the existing ui/ parts (Module 6). And new strings in both en.json and zh.json, because the app is bilingual (Module 6). Brief an AI with that list and you will get something worth keeping."
+                 data-explanation-wrong="Think about the route a request takes through this app, and everything it touches on the way. A single component cannot store anything, and a single table cannot show anything. Trace the whole path — and do not forget that this app speaks two languages.">
+              <h3 class="quiz-question">Which layers would you expect to change?</h3>
+              <div class="quiz-options">
+                <button class="quiz-option" data-value="q4-a" onclick="selectOption(this)">
+                  <div class="quiz-option-radio"></div>
+                  <span>Just a new component with a heart icon on it</span>
+                </button>
+                <button class="quiz-option" data-value="q4-b" onclick="selectOption(this)">
+                  <div class="quiz-option-radio"></div>
+                  <span>A new database table, and nothing else</span>
+                </button>
+                <button class="quiz-option" data-value="q4-c" onclick="selectOption(this)">
+                  <div class="quiz-option-radio"></div>
+                  <span>A table plus a migration, a model, a service, an API route that checks the session, a component — and new strings in both languages</span>
+                </button>
+              </div>
+              <div class="quiz-feedback"></div>
+            </div>
+          </div>
+
+          <div class="quiz-question-block"
+               data-correct="q5-b"
+               data-explanation-right="Exactly — the two invisible ceilings from this module. The 60-second function limit in vercel.json kills any request that runs long, and an exhausted Gemini key pool turns into queueing and retries that push requests towards that limit. Under load they feed each other, which is why a traffic spike breaks things that were fine in testing."
+               data-explanation-wrong="Think about what only bites when there is a lot of traffic: a hard ceiling on how long one request may take, and a daily allowance being consumed much faster than usual. Both of those are in this app right now.">
+            <h3 class="quiz-question">The generation feature starts timing out, but only during a traffic spike. Name two suspects you now know about.</h3>
+            <div class="quiz-options">
+              <button class="quiz-option" data-value="q5-a" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>The translation files and the design system</span>
+              </button>
+              <button class="quiz-option" data-value="q5-b" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>The 60-second function limit, and every key in the Gemini pool being benched on quota</span>
+              </button>
+              <button class="quiz-option" data-value="q5-c" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>The webhook signature and the credits ledger</span>
+              </button>
+            </div>
+            <div class="quiz-feedback"></div>
+          </div>
+
+          <button class="quiz-check-btn" onclick="checkQuiz('quiz-module7')">Check Answers</button>
+          <button class="quiz-reset-btn" onclick="resetQuiz('quiz-module7')">Try Again</button>
+        </div>
+
+        <div class="callout callout-accent" style="margin-top: var(--space-12)">
+          <div class="callout-icon">🎈</div>
+          <div class="callout-content">
+            <strong class="callout-title">You Just Read a Real Production Codebase, End to End</strong>
+            <p>Not a tutorial project — a live app with real customers, real money moving through it, a hardcoded password, a deleted database, and an endpoint named after a product that no longer exists. That is what all of them look like, including the ones built by teams of twenty.</p>
+          </div>
+        </div>
+
+        <p>You do not need to write any of this from scratch. You need to read it, recognise the shapes, and know the words — and you now do. The next time an AI assistant hands you something that smells off, you will be able to say exactly why.</p>
+
+        <p style="margin-top: var(--space-8)"><strong>Go and build something. And when it breaks, you already know which question to ask first.</strong></p>
+      </section>
+
+    </div>
+  </div>
+</section>

--- a/courses/general-course/styles.css
+++ b/courses/general-course/styles.css
@@ -1,0 +1,1195 @@
+/* =============================================================
+   CODEBASE-TO-COURSE — COMPLETE DESIGN SYSTEM
+   Copy this file verbatim into the course output directory.
+   Never regenerate it — customize only via :root overrides
+   in _base.html (accent color only).
+   ============================================================= */
+
+/* ── GOOGLE FONTS (loaded via _base.html <head>) ───────────────
+   Bricolage Grotesque · DM Sans · JetBrains Mono
+   ──────────────────────────────────────────────────────────── */
+
+/* ── DESIGN TOKENS ─────────────────────────────────────────── */
+:root {
+  /* BACKGROUNDS */
+  --color-bg:             #FAF7F2;
+  --color-bg-warm:        #F5F0E8;
+  --color-bg-code:        #1E1E2E;
+  --color-text:           #2C2A28;
+  --color-text-secondary: #6B6560;
+  --color-text-muted:     #9E9790;
+  --color-border:         #E5DFD6;
+  --color-border-light:   #EEEBE5;
+  --color-surface:        #FFFFFF;
+  --color-surface-warm:   #FDF9F3;
+
+  /* ACCENT — overridden per course in _base.html */
+  --color-accent:         #D94F30;
+  --color-accent-hover:   #C4432A;
+  --color-accent-light:   #FDEEE9;
+  --color-accent-muted:   #E8836C;
+
+  /* SEMANTIC */
+  --color-success:        #2D8B55;
+  --color-success-light:  #E8F5EE;
+  --color-error:          #C93B3B;
+  --color-error-light:    #FDE8E8;
+  --color-info:           #2A7B9B;
+  --color-info-light:     #E4F2F7;
+
+  /* ACTOR COLORS */
+  --color-actor-1:        #D94F30;
+  --color-actor-2:        #2A7B9B;
+  --color-actor-3:        #7B6DAA;
+  --color-actor-4:        #D4A843;
+  --color-actor-5:        #2D8B55;
+
+  /* FONTS */
+  --font-display: 'Bricolage Grotesque', Georgia, serif;
+  --font-body:    'DM Sans', -apple-system, sans-serif;
+  --font-mono:    'JetBrains Mono', 'Fira Code', 'Consolas', monospace;
+
+  /* TYPE SCALE */
+  --text-xs:   0.75rem;
+  --text-sm:   0.875rem;
+  --text-base: 1rem;
+  --text-lg:   1.125rem;
+  --text-xl:   1.25rem;
+  --text-2xl:  1.5rem;
+  --text-3xl:  1.875rem;
+  --text-4xl:  2.25rem;
+  --text-5xl:  3rem;
+  --text-6xl:  3.75rem;
+
+  /* LINE HEIGHTS */
+  --leading-tight:  1.15;
+  --leading-snug:   1.3;
+  --leading-normal: 1.6;
+  --leading-loose:  1.8;
+
+  /* SPACING */
+  --space-1:  0.25rem;
+  --space-2:  0.5rem;
+  --space-3:  0.75rem;
+  --space-4:  1rem;
+  --space-5:  1.25rem;
+  --space-6:  1.5rem;
+  --space-8:  2rem;
+  --space-10: 2.5rem;
+  --space-12: 3rem;
+  --space-16: 4rem;
+  --space-20: 5rem;
+  --space-24: 6rem;
+
+  /* LAYOUT */
+  --content-width:      800px;
+  --content-width-wide: 1000px;
+  --nav-height:         50px;
+
+  /* RADII */
+  --radius-sm:   8px;
+  --radius-md:   12px;
+  --radius-lg:   16px;
+  --radius-full: 9999px;
+
+  /* SHADOWS (warm-tinted, never pure black) */
+  --shadow-sm: 0 1px 2px rgba(44,42,40,0.05);
+  --shadow-md: 0 4px 12px rgba(44,42,40,0.08);
+  --shadow-lg: 0 8px 24px rgba(44,42,40,0.10);
+  --shadow-xl: 0 16px 48px rgba(44,42,40,0.12);
+
+  /* EASING */
+  --ease-out:    cubic-bezier(0.16,1,0.3,1);
+  --ease-in-out: cubic-bezier(0.65,0,0.35,1);
+
+  /* DURATIONS */
+  --duration-fast:   150ms;
+  --duration-normal: 300ms;
+  --duration-slow:   500ms;
+  --stagger-delay:   120ms;
+}
+
+/* ── RESET & BASE ───────────────────────────────────────────── */
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+html {
+  scroll-snap-type: y proximity;
+  scroll-behavior: smooth;
+}
+
+body {
+  font-family: var(--font-body);
+  font-size: var(--text-base);
+  color: var(--color-text);
+  line-height: var(--leading-normal);
+  background: var(--color-bg);
+  background-image: radial-gradient(
+    ellipse at 20% 50%,
+    rgba(217,79,48,0.03) 0%,
+    transparent 50%
+  );
+}
+
+/* ── SCROLLBAR ──────────────────────────────────────────────── */
+::-webkit-scrollbar { width: 6px; }
+::-webkit-scrollbar-track { background: transparent; }
+::-webkit-scrollbar-thumb {
+  background: var(--color-border);
+  border-radius: var(--radius-full);
+}
+
+/* ── CODE GLOBALS ───────────────────────────────────────────── */
+pre, code {
+  white-space: pre-wrap;
+  word-break: break-word;
+  overflow-x: hidden;
+}
+.translation-code::-webkit-scrollbar,
+pre::-webkit-scrollbar { display: none; }
+
+/* Catppuccin-inspired syntax highlighting */
+.code-keyword  { color: #CBA6F7; }
+.code-string   { color: #A6E3A1; }
+.code-function { color: #89B4FA; }
+.code-comment  { color: #6C7086; }
+.code-number   { color: #FAB387; }
+.code-property { color: #F9E2AF; }
+.code-operator { color: #94E2D5; }
+.code-tag      { color: #F38BA8; }
+.code-attr     { color: #F9E2AF; }
+.code-value    { color: #A6E3A1; }
+.code-line     { display: block; }
+
+/* ── NAV ────────────────────────────────────────────────────── */
+.nav {
+  position: fixed;
+  top: 0; left: 0; right: 0;
+  height: var(--nav-height);
+  z-index: 1000;
+  background: rgba(250,247,242,0.92);
+  backdrop-filter: blur(8px);
+  border-bottom: 1px solid var(--color-border-light);
+}
+
+.progress-bar {
+  position: absolute;
+  bottom: 0; left: 0;
+  height: 2px;
+  width: 0%;
+  background: var(--color-accent);
+  transition: width 100ms linear;
+}
+
+.nav-inner {
+  max-width: var(--content-width-wide);
+  margin: 0 auto;
+  padding: 0 var(--space-6);
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-4);
+}
+
+.nav-title {
+  font-family: var(--font-display);
+  font-size: var(--text-sm);
+  font-weight: 600;
+  color: var(--color-text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 300px;
+}
+
+.nav-dots {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.nav-dot {
+  width: 10px; height: 10px;
+  border-radius: 50%;
+  border: 2px solid var(--color-text-muted);
+  background: transparent;
+  cursor: pointer;
+  transition: all var(--duration-fast);
+  position: relative;
+}
+.nav-dot::after {
+  content: attr(data-tooltip);
+  position: absolute;
+  top: calc(100% + 6px);
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--color-bg-code);
+  color: #CDD6F4;
+  font-family: var(--font-body);
+  font-size: var(--text-xs);
+  white-space: nowrap;
+  padding: var(--space-1) var(--space-3);
+  border-radius: var(--radius-sm);
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity var(--duration-fast);
+}
+.nav-dot:hover::after { opacity: 1; }
+.nav-dot.active {
+  border-color: var(--color-accent);
+  background: var(--color-accent);
+  box-shadow: 0 0 0 3px var(--color-accent-light);
+}
+.nav-dot.visited {
+  border-color: var(--color-accent-muted);
+  background: var(--color-accent-muted);
+}
+
+/* ── MODULE STRUCTURE ───────────────────────────────────────── */
+.module {
+  min-height: 100dvh;
+  min-height: 100vh;
+  scroll-snap-align: start;
+  padding: var(--space-16) var(--space-6);
+  padding-top: calc(var(--nav-height) + var(--space-12));
+}
+
+.module-content {
+  max-width: var(--content-width);
+  margin: 0 auto;
+}
+
+.module-header { margin-bottom: var(--space-12); }
+
+.module-number {
+  display: block;
+  font-family: var(--font-display);
+  font-size: var(--text-6xl);
+  font-weight: 800;
+  color: var(--color-accent);
+  opacity: 0.15;
+  line-height: 1;
+  margin-bottom: var(--space-2);
+}
+
+.module-title {
+  font-family: var(--font-display);
+  font-size: var(--text-4xl);
+  font-weight: 700;
+  line-height: var(--leading-tight);
+  color: var(--color-text);
+}
+
+.module-subtitle {
+  margin-top: var(--space-3);
+  font-size: var(--text-lg);
+  color: var(--color-text-secondary);
+  line-height: var(--leading-snug);
+}
+
+.screen {
+  margin-bottom: var(--space-16);
+}
+
+.screen-heading {
+  font-family: var(--font-display);
+  font-size: var(--text-2xl);
+  font-weight: 600;
+  color: var(--color-text);
+  margin-bottom: var(--space-6);
+  line-height: var(--leading-snug);
+}
+
+p { margin-bottom: var(--space-4); }
+p:last-child { margin-bottom: 0; }
+
+/* ── SCROLL ANIMATIONS ──────────────────────────────────────── */
+.animate-in {
+  opacity: 0;
+  transform: translateY(20px);
+  transition:
+    opacity var(--duration-slow) var(--ease-out),
+    transform var(--duration-slow) var(--ease-out);
+}
+.animate-in.visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+.stagger-children > .animate-in {
+  transition-delay: calc(var(--stagger-index, 0) * var(--stagger-delay));
+}
+
+/* ── TRANSLATION BLOCKS ─────────────────────────────────────── */
+.translation-block {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0;
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  box-shadow: var(--shadow-md);
+  margin: var(--space-8) 0;
+}
+
+.translation-code {
+  background: var(--color-bg-code);
+  color: #CDD6F4;
+  padding: var(--space-6);
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  line-height: 1.7;
+  position: relative;
+  overflow-x: hidden;
+}
+
+.translation-english {
+  background: var(--color-surface-warm);
+  padding: var(--space-6);
+  font-size: var(--text-sm);
+  line-height: 1.7;
+  border-left: 3px solid var(--color-accent);
+}
+
+.translation-label {
+  position: absolute;
+  top: var(--space-2);
+  right: var(--space-3);
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  opacity: 0.5;
+}
+.translation-english .translation-label {
+  position: static;
+  display: block;
+  margin-bottom: var(--space-3);
+  color: var(--color-text-muted);
+}
+
+.translation-lines .tl {
+  padding: var(--space-1) 0;
+  border-bottom: 1px solid var(--color-border-light);
+  color: var(--color-text-secondary);
+}
+.translation-lines .tl:last-child { border-bottom: none; }
+
+/* ── QUIZ ───────────────────────────────────────────────────── */
+.quiz-container {
+  background: var(--color-surface);
+  border-radius: var(--radius-lg);
+  padding: var(--space-8);
+  box-shadow: var(--shadow-md);
+  margin: var(--space-8) 0;
+}
+
+.quiz-question-block { margin-bottom: var(--space-8); }
+.quiz-question-block:last-of-type { margin-bottom: 0; }
+
+.quiz-question {
+  font-family: var(--font-display);
+  font-size: var(--text-lg);
+  font-weight: 600;
+  margin-bottom: var(--space-4);
+  line-height: var(--leading-snug);
+}
+
+.quiz-options {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.quiz-option {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-3) var(--space-4);
+  border: 2px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  background: var(--color-surface);
+  cursor: pointer;
+  width: 100%;
+  text-align: left;
+  font-family: var(--font-body);
+  font-size: var(--text-base);
+  transition: border-color var(--duration-fast), background var(--duration-fast);
+}
+.quiz-option:hover:not(:disabled) { border-color: var(--color-accent-muted); }
+.quiz-option.selected { border-color: var(--color-accent); background: var(--color-accent-light); }
+.quiz-option.correct  { border-color: var(--color-success); background: var(--color-success-light); }
+.quiz-option.incorrect{ border-color: var(--color-error);   background: var(--color-error-light); }
+.quiz-option:disabled { cursor: default; }
+
+.quiz-option-radio {
+  width: 18px; height: 18px;
+  border-radius: 50%;
+  border: 2px solid var(--color-border);
+  flex-shrink: 0;
+  transition: all var(--duration-fast);
+}
+.quiz-option.selected .quiz-option-radio {
+  border-color: var(--color-accent);
+  background: var(--color-accent);
+  box-shadow: inset 0 0 0 3px white;
+}
+.quiz-option.correct .quiz-option-radio  { border-color: var(--color-success); background: var(--color-success); box-shadow: inset 0 0 0 3px white; }
+.quiz-option.incorrect .quiz-option-radio{ border-color: var(--color-error);   background: var(--color-error);   box-shadow: inset 0 0 0 3px white; }
+
+.quiz-feedback {
+  max-height: 0;
+  overflow: hidden;
+  opacity: 0;
+  transition: max-height var(--duration-normal), opacity var(--duration-normal);
+  font-size: var(--text-sm);
+  border-radius: var(--radius-sm);
+}
+.quiz-feedback.show {
+  max-height: 200px;
+  opacity: 1;
+  padding: var(--space-3);
+  margin-top: var(--space-2);
+}
+.quiz-feedback.success { background: var(--color-success-light); color: var(--color-success); }
+.quiz-feedback.error   { background: var(--color-error-light);   color: var(--color-error); }
+.quiz-feedback.warning { background: var(--color-info-light);    color: var(--color-info); }
+
+.quiz-check-btn, .quiz-reset-btn {
+  margin-top: var(--space-6);
+  padding: var(--space-3) var(--space-6);
+  border-radius: var(--radius-sm);
+  font-family: var(--font-body);
+  font-size: var(--text-sm);
+  font-weight: 600;
+  cursor: pointer;
+  border: none;
+  transition: background var(--duration-fast), transform var(--duration-fast);
+}
+.quiz-check-btn {
+  background: var(--color-accent);
+  color: white;
+  margin-right: var(--space-3);
+}
+.quiz-check-btn:hover { background: var(--color-accent-hover); transform: translateY(-1px); }
+.quiz-reset-btn {
+  background: var(--color-surface);
+  color: var(--color-text-secondary);
+  border: 1px solid var(--color-border);
+}
+.quiz-reset-btn:hover { border-color: var(--color-accent-muted); }
+
+/* Scenario block */
+.scenario-block { margin-bottom: var(--space-6); }
+.scenario-context {
+  background: var(--color-info-light);
+  border-left: 3px solid var(--color-info);
+  border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
+  padding: var(--space-4);
+  margin-bottom: var(--space-4);
+}
+.scenario-label {
+  display: inline-block;
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--color-info);
+  margin-bottom: var(--space-2);
+}
+
+/* ── DRAG AND DROP ──────────────────────────────────────────── */
+.dnd-container { margin: var(--space-8) 0; }
+.dnd-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-3);
+  margin-bottom: var(--space-6);
+}
+.dnd-chip {
+  padding: var(--space-2) var(--space-4);
+  background: var(--color-accent);
+  color: white;
+  border-radius: var(--radius-full);
+  font-size: var(--text-sm);
+  font-weight: 600;
+  cursor: grab;
+  user-select: none;
+  transition: opacity var(--duration-fast), transform var(--duration-fast);
+}
+.dnd-chip:active { cursor: grabbing; transform: scale(1.05); }
+.dnd-chip.dragging { opacity: 0.4; }
+.dnd-chip.placed { opacity: 0.3; pointer-events: none; }
+
+.dnd-zones { display: flex; flex-direction: column; gap: var(--space-4); }
+.dnd-zone {
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  padding: var(--space-4);
+  background: var(--color-surface);
+}
+.dnd-zone-label { font-size: var(--text-sm); color: var(--color-text-secondary); margin-bottom: var(--space-3); }
+.dnd-zone-target {
+  min-height: 40px;
+  border: 2px dashed var(--color-border);
+  border-radius: var(--radius-sm);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: var(--text-sm);
+  color: var(--color-text-muted);
+  transition: border-color var(--duration-fast), background var(--duration-fast);
+}
+.dnd-zone-target.drag-over { border-color: var(--color-accent); background: var(--color-accent-light); }
+.dnd-zone-target.correct-placed { border-color: var(--color-success); background: var(--color-success-light); color: var(--color-success); font-weight: 600; }
+.dnd-zone-target.incorrect-placed{ border-color: var(--color-error); background: var(--color-error-light); }
+.touch-ghost {
+  padding: var(--space-2) var(--space-4);
+  background: var(--color-accent);
+  color: white;
+  border-radius: var(--radius-full);
+  font-size: var(--text-sm);
+  font-weight: 600;
+  opacity: 0.85;
+  pointer-events: none;
+}
+
+/* ── GROUP CHAT ─────────────────────────────────────────────── */
+.chat-window {
+  background: var(--color-surface);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-md);
+  overflow: hidden;
+  margin: var(--space-8) 0;
+}
+
+.chat-messages {
+  padding: var(--space-6);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+  min-height: 200px;
+}
+
+.chat-message {
+  display: flex;
+  align-items: flex-end;
+  gap: var(--space-3);
+  animation: fadeSlideUp 0.3s var(--ease-out);
+}
+
+.chat-avatar {
+  width: 36px; height: 36px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: var(--font-display);
+  font-size: var(--text-sm);
+  font-weight: 700;
+  color: white;
+  flex-shrink: 0;
+}
+
+.chat-bubble {
+  max-width: 75%;
+  background: var(--color-bg-warm);
+  border-radius: var(--radius-md) var(--radius-md) var(--radius-md) 4px;
+  padding: var(--space-3) var(--space-4);
+}
+
+.chat-sender {
+  display: block;
+  font-size: var(--text-xs);
+  font-weight: 700;
+  margin-bottom: var(--space-1);
+  font-family: var(--font-mono);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.chat-bubble p {
+  font-size: var(--text-sm);
+  margin: 0;
+  line-height: var(--leading-normal);
+}
+
+.chat-typing {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding: 0 var(--space-6) var(--space-4);
+}
+
+.chat-typing-dots {
+  display: flex;
+  gap: var(--space-1);
+  background: var(--color-bg-warm);
+  padding: var(--space-3) var(--space-4);
+  border-radius: var(--radius-md);
+}
+
+.typing-dot {
+  width: 8px; height: 8px;
+  border-radius: 50%;
+  background: var(--color-text-muted);
+  animation: typingBounce 1.4s infinite;
+}
+.typing-dot:nth-child(2) { animation-delay: 0.2s; }
+.typing-dot:nth-child(3) { animation-delay: 0.4s; }
+
+.chat-controls {
+  padding: var(--space-4) var(--space-6);
+  border-top: 1px solid var(--color-border-light);
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  background: var(--color-surface-warm);
+}
+.chat-progress {
+  margin-left: auto;
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
+  font-family: var(--font-mono);
+}
+
+/* ── FLOW / DATA FLOW ANIMATION ─────────────────────────────── */
+.flow-animation {
+  position: relative;
+  background: var(--color-surface);
+  border-radius: var(--radius-lg);
+  padding: var(--space-8);
+  box-shadow: var(--shadow-md);
+  margin: var(--space-8) 0;
+}
+
+.flow-actors {
+  display: flex;
+  justify-content: space-around;
+  align-items: center;
+  gap: var(--space-4);
+  margin-bottom: var(--space-8);
+  flex-wrap: wrap;
+}
+
+.flow-actor {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-2);
+  transition: all var(--duration-normal) var(--ease-out);
+}
+
+.flow-actor-icon {
+  width: 56px; height: 56px;
+  border-radius: var(--radius-md);
+  background: var(--color-bg-warm);
+  border: 2px solid var(--color-border);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: var(--font-display);
+  font-size: var(--text-xl);
+  font-weight: 700;
+  transition: all var(--duration-normal) var(--ease-out);
+}
+
+.flow-actor span {
+  font-size: var(--text-xs);
+  color: var(--color-text-secondary);
+  font-family: var(--font-mono);
+  text-align: center;
+}
+
+.flow-actor.active .flow-actor-icon {
+  border-color: var(--color-accent);
+  background: var(--color-accent-light);
+  box-shadow: 0 0 0 3px var(--color-accent-light), 0 0 20px rgba(217,79,48,0.15);
+  transform: scale(1.1);
+}
+
+.flow-packet {
+  width: 16px; height: 16px;
+  border-radius: 50%;
+  background: var(--color-accent);
+  position: absolute;
+  pointer-events: none;
+  display: none;
+  box-shadow: 0 0 8px rgba(217,79,48,0.5);
+}
+
+.flow-step-label {
+  text-align: center;
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+  min-height: 2.5em;
+  padding: var(--space-3) var(--space-4);
+  background: var(--color-bg-warm);
+  border-radius: var(--radius-sm);
+  margin-bottom: var(--space-6);
+  line-height: var(--leading-normal);
+}
+
+.flow-controls {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+}
+.flow-progress {
+  margin-left: auto;
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
+  font-family: var(--font-mono);
+}
+
+/* ── ARCHITECTURE DIAGRAM ───────────────────────────────────── */
+.arch-diagram {
+  background: var(--color-surface);
+  border-radius: var(--radius-lg);
+  padding: var(--space-8);
+  box-shadow: var(--shadow-md);
+  margin: var(--space-8) 0;
+}
+.arch-zone {
+  border: 1px dashed var(--color-border);
+  border-radius: var(--radius-md);
+  padding: var(--space-6);
+  margin-bottom: var(--space-4);
+}
+.arch-zone-label {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--color-text-muted);
+  margin-bottom: var(--space-4);
+}
+.arch-component {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-4);
+  background: var(--color-surface-warm);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  margin: var(--space-2);
+  transition: all var(--duration-fast);
+  font-size: var(--text-sm);
+}
+.arch-component:hover, .arch-component.active {
+  border-color: var(--color-accent);
+  background: var(--color-accent-light);
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-sm);
+}
+.arch-icon { font-size: 1.5rem; }
+.arch-description {
+  margin-top: var(--space-4);
+  padding: var(--space-4);
+  background: var(--color-bg-warm);
+  border-radius: var(--radius-sm);
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+  min-height: 2.5em;
+}
+
+/* ── LAYER TOGGLE ───────────────────────────────────────────── */
+.layer-demo { margin: var(--space-8) 0; }
+.layer-tabs {
+  display: flex;
+  gap: var(--space-2);
+  margin-bottom: var(--space-4);
+}
+.layer-tab {
+  padding: var(--space-2) var(--space-5);
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--color-border);
+  background: var(--color-surface);
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  cursor: pointer;
+  transition: all var(--duration-fast);
+}
+.layer-tab.active {
+  background: var(--color-accent);
+  color: white;
+  border-color: var(--color-accent);
+}
+.layer-viewport {
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  border: 1px solid var(--color-border);
+}
+.layer-description {
+  margin-top: var(--space-3);
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+}
+
+/* ── BUG CHALLENGE ──────────────────────────────────────────── */
+.bug-challenge {
+  background: var(--color-surface);
+  border-radius: var(--radius-lg);
+  padding: var(--space-8);
+  box-shadow: var(--shadow-md);
+  margin: var(--space-8) 0;
+}
+.bug-challenge h3 {
+  font-family: var(--font-display);
+  font-size: var(--text-lg);
+  font-weight: 600;
+  margin-bottom: var(--space-4);
+}
+.bug-code {
+  background: var(--color-bg-code);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  margin-bottom: var(--space-4);
+}
+.bug-line {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-2) var(--space-4);
+  cursor: pointer;
+  transition: background var(--duration-fast);
+}
+.bug-line:hover { background: rgba(255,255,255,0.05); }
+.bug-line.correct  { background: rgba(45,139,85,0.2); }
+.bug-line.incorrect{ background: rgba(201,59,59,0.2); }
+.line-num {
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  color: #6C7086;
+  min-width: 1.5em;
+  text-align: right;
+  user-select: none;
+}
+.bug-line code {
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  color: #CDD6F4;
+}
+.bug-feedback {
+  max-height: 0;
+  overflow: hidden;
+  opacity: 0;
+  transition: max-height var(--duration-normal), opacity var(--duration-normal);
+  font-size: var(--text-sm);
+  border-radius: var(--radius-sm);
+}
+.bug-feedback.show {
+  max-height: 200px;
+  opacity: 1;
+  padding: var(--space-3);
+}
+.bug-feedback.success { background: var(--color-success-light); color: var(--color-success); }
+.bug-feedback.error   { background: var(--color-error-light);   color: var(--color-error); }
+
+/* ── CALLOUT BOXES ──────────────────────────────────────────── */
+.callout {
+  display: flex;
+  gap: var(--space-4);
+  padding: var(--space-5);
+  border-radius: var(--radius-md);
+  margin: var(--space-6) 0;
+  border-left: 4px solid;
+}
+.callout-accent  { background: var(--color-accent-light);  border-color: var(--color-accent); }
+.callout-info    { background: var(--color-info-light);    border-color: var(--color-info); }
+.callout-warning { background: var(--color-error-light);   border-color: var(--color-error); }
+
+.callout-icon { font-size: 1.25rem; flex-shrink: 0; margin-top: 2px; }
+.callout-title { display: block; font-weight: 700; margin-bottom: var(--space-1); }
+.callout-content p { font-size: var(--text-sm); margin: 0; color: var(--color-text-secondary); }
+
+/* ── PATTERN / FEATURE CARDS ────────────────────────────────── */
+.pattern-cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: var(--space-4);
+  margin: var(--space-6) 0;
+}
+.pattern-card {
+  background: var(--color-surface);
+  border-radius: var(--radius-md);
+  padding: var(--space-6);
+  box-shadow: var(--shadow-sm);
+  border-top: 3px solid var(--color-accent);
+  transition: transform var(--duration-normal) var(--ease-out), box-shadow var(--duration-normal);
+}
+.pattern-card:hover { transform: translateY(-4px); box-shadow: var(--shadow-md); }
+.pattern-icon {
+  width: 40px; height: 40px;
+  border-radius: var(--radius-sm);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.1rem;
+  margin-bottom: var(--space-3);
+}
+.pattern-title {
+  font-family: var(--font-display);
+  font-size: var(--text-base);
+  font-weight: 700;
+  margin-bottom: var(--space-2);
+}
+.pattern-desc {
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+  line-height: var(--leading-normal);
+  margin: 0;
+}
+
+/* ── FLOW DIAGRAMS (static) ─────────────────────────────────── */
+.flow-steps {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  flex-wrap: wrap;
+  margin: var(--space-6) 0;
+}
+.flow-step {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-2);
+  text-align: center;
+}
+.flow-step-num {
+  width: 40px; height: 40px;
+  border-radius: 50%;
+  background: var(--color-accent);
+  color: white;
+  font-family: var(--font-display);
+  font-weight: 700;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.flow-step p { font-size: var(--text-sm); color: var(--color-text-secondary); max-width: 120px; margin: 0; }
+.flow-arrow {
+  font-size: var(--text-xl);
+  color: var(--color-text-muted);
+  flex-shrink: 0;
+}
+
+/* ── BADGE / CONFIG LIST ────────────────────────────────────── */
+.badge-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  margin: var(--space-6) 0;
+}
+.badge-item {
+  display: flex;
+  align-items: center;
+  gap: var(--space-4);
+  padding: var(--space-3) var(--space-4);
+  border: 1px solid var(--color-border-light);
+  border-radius: var(--radius-sm);
+  background: var(--color-surface);
+  transition: border-color var(--duration-fast);
+}
+.badge-item:hover { border-color: var(--color-accent-muted); }
+.badge-code {
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  background: var(--color-bg-code);
+  color: #CBA6F7;
+  padding: var(--space-1) var(--space-3);
+  border-radius: var(--radius-sm);
+  white-space: nowrap;
+}
+.badge-desc {
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+}
+
+/* ── GLOSSARY TOOLTIPS ──────────────────────────────────────── */
+.term {
+  border-bottom: 1.5px dashed var(--color-accent-muted);
+  cursor: pointer;
+}
+.term:hover, .term.active {
+  border-bottom-color: var(--color-accent);
+  color: var(--color-accent);
+}
+.term-tooltip {
+  position: fixed;
+  background: var(--color-bg-code);
+  color: #CDD6F4;
+  padding: var(--space-3) var(--space-4);
+  border-radius: var(--radius-sm);
+  font-size: var(--text-sm);
+  font-family: var(--font-body);
+  line-height: var(--leading-normal);
+  width: max(200px, min(320px, 80vw));
+  box-shadow: var(--shadow-lg);
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity var(--duration-fast);
+  z-index: 10000;
+}
+.term-tooltip::after {
+  content: '';
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  border: 6px solid transparent;
+  border-top-color: var(--color-bg-code);
+}
+.term-tooltip.visible { opacity: 1; }
+.term-tooltip.flip::after {
+  top: auto;
+  bottom: 100%;
+  border-top-color: transparent;
+  border-bottom-color: var(--color-bg-code);
+}
+
+/* ── VISUAL FILE TREE ───────────────────────────────────────── */
+.file-tree {
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  margin: var(--space-6) 0;
+}
+.ft-folder, .ft-file {
+  padding: var(--space-2) var(--space-3);
+  border-left: 2px solid var(--color-border-light);
+  margin-left: var(--space-4);
+}
+.ft-folder > .ft-name { color: var(--color-accent); font-weight: 600; }
+.ft-folder > .ft-name::before { content: '📁 '; }
+.ft-file > .ft-name::before { content: '📄 '; }
+.ft-desc {
+  color: var(--color-text-secondary);
+  font-family: var(--font-body);
+  margin-left: var(--space-2);
+  font-size: var(--text-xs);
+}
+.ft-children { margin-left: var(--space-4); }
+
+/* ── ICON-LABEL ROWS ────────────────────────────────────────── */
+.icon-rows {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+  margin: var(--space-6) 0;
+}
+.icon-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-4);
+  padding: var(--space-4);
+  background: var(--color-surface);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-sm);
+}
+.icon-row strong { display: block; font-weight: 600; }
+.icon-row p { margin: var(--space-1) 0 0; color: var(--color-text-secondary); font-size: var(--text-sm); }
+.icon-circle {
+  width: 48px; height: 48px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.25rem;
+  flex-shrink: 0;
+}
+
+/* ── NUMBERED STEP CARDS ────────────────────────────────────── */
+.step-cards {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  margin: var(--space-6) 0;
+}
+.step-card {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-4);
+  padding: var(--space-4) var(--space-5);
+  background: var(--color-surface);
+  border-radius: var(--radius-md);
+  border-left: 3px solid var(--color-accent);
+  box-shadow: var(--shadow-sm);
+}
+.step-num {
+  width: 32px; height: 32px;
+  border-radius: 50%;
+  background: var(--color-accent);
+  color: white;
+  font-weight: 700;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: var(--font-display);
+  flex-shrink: 0;
+}
+.step-body strong { display: block; font-weight: 600; margin-bottom: var(--space-1); }
+.step-body p { margin: 0; color: var(--color-text-secondary); font-size: var(--text-sm); }
+
+/* ── SHARED BUTTON STYLE ────────────────────────────────────── */
+.btn {
+  padding: var(--space-2) var(--space-5);
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--color-border);
+  background: var(--color-surface);
+  font-family: var(--font-body);
+  font-size: var(--text-sm);
+  font-weight: 600;
+  cursor: pointer;
+  transition: all var(--duration-fast);
+  color: var(--color-text-secondary);
+}
+.btn:hover { border-color: var(--color-accent-muted); color: var(--color-accent); }
+.btn-primary {
+  background: var(--color-accent);
+  color: white;
+  border-color: var(--color-accent);
+}
+.btn-primary:hover { background: var(--color-accent-hover); border-color: var(--color-accent-hover); color: white; }
+
+/* ── RESPONSIVE ─────────────────────────────────────────────── */
+@media (max-width: 768px) {
+  :root {
+    --text-4xl: 1.875rem;
+    --text-5xl: 2.25rem;
+    --text-6xl: 3rem;
+  }
+  .translation-block { grid-template-columns: 1fr; }
+  .translation-english { border-left: none; border-top: 3px solid var(--color-accent); }
+  .pattern-cards { grid-template-columns: 1fr 1fr; }
+}
+
+@media (max-width: 480px) {
+  :root {
+    --text-4xl: 1.5rem;
+    --text-5xl: 1.875rem;
+    --text-6xl: 2.25rem;
+  }
+  .module { padding: var(--space-8) var(--space-4); }
+  .pattern-cards { grid-template-columns: 1fr; }
+  .flow-steps { flex-direction: column; }
+  .flow-arrow { transform: rotate(90deg); }
+  .nav-title { max-width: 140px; }
+}
+
+/* ── KEYFRAMES ──────────────────────────────────────────────── */
+@keyframes fadeSlideUp {
+  from { opacity: 0; transform: translateY(12px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes typingBounce {
+  0%, 60%, 100% { transform: translateY(0); }
+  30%           { transform: translateY(-6px); }
+}
+
+@keyframes packetMove {
+  from { left: var(--packet-from-x); top: var(--packet-from-y); opacity: 0; }
+  20%  { opacity: 1; }
+  80%  { opacity: 1; }
+  to   { left: var(--packet-to-x);   top: var(--packet-to-y);   opacity: 0; }
+}

--- a/courses/image-generator-ui-course/_base.html
+++ b/courses/image-generator-ui-course/_base.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Inside the Image Generator</title>
+
+  <!-- Google Fonts: Bricolage Grotesque · DM Sans · JetBrains Mono -->
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:opsz,wght@12..96,400;12..96,600;12..96,700;12..96,800&family=DM+Sans:ital,opsz,wght@0,9..40,300;0,9..40,400;0,9..40,500;0,9..40,600;0,9..40,700;1,9..40,400;1,9..40,500&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+
+  <link rel="stylesheet" href="styles.css">
+
+  <!--
+    CUSTOMIZE PER COURSE — change only the three accent variables below.
+    Options:
+      vermillion  #D94F30 / #C4432A / #FDEEE9 / #E8836C  (default)
+      coral       #E06B56 / #C85A47 / #FDECEA / #E89585
+      teal        #2A7B9B / #1F6280 / #E4F2F7 / #5A9DB8
+      amber       #D4A843 / #BF9530 / #FDF5E0 / #E0C070
+      forest      #2D8B55 / #226B41 / #E8F5EE / #5AAD7A
+  -->
+  <style>
+    :root {
+      --color-accent:       #2A7B9B;
+      --color-accent-hover: #1F6280;
+      --color-accent-light: #E4F2F7;
+      --color-accent-muted: #5A9DB8;
+    }
+  </style>
+
+  <script src="main.js" defer></script>
+</head>
+<body>
+
+  <nav class="nav" id="nav">
+    <div class="progress-bar" id="progress-bar" role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100"></div>
+    <div class="nav-inner">
+      <span class="nav-title">Inside the Image Generator</span>
+      <div class="nav-dots" id="nav-dots" role="tablist">
+        <button class="nav-dot" data-target="module-1" data-tooltip="The Journey of One Photo" role="tab" aria-label="Module 1: The Journey of One Photo"></button>
+        <button class="nav-dot" data-target="module-2" data-tooltip="Front of House, Backstage" role="tab" aria-label="Module 2: Front of House, Backstage"></button>
+        <button class="nav-dot" data-target="module-3" data-tooltip="Commissioning the Artist" role="tab" aria-label="Module 3: Commissioning the Artist"></button>
+        <button class="nav-dot" data-target="module-4" data-tooltip="The LEGO Box" role="tab" aria-label="Module 4: The LEGO Box"></button>
+        <button class="nav-dot" data-target="module-5" data-tooltip="Tapping the Walls" role="tab" aria-label="Module 5: Tapping the Walls"></button>
+      </div>
+    </div>
+  </nav>
+
+  <main id="main">
+    <!-- modules/*.html content is assembled here by build.sh -->

--- a/courses/image-generator-ui-course/_footer.html
+++ b/courses/image-generator-ui-course/_footer.html
@@ -1,0 +1,4 @@
+  </main>
+
+</body>
+</html>

--- a/courses/image-generator-ui-course/briefs/01-journey.md
+++ b/courses/image-generator-ui-course/briefs/01-journey.md
@@ -1,0 +1,129 @@
+# Module 1: The Journey of One Photo
+
+**Output file:** `courses/image-generator-ui-course/modules/01-journey.html`
+**Section wrapper:** `<section class="module" id="module-1">`
+
+## What the app is (context for the opening — explain this in plain English on screen 1)
+
+The app is a website called **Charlie & Lola AI**. You drag a photo of yourself (or your dog, or a toy) onto the page, click **Generate**, wait a few seconds, and you get back the same subject redrawn in the scratchy, flat-colour, hand-drawn style of the British children's cartoon *Charlie and Lola*. Then you can download it or copy a share link.
+
+That's the entire product. Everything in this course is about the machinery behind that one button — and about the visual building blocks the interface is made from.
+
+Built with: Next.js 15 (a website framework), React, TypeScript, Tailwind CSS + Shadcn UI for looks, and Google's **Gemini** model for the actual drawing.
+
+## Teaching Arc
+
+- **Metaphor:** **The one-hour photo lab.** You hand your film over the counter, it disappears behind the wall into machines you never see, and twenty minutes later prints come back. You don't know what the machines do — but there IS a fixed sequence, and every failed photo has a specific station where it went wrong. This module walks the learner behind the counter for the first time. (Do NOT reuse this metaphor later — modules 2–5 have their own.)
+- **Opening hook:** "You drop a photo onto the box and click Generate. For four seconds, nothing visible happens. Here's everything that happens in those four seconds."
+- **Key insight:** A generation is not one magical event — it's a **relay of seven hand-offs** between separate pieces of software, three of which are not on your computer at all. Knowing the seven stations means that when something breaks you can name the station instead of saying "the AI is broken."
+- **"Why should I care?":** When you tell an AI coding assistant "the image isn't showing up," you get a shotgun of guesses. When you say "the POST to /api/generate-cyberpunk returns fine but the preview stays empty," you get a fix. This module is where you learn to say the second thing.
+
+## Screens (suggested — 5 screens)
+
+1. **What this thing does** — the product in plain English + the two halves this course covers (the generator engine; the interface it lives in). Short.
+2. **The seven stations** — the hero visual: the data flow animation, described below.
+3. **Station 1–2: the photo never leaves the page (at first)** — `handleFileUpload`, FileReader, data URLs, and why the photo sits in the browser as text before it goes anywhere.
+4. **Station 3: packing the parcel** — `generateImage()` building FormData and POSTing it.
+5. **Station 6–7: the image comes back as text** — what the server sends back, and the quiz.
+
+## Code Snippets (pre-extracted — use VERBATIM, do not trim or reformat)
+
+**File: `src/components/blocks/imagen-wrapper/imagen-client.tsx` (lines 281–294)**
+```
+  const handleFileUpload = (file: File) => {
+    if (uploadedImages.length >= 5) {
+      toast.error(t.upload.max_images_error);
+      return;
+    }
+
+    const reader = new FileReader();
+    reader.onload = (e) => {
+      const imageData = e.target?.result as string;
+      setUploadedImages(prev => [...prev, imageData]);
+      setGeneratedImage(null);
+    };
+    reader.readAsDataURL(file);
+  };
+```
+
+**File: `src/components/blocks/imagen-wrapper/imagen-client.tsx` (lines 334–357)**
+```
+      const formData = new FormData();
+
+      formData.append('mode', 'image2image');
+      formData.append('style', 'charlie-lola'); // Fixed style for Charlie and Lola
+      formData.append('aspectRatio', aspectRatio);
+      formData.append('outputFormat', outputFormat);
+      formData.append('model', 'standard'); // Fixed model
+
+      if (customPrompt.trim()) {
+        formData.append('customPrompt', customPrompt);
+      }
+
+      for (let i = 0; i < uploadedImages.length; i++) {
+        const response = await fetch(uploadedImages[i]);
+        const blob = await response.blob();
+        formData.append(`image_${i}`, blob);
+      }
+
+      formData.append('imageCount', uploadedImages.length.toString());
+
+      const apiResponse = await fetch('/api/generate-cyberpunk', {
+        method: 'POST',
+        body: formData,
+      });
+```
+
+**File: `src/app/api/generate-cyberpunk/route.ts` (lines 173–178)**
+```
+    // Generate filename and store the image
+    const batch = getUuid();
+    const fileExtension = generatedImageMimeType.split('/')[1];
+    const filename = `charlie-lola-${batch}.${fileExtension}`;
+
+    let finalImageUrl = `data:${generatedImageMimeType};base64,${generatedImageData}`;
+```
+
+**File: `src/components/blocks/imagen-wrapper/imagen-client.tsx` (lines 363–367)**
+```
+      const result = await apiResponse.json();
+
+      if (result.code === 0 && result.data?.imageUrl) {
+        setGeneratedImage(result.data.imageUrl);
+
+```
+
+## Interactive Elements (all required)
+
+- **Data flow animation** (this module's hero visual — `references/interactive-elements.md` → "Message Flow / Data Flow Animation"). Actors, left to right:
+  `You (the browser)` → `ImagenClient (the page's code)` → `/api/generate-cyberpunk (the server)` → `Google Gemini` → `Cloudflare R2 (file storage)`
+  Steps (7):
+  1. You drop a photo onto the dashed box — the browser reads the file into a long text string (a *data URL*). Nothing has left your computer yet.
+  2. You click Generate. `ImagenClient` packs the photo + settings into a FormData parcel.
+  3. The parcel is POSTed to `/api/generate-cyberpunk` — the app's own server.
+  4. The server picks an unused Gemini API key from its pool, converts the photo to base64, and glues it to a written style instruction.
+  5. Gemini reads the picture and the instruction and sends back a **new picture, encoded as text**.
+  6. The server uploads that picture to Cloudflare R2 storage and gets back a public web address.
+  7. The address travels back to the browser, gets dropped into `setGeneratedImage(...)`, and React repaints the right-hand panel.
+
+- **Code ↔ English translation** — at minimum the `handleFileUpload` snippet and the FormData snippet. Line-by-line English on the right.
+- **Quiz** — 3 questions, scenario/tracing style. Suggested angles:
+  1. A user says "I dropped my photo in and the thumbnail appeared instantly, even with my wifi off." Which stations had already run? (Answer: 1–2 only; FileReader is entirely local. Teaches the local/remote boundary.)
+  2. The preview panel stays empty but the browser's network tab shows the POST returned successfully with an `imageUrl`. Where would you look first? (Answer: the handling of the response in the browser — `result.code === 0` — not the AI. Sets up module 5.)
+  3. You want to add "generate three variations at once." Which station's shape changes most? (Answer: the server route + the Gemini call; the upload UI already accepts 5 images. Tests architecture reading.)
+- **Callout box** — "aha!": *An image on the web is just text if you squint.* base64 / data URLs mean the same picture can travel as a string of letters through channels that only carry text. This is why AI APIs can hand pictures back over a text connection.
+- **Glossary tooltips** (first use, aggressive): browser, server, API, endpoint, route, FormData, POST, data URL, base64, MIME type, state, React, component, upload, storage bucket, response, JSON.
+
+## Reference Files to Read
+
+- `references/content-philosophy.md` — all of it
+- `references/gotchas.md` — all of it
+- `references/interactive-elements.md` → "Message Flow / Data Flow Animation", "Code ↔ English Translation Blocks", "Multiple-Choice Quizzes", "Callout Boxes", "Numbered Step Cards", "Glossary Tooltips"
+- `references/design-system.md` → "Module Structure", "Typography", "Color Palette"
+
+## Connections
+
+- **Previous module:** none — this is the opening. Open by explaining what the app is.
+- **Next module:** *Front of House, Backstage* — which of these stations run in the visitor's browser, which run on the company's server, and why the API key can only ever live on one side. End module 1 by teasing that question: "Station 3 crossed a line. That line is the single most important thing to understand about this app — and it's next."
+- **Tone/style notes:** Accent colour is teal. Refer to code files by their real paths. Call the generator's client component **`ImagenClient`** and the server route **`/api/generate-cyberpunk`** consistently — every module uses those names. Never call the learner a "developer." Never say "as you know."
+- **Naming gotcha to mention once, lightly:** the endpoint is called `generate-cyberpunk` even though the app makes children's-book art — it's a leftover name from the template this app was built from. Mention it as a joke and move on; module 5 covers stale naming properly.

--- a/courses/image-generator-ui-course/briefs/02-actors.md
+++ b/courses/image-generator-ui-course/briefs/02-actors.md
@@ -1,0 +1,115 @@
+# Module 2: Front of House, Backstage
+
+**Output file:** `courses/image-generator-ui-course/modules/02-actors.html`
+**Section wrapper:** `<section class="module" id="module-2">`
+
+## Teaching Arc
+
+- **Metaphor:** **A theatre.** Front of house is what the audience sees: the stage, the actors, the programme in their hands. Backstage is the fly system, the lighting desk, and the safe in the manager's office with the keys in it. The audience can walk right up to the stage — they can never walk into the office. In this app, "front of house" is the visitor's browser and "backstage" is the company's server, and the single line `'use client'` at the top of a file is the stage door. (Metaphor is exclusive to this module — module 1 used a photo lab, module 4 uses a LEGO box.)
+- **Opening hook:** "The Google API key that pays for every image this app makes is sitting in a file right now. If it ever reached a visitor's browser, a stranger could run up the bill. Here's the wall that keeps it from happening — and how you can tell which side of the wall any file is on."
+- **Key insight:** Every file in a Next.js app runs on exactly one of two machines, and you can tell which by looking at the top line and at what the file touches. Files with `'use client'` are shipped to strangers. Files without it run only on the server, and only their *output* is shipped. Secrets, and anything expensive, must live on the server side.
+- **"Why should I care?":** This is the #1 thing AI coding assistants get wrong in Next.js projects — they put a `useState` in a server file, or read `process.env.SECRET` in a client file, and the error messages are famously confusing ("useState is not a function", "hydration mismatch"). If you can spot which side a file belongs to, you can correct the AI in one sentence instead of ten rounds of trial and error.
+
+## The cast (build the architecture visual around these five)
+
+| Actor | File | Side | Job |
+|---|---|---|---|
+| **The Page** | `src/app/[locale]/(default)/page.tsx` | server | The homepage. Renders the generator plus ten marketing sections below it. |
+| **ImagenWrapper** | `src/components/blocks/imagen-wrapper/index.tsx` | server | Looks up every piece of English/Chinese text the generator needs, bundles it into one plain object, hands it down as a prop. |
+| **ImagenClient** | `src/components/blocks/imagen-wrapper/imagen-client.tsx` | client (893 lines) | Everything interactive: drag-and-drop, previews, the Generate button, spinners, toasts, localStorage. |
+| **The route** | `src/app/api/generate-cyberpunk/route.ts` | server | The only door between the two worlds. Validates, spends credits, calls Gemini, stores the result. |
+| **The key pool** | `src/lib/gemini-api-pool.ts` | server | Holds the Gemini API keys read from environment variables. Never leaves the building. (Module 3 covers how it rotates them.) |
+
+## Code Snippets (pre-extracted — use VERBATIM, do not trim or reformat)
+
+**File: `src/components/blocks/imagen-wrapper/index.tsx` (lines 8–18)** — the server wrapper
+```
+export default async function ImagenWrapper({ locale = 'en' }: ImagenWrapperProps = {}) {
+  // Set the request locale for server-side translations
+  setRequestLocale(locale);
+
+  // Get the translations on the server side with explicit locale
+  const t = await getTranslations({ locale, namespace: 'imagen' });
+
+  // Pass translations as props to the client component
+  const translations = {
+    badge: { text: t('badge.text') },
+    title: { main: t('title.main'), subtitle: t('title.subtitle') },
+```
+
+**File: `src/components/blocks/imagen-wrapper/index.tsx` (line 82)** — the hand-off
+```
+  return <ImagenClient translations={translations} />;
+```
+
+**File: `src/components/blocks/imagen-wrapper/imagen-client.tsx` (lines 1–8)** — the stage door
+```
+'use client';
+
+import React, { useState, useRef, useEffect } from 'react';
+import { useSession } from 'next-auth/react';
+import { Card, CardContent } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+import { useUserCredits } from '@/hooks/useUserCredits';
+```
+
+**File: `src/lib/gemini-api-pool.ts` (lines 19–27)** — what only the server can see
+```
+    // Get all Gemini API keys from environment variables
+    const geminiKeys = [
+      process.env.GEMINI_API_KEY,
+      process.env.GEMINI_API_KEY_1,
+      process.env.GEMINI_API_KEY_2, 
+      process.env.GEMINI_API_KEY_3,
+      process.env.GEMINI_API_KEY_4,
+      process.env.GEMINI_API_KEY_5,
+    ].filter(key => key && key.trim() !== '');
+```
+
+**File: `src/components/blocks/imagen-wrapper/imagen-client.tsx` (lines 776–782)** — the one env var that IS allowed in the browser, because of its name
+```
+                    {t.buttons.generate}
+                    <span className="text-cl-blue font-medium">
+                      {process.env.NEXT_PUBLIC_FREE_MODE_ENABLED === 'true' 
+                        ? `(${t.buttons.limited_free})`
+                        : `(${modelOptions.find(m => m.value === selectedModel)?.credits || 10} credits)`
+                      }
+                    </span>
+```
+> Teaching note for this last one: the `NEXT_PUBLIC_` prefix is a promise you make to the framework — "it is safe for strangers to read this one." Anything with that prefix gets baked into the JavaScript sent to browsers. Anything without it is stripped out. Naming is the entire security mechanism, which is why a typo here is a real leak.
+
+## Interactive Elements (all required)
+
+- **Group chat animation** (this module's hero visual — `references/interactive-elements.md` → "Group Chat Animation"). This is the mandatory group-chat element for the whole course, so make it good. Frame it as a backstage group chat between the five actors above the moment a visitor loads the homepage. Suggested script:
+  - **The Page:** "Visitor incoming, locale `en`. Wrapper, you're up."
+  - **ImagenWrapper:** "On it. Pulling all 40-odd strings from the `imagen` namespace… badge, title, upload prompts, error messages. Bundling."
+  - **ImagenClient:** "Just send me the finished words. I can't read translation files — I run on a stranger's laptop."
+  - **ImagenWrapper:** "Here. One plain object, already in English." *(hands over `translations`)*
+  - **ImagenClient:** "Great. I'll take it from here — drag-and-drop, previews, the button. Route, stand by."
+  - **The route:** "Standing by. Nobody talks to Gemini except me."
+  - **ImagenClient:** "Can I just have the API key? It'd save a round trip."
+  - **The key pool:** "Absolutely not. 😊"
+  - **The route:** "It'd be in the page source in about four seconds. Send me the photo, I'll send you a picture."
+- **Code ↔ English translation** — at minimum the `'use client'` snippet and the `ImagenWrapper` translations snippet. Emphasise that `getTranslations` is `await`ed — a server component may pause and go look things up; a client component may not.
+- **Quiz** — 3–4 questions, architecture/debugging style. Suggested angles:
+  1. You ask an AI to "add a dropdown that remembers the last style the user picked." It writes the code into `index.tsx` (the wrapper). What goes wrong, and what's the one-line correction to give it? (Answer: remembering = state = client side. Tell it to put the dropdown in `imagen-client.tsx`, or make a new `'use client'` component.)
+  2. A teammate adds `process.env.GEMINI_API_KEY` to `imagen-client.tsx` to "speed things up." What's the actual consequence? (Answer: undefined at best because the prefix is missing — and if they "fixed" it by renaming to `NEXT_PUBLIC_GEMINI_API_KEY`, they'd publish the key to every visitor.)
+  3. Why does `ImagenWrapper` exist at all, when `ImagenClient` could fetch its own text? (Answer: translations are chosen per-visitor per-language on the server, so the correct words are already in the HTML before any JavaScript runs — faster first paint, and search engines see real text.)
+  4. Optional: the 893-line `imagen-client.tsx` holds upload, preview, prompt editing, download and share. What's the practical cost of that? (Answer: everything in it ships to every visitor and every change risks the whole panel; the honest answer is "it works, but it's the file you'd split first.")
+- **Callout box** — "aha!": *The browser is a hostile environment you don't control.* Everything you send there can be read, edited and replayed by whoever's holding the laptop. The client/server line isn't bureaucracy — it's the only place secrets can hide.
+- **Optional extra:** an architecture diagram or visual file tree showing the five actors with a vertical wall between browser and server.
+- **Glossary tooltips** (first use): server component, client component, `'use client'`, hydration, props, environment variable, `process.env`, API key, locale, internationalisation (i18n), namespace, `await` / asynchronous, prop drilling, bundle, page source.
+
+## Reference Files to Read
+
+- `references/content-philosophy.md` — all of it
+- `references/gotchas.md` — all of it
+- `references/interactive-elements.md` → "Group Chat Animation", "Code ↔ English Translation Blocks", "Multiple-Choice Quizzes", "Callout Boxes", "Visual File Tree", "Interactive Architecture Diagram", "Glossary Tooltips"
+- `references/design-system.md` → "Module Structure", "Color Palette"
+
+## Connections
+
+- **Previous module:** *The Journey of One Photo* — traced a single generation through seven stations, ending at the moment the parcel crossed from browser to server. Open by picking that moment back up.
+- **Next module:** *Commissioning the Artist* — what the server actually says to Gemini, and how it juggles six API keys so one exhausted key doesn't take the site down. Tease: "Backstage, there's a drawer with up to six keys in it. Only one gets used per request, and the drawer remembers which ones are burnt."
+- **Tone/style notes:** Accent colour is teal. Keep the five actor names exactly as in the table — modules 3 and 5 reuse them. Even/odd module backgrounds alternate automatically; don't add your own background overrides.

--- a/courses/image-generator-ui-course/briefs/03-gemini.md
+++ b/courses/image-generator-ui-course/briefs/03-gemini.md
@@ -1,0 +1,123 @@
+# Module 3: Commissioning the Artist
+
+**Output file:** `courses/image-generator-ui-course/modules/03-gemini.html`
+**Section wrapper:** `<section class="module" id="module-3">`
+
+## Teaching Arc
+
+- **Metaphor:** **Commissioning an illustrator.** You don't press a "Charlie and Lola" button — there is no such button anywhere in the world. Someone wrote a paragraph of instructions describing exactly how the drawing should look, including a list of things it must *not* look like, and the app sends that paragraph plus your photo to a general-purpose artist every single time. The "style" you picked in the interface is a written brief, not a filter. (Exclusive to this module.)
+- **Opening hook:** "Open the prompt box on the right of the generator and you can read the entire product. The whole 'Charlie & Lola style' is one paragraph of English, and you're allowed to edit it."
+- **Key insight:** The intelligence in this app is rented, not built. The app's own contribution is: choosing a key, describing the style well, attaching the photo in the right shape, digging the picture back out of the reply, and putting it somewhere permanent. That's the job — and each of those five steps is a place things break.
+- **"Why should I care?":** Three payoffs. (1) You learn that the biggest quality lever in an AI feature is the wording of the prompt, which you can change without touching any code. (2) You learn what a rate limit is and why apps pool keys — so you can reason about cost and capacity before you build. (3) You learn to check what the code actually calls rather than what the docs claim, because in this very repo the two disagree.
+
+## The documentation trap (teach this — it's the module's best moment)
+
+The project's own instructions file, `CLAUDE.md`, says in bold: *"The cyberpunk image generator requires a valid OpenAI API key to function"* and lists `OPENAI_API_KEY` as **REQUIRED**.
+
+The code does not call OpenAI. It calls **Google Gemini** (`gemini-2.5-flash-image-preview`), reading `GEMINI_API_KEY` through `src/lib/gemini-api-pool.ts`. The endpoint is also still called `generate-cyberpunk` and there is a separate, unused Kling video SDK sitting in `src/aisdk/` (only a demo route at `src/app/api/demo/gen-image/route.ts` ever imports it).
+
+Frame this generously — it's the completely normal residue of a project that got rebuilt while its documentation didn't. But make the lesson sharp: **an AI coding assistant reads `CLAUDE.md` and README files as gospel.** If you ask one to "fix the image generation," it may well go add OpenAI code to a Gemini app. The habit worth building is: *before trusting a doc, grep for what the code imports.*
+
+## Code Snippets (pre-extracted — use VERBATIM, do not trim or reformat)
+
+**File: `src/app/api/generate-cyberpunk/route.ts` (lines 121–129)** — the parcel handed to the model
+```
+    const imageEditPrompt = [
+      { text: charlieLolaPrompt },
+      {
+        inlineData: {
+          mimeType: mimeType,
+          data: base64Image,
+        },
+      },
+    ];
+```
+
+**File: `src/app/api/generate-cyberpunk/route.ts` (lines 136–139)** — the actual AI call, all four lines of it
+```
+      response = await ai.models.generateContent({
+        model: "gemini-2.5-flash-image-preview",
+        contents: imageEditPrompt,
+      });
+```
+
+**File: `src/app/api/generate-cyberpunk/route.ts` (lines 161–167)** — digging the picture out of the reply
+```
+    for (const part of response.candidates[0].content.parts) {
+      if (part.inlineData) {
+        generatedImageData = part.inlineData.data;
+        generatedImageMimeType = part.inlineData.mimeType;
+        break;
+      }
+    }
+```
+
+**File: `src/lib/gemini-api-pool.ts` (lines 49–59)** — the rotation
+```
+    // Try each key starting from current index
+    for (let i = 0; i < this.apiKeys.length; i++) {
+      const index = (this.currentIndex + i) % this.apiKeys.length;
+      const keyStatus = this.apiKeys[index];
+
+      if (keyStatus.isAvailable && keyStatus.requestCount < keyStatus.dailyLimit) {
+        this.currentIndex = (index + 1) % this.apiKeys.length;
+        keyStatus.lastUsed = new Date();
+        keyStatus.requestCount++;
+        return keyStatus.key;
+      }
+    }
+```
+
+**File: `src/app/api/generate-cyberpunk/route.ts` (lines 143–147)** — what happens when a key burns out
+```
+      // Check if it's a quota/limit error
+      if (error.message?.includes('quota') || error.message?.includes('limit') || error.status === 429) {
+        geminiApiPool.markKeyAsUnavailable(geminiApiKey, 'Quota exceeded');
+        return respErr("Too many users online! VIP users get priority access. You're in queue, please wait a moment or upgrade to VIP for instant access.", 'QUEUE_REQUIRED');
+      }
+```
+
+**File: `src/app/api/generate-cyberpunk/route.ts` (lines 182–186)** — the graceful fallback
+```
+    const hasStorageConfig = process.env.STORAGE_ENDPOINT && 
+                            process.env.STORAGE_ACCESS_KEY && 
+                            process.env.STORAGE_SECRET_KEY && 
+                            process.env.STORAGE_BUCKET;
+```
+> Teaching note: if storage isn't configured, `finalImageUrl` stays as the giant `data:image/png;base64,...` string from line 178 and the app still works — the picture just travels inside the response instead of living at a web address. A feature that degrades instead of crashing. Worth a callout.
+
+**The prompt itself** — quote it as prose in a callout or blockquote (it is one very long line in the source, `route.ts` line 94, so don't force it into a code block if it looks bad). Key parts to show: *"thin sketchy outlines, flat colors, childlike proportions, playful hand-drawn charm"* … *"Retain the subject's original clothing, hairstyle, facial features, accessories, skin tone, pose, and expression"* … *"Negative Prompt: No realistic shading, no detailed rendering, no anime or manga style, no 3D modeling, no photographic textures!"*
+Teach the three-part shape of a good image brief: **what to make** / **what to preserve** / **what to forbid** (the negative prompt). That structure transfers to any image model.
+
+## Interactive Elements (all required)
+
+- **Data flow animation** (hero visual — `references/interactive-elements.md` → "Message Flow / Data Flow Animation"). Actors: `Request` → `Key Pool (6 slots)` → `Gemini` → `R2 Storage` → `Response`. Steps:
+  1. Request arrives. Pool checks: does *any* key have life left? (`hasAvailableKeys()`)
+  2. Pool hands out key #3 — the next one in the circle — and immediately advances the pointer to #4, so the next request gets a different key.
+  3. The photo (base64) and the style brief travel to Gemini as one bundle.
+  4. Gemini answers with `candidates` — a list of parts, some text, one containing the new picture.
+  5. Server loops through the parts, grabs the first one with `inlineData`, throws the rest away.
+  6. Picture is uploaded to R2 storage and becomes a normal web address.
+  7. Alternate ending: Gemini answers **429 Too Many Requests** → key #3 is marked burnt and skipped by every future request → the user sees the queue message.
+- **Code ↔ English translation** — at minimum `imageEditPrompt` + `generateContent`, and the key rotation loop. For the rotation loop explain the `%` (modulo) as "a clock face — when you run past the last key, you wrap around to the first."
+- **Quiz** — 3–4 questions, decision/debugging style. Suggested angles:
+  1. Every user suddenly sees "Too many users online!" but your Gemini dashboard shows plenty of quota left. What's the most likely cause? (Answer: keys got marked unavailable in memory and nothing ever un-marks them — `markKeyAsAvailable` and `resetDailyLimits` exist but nothing calls them on a schedule. Also: the pool lives in one server's memory, so a restart is the accidental cure.)
+  2. You want output that keeps people's glasses instead of dropping them. Cheapest place to fix it? (Answer: the prompt paragraph — add it to the "retain" list. No deploy of new logic, no model change.)
+  3. You ask an AI assistant to "add support for the new OpenAI image model, matching how we do it today." What should you say first? (Answer: correct the premise — the app uses Gemini, `CLAUDE.md` is stale; point it at `route.ts` and the pool.)
+  4. Optional: a request returns 200 but "No image data found in Gemini API response." What does that tell you about where the failure was? (Answer: the call succeeded and the model replied — it just replied with text, e.g. a safety refusal. Not a network or key problem.)
+- **Callout boxes** — at least two: (a) *aha!*: "Rate limits are a nightclub capacity, not a fine — the API doesn't charge you more, it stops letting you in." (b) *the pool is memory, not a database*: on a platform that runs several server copies, each copy has its own private pool and its own idea of which keys are burnt.
+- **Optional extra:** pattern cards for the five jobs the app does around the model (choose a key / write the brief / attach the photo / dig out the reply / store it), or config badges for the environment variables (`GEMINI_API_KEY`…`GEMINI_API_KEY_5`, `STORAGE_*`).
+- **Glossary tooltips** (first use): prompt, negative prompt, model, token, rate limit, quota, HTTP 429, round-robin, modulo, singleton, in-memory, candidates, `inlineData`, MIME type, fallback, environment variable, SDK, endpoint.
+
+## Reference Files to Read
+
+- `references/content-philosophy.md` — all of it
+- `references/gotchas.md` — all of it
+- `references/interactive-elements.md` → "Message Flow / Data Flow Animation", "Code ↔ English Translation Blocks", "Multiple-Choice Quizzes", "Callout Boxes", "Pattern/Feature Cards", "Permission/Config Badges", "Glossary Tooltips"
+- `references/design-system.md` → "Module Structure", "Syntax Highlighting (Catppuccin-inspired)"
+
+## Connections
+
+- **Previous module:** *Front of House, Backstage* — established that the route and the key pool live on the server and the API key never crosses to the browser. Open by stepping through the door it left open.
+- **Next module:** *The LEGO Box* — how the interface around all this is built: colour tokens, Tailwind, and the Shadcn components the generator's panels are made of. Tease: "The engine is rented. The interface is entirely the app's own — and it's built out of about thirty reusable bricks."
+- **Tone/style notes:** Accent colour is teal. Keep actor names consistent with module 2 (`ImagenClient`, the route, the key pool). Be generous, not sneering, about the doc/code mismatch — the point is a habit, not a gotcha. Don't repeat module 1's photo-lab metaphor or module 2's theatre.

--- a/courses/image-generator-ui-course/briefs/04-ui.md
+++ b/courses/image-generator-ui-course/briefs/04-ui.md
@@ -1,0 +1,156 @@
+# Module 4: The LEGO Box
+
+**Output file:** `courses/image-generator-ui-course/modules/04-ui.html`
+**Section wrapper:** `<section class="module" id="module-4">`
+
+## Teaching Arc
+
+- **Metaphor:** **A LEGO box with a paint chart taped inside the lid.** `src/components/ui/` is the tray of loose bricks — Button, Card, Input, Dialog, thirty-odd of them, each doing one thing and owned by nobody in particular. `src/components/blocks/` is the finished models built from those bricks — the hero section, the pricing table, the generator panel. And `src/app/theme.css` is the paint chart: change one swatch there and every brick in every model repaints at once, because no brick names a colour directly. (Exclusive to this module — module 1 used a photo lab, module 2 a theatre, module 3 an illustrator's commission.)
+- **Opening hook:** "The generator's upload box glows yellow when you drag a photo over it. Nobody wrote the colour yellow anywhere near that box. Here's how the glow gets there — through four layers of indirection, every one of them earning its keep."
+- **Key insight:** Nothing in this interface names a colour, a corner radius or a shadow directly. Everything names a *role* — `primary`, `card`, `border`, `muted-foreground` — and the roles get their values in one file, twice: once for light mode, once for dark. That's why the whole app can flip to dark mode without a single component knowing dark mode exists.
+- **"Why should I care?":** When you tell an AI "make this button match the rest of the site," a vague request gets you a hardcoded hex colour that looks right today and wrong after the next theme tweak. Knowing the vocabulary — *"use the `secondary` token, not a hex value"*, *"add a `variant` to the existing `buttonVariants`, don't write a new component"* — is the difference between an interface that stays consistent and one that drifts into forty shades of almost-yellow.
+
+## The four layers (this is the module's spine — consider a layer-toggle or numbered step cards)
+
+1. **The paint chart** — `src/app/theme.css`, `:root` block: raw colour values in `oklch()`, given role names like `--primary`, `--card`, `--border`. A second block, `.dark`, redefines the same names with different values.
+2. **The bridge** — the `@theme inline { ... }` block in the same file maps `--primary` to `--color-primary`, which is what turns each role into a usable Tailwind class name.
+3. **The utility classes** — Tailwind CSS. `bg-primary`, `text-muted-foreground`, `border-2`, `rounded-xl`, `grid lg:grid-cols-2`. Explain Tailwind honestly: instead of writing a stylesheet in one file and class names in another, you write tiny single-purpose classes directly on the element. It looks noisy and it means you never have to invent a name like `.upload-box-inner-wrapper` again.
+4. **The bricks** — Shadcn UI. Crucially, **Shadcn is not a library you install and import from** — its components are copied into your own repo as ordinary files you own and edit. That's why `src/components/ui/button.tsx` is only 59 lines and sitting right there in the project.
+
+## Code Snippets (pre-extracted — use VERBATIM, do not trim or reformat)
+
+**File: `src/app/theme.css` (lines 11–19)** — roles, not colours
+```
+  --primary: oklch(0.9 0.15 85);            /* Lemon Yellow */
+  --primary-foreground: oklch(0.17 0 0);
+  --secondary: oklch(0.8 0.08 200);         /* Sky Blue */
+  --secondary-foreground: oklch(0.17 0 0);
+  --muted: oklch(0.95 0.02 90);            /* Lighter gray */
+  --muted-foreground: oklch(0.4 0.02 50);
+  --accent: oklch(0.8 0.15 60);             /* Coral Orange */
+  --accent-foreground: oklch(0.17 0 0);
+  --destructive: oklch(0.7 0.2 25);           /* Tomato Red */
+```
+> `oklch(lightness chroma hue)` — a newer way of writing colours where the first number is how light it is, the second how vivid, the third which hue on the colour wheel. Its selling point over hex: nudging the lightness of two different hues by the same amount actually *looks* like the same amount. Worth a tooltip; don't over-explain.
+
+**File: `src/app/theme.css` (lines 99–107)** — the bridge that turns a role into a class name
+```
+@theme inline {
+  --color-background: var(--background);
+  --color-foreground: var(--foreground);
+  --color-card: var(--card);
+  --color-card-foreground: var(--card-foreground);
+  --color-popover: var(--popover);
+  --color-popover-foreground: var(--popover-foreground);
+  --color-primary: var(--primary);
+  --color-primary-foreground: var(--primary-foreground);
+```
+
+**File: `src/components/ui/button.tsx` (lines 10–23)** — one component, six looks
+```
+    variants: {
+      variant: {
+        default:
+          "bg-primary text-primary-foreground shadow-xs hover:bg-primary/90",
+        destructive:
+          "bg-destructive text-white shadow-xs hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
+        outline:
+          "border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50",
+        secondary:
+          "bg-secondary text-secondary-foreground shadow-xs hover:bg-secondary/80",
+        ghost:
+          "hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50",
+        link: "text-primary underline-offset-4 hover:underline",
+      },
+```
+> This is `cva` — "class variance authority". A lookup table from `variant="outline"` to a string of Tailwind classes. When you tell an AI "add a `warning` style to our button," this table is the correct place, and saying so saves it from inventing a second button component.
+
+**File: `src/lib/utils.ts` (whole file, 6 lines)** — the most-used function in the codebase
+```
+import { clsx, type ClassValue } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}
+```
+> `clsx` glues class names together and drops any that are false. `twMerge` then settles fights: if the list ends up with both `px-4` and `px-6`, the later one wins and the earlier one is deleted, instead of both landing in the HTML and leaving the browser to guess. That's why a component's own classes can always be overridden by the `className` you pass in.
+
+**File: `src/components/blocks/imagen-wrapper/imagen-client.tsx` (lines 582–588)** — `cn()` doing conditional styling in the generator itself
+```
+                    className={cn(
+                      "relative min-h-[400px] rounded-xl border-2 border-dashed transition-all duration-300 cursor-pointer",
+                      uploadedImages.length > 0 ? "flex" : "flex items-center justify-center",
+                      dragActive 
+                        ? "border-cl-yellow bg-cl-yellow/10" 
+                        : "border-muted hover:border-cl-yellow hover:bg-cl-yellow/5"
+                    )}
+```
+> This is the yellow glow from the opening hook: one boolean, `dragActive`, flipped by `onDragOver` / `onDragLeave`, swapping one set of class names for another. No animation library, no manual DOM editing. State goes in, classes come out.
+
+**File: `src/components/ui/card.tsx` (lines 5–16)** — a brick, in full
+```
+function Card({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card"
+      className={cn(
+        "bg-card text-card-foreground flex flex-col gap-6 rounded-xl border py-6 shadow-sm",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+```
+
+**File: `src/app/theme.css` (lines 157–162)** — how this app gives every Shadcn card its own personality
+```
+[data-slot="card"] {
+  background: var(--card);
+  border: 2px solid var(--border);
+  border-radius: var(--radius);
+  box-shadow: none;
+}
+```
+> Every Shadcn component stamps a `data-slot` label on itself. This project uses those labels as a back door to restyle all cards at once — thick black outlines instead of soft grey ones — without editing `card.tsx`. Nice trick to know; module 5 shows the version of it that silently fails.
+
+**File: `src/components/blocks/form/index.tsx` (lines 34–42)** — the other way to build a form, for contrast
+```
+function buildFieldSchema(field: FormFieldType) {
+  let schema = z.string();
+
+  if (field.validation?.required) {
+    schema = schema.min(1, {
+      message: field.validation.message || `${field.title} is required`,
+    });
+  }
+```
+> The generator panel is hand-rolled: raw `useState` per control, no validation library. The app's *other* forms (feedback, API keys) use **React Hook Form** + **Zod** — you declare the rules once (`required`, `min`, `email`), and the error messages, the red outlines and the blocked submit all follow automatically. Teach the tradeoff in one line: hand-rolled is fine for three controls you fully own; the moment a form has validation rules worth stating out loud, declaring them beats hand-checking them.
+
+## Interactive Elements (all required)
+
+- **Layer toggle or numbered step cards** (hero visual) walking the four layers above, ideally showing the same yellow travelling: `oklch(0.9 0.15 85)` → `--primary` → `--color-primary` → `bg-primary` → the Generate button.
+- **Code ↔ English translation** — at minimum the `cn()` file and the `cva` variants table. The `dragActive` snippet is the best third choice because it ties back to the generator.
+- **Quiz** — 3–4 questions, decision-making style. Suggested angles:
+  1. A designer wants every card in the app to have rounded corners twice as large. Where's the one-line change? (Answer: `--radius` in `theme.css`. Every `rounded-*` token derives from it — see the `--radius-sm/md/lg/xl` calculations.)
+  2. You need a button that looks like the others but is green for "Export". Best instruction to give an AI? (Answer: add a `variant` to `buttonVariants` using a token — not a new component, not an inline hex.)
+  3. A component has `className="px-4"` baked in and you pass `className="px-8"`. What actually renders, and why isn't it a coin flip? (Answer: `px-8` — `twMerge` deletes the conflicting earlier class. Teaches why `cn()` exists.)
+  4. Optional: the generator's prompt box is a raw `<textarea>` with `useState`; the feedback form uses Zod. When is each right? (Answer: complexity of the rules, not size of the form.)
+- **Callout box** — *aha!*: **Indirection is a superpower you can ask for.** "Use a token" and "add a variant" are two of the highest-value phrases you can say to an AI coding assistant — they're the difference between a change that lands in one place and a change that lands in forty.
+- **Optional extra:** pattern/feature cards contrasting `src/components/ui/` (bricks — generic, no business logic, safe to reuse anywhere) with `src/components/blocks/` (models — know about this app, its text, its data).
+- **Also mention briefly (one compact visual, don't sprawl):** the two toggles in the header. Dark mode: `ThemeProvider` in `src/contexts/theme-context.tsx` adds the class `dark` to the page root and the `.dark` block in `theme.css` takes over — one class, whole app repainted. Language: `LocaleSwitcher` in `src/components/ui/locale-switcher.tsx` rewrites the URL's language prefix (`/zh/showcase`) and Next.js re-renders the page server-side in that language.
+- **Glossary tooltips** (first use): CSS, class, utility class, Tailwind, Shadcn UI, design token, CSS variable / custom property, `oklch`, `:root`, dark mode, variant, `cva`, `clsx`, specificity, component, prop, `data-` attribute, boolean, validation, schema, Zod, React Hook Form, responsive breakpoint (`lg:`).
+
+## Reference Files to Read
+
+- `references/content-philosophy.md` — all of it
+- `references/gotchas.md` — all of it
+- `references/interactive-elements.md` → "Layer Toggle Demo", "Numbered Step Cards", "Code ↔ English Translation Blocks", "Multiple-Choice Quizzes", "Callout Boxes", "Pattern/Feature Cards", "Glossary Tooltips"
+- `references/design-system.md` → "Color Palette", "Module Structure", "Code Block Globals"
+
+## Connections
+
+- **Previous module:** *Commissioning the Artist* — the rented AI engine, the written style brief, and the rotating pool of API keys. Open by turning away from the engine and toward the dashboard around it.
+- **Next module:** *Tapping the Walls* — five real cracks in this exact codebase, including one where a `data-slot` rule like the card one above never fires. Tease it: "You've now seen how this interface is supposed to work. Next: five places where it doesn't — and how you'd have caught each one."
+- **Tone/style notes:** Accent colour is teal — do NOT recolour the course to the app's yellow, just describe the app's yellow. Keep actor names consistent with modules 2–3. Resist listing every Shadcn component; three examples beat thirty.

--- a/courses/image-generator-ui-course/briefs/05-breaks.md
+++ b/courses/image-generator-ui-course/briefs/05-breaks.md
@@ -1,0 +1,159 @@
+# Module 5: Tapping the Walls
+
+**Output file:** `courses/image-generator-ui-course/modules/05-breaks.html`
+**Section wrapper:** `<section class="module" id="module-5">`
+
+## Teaching Arc
+
+- **Metaphor:** **A home inspection.** An inspector doesn't wait for the ceiling to fall in. They walk the house tapping walls, listening for the hollow spot, checking whether the switch by the door is actually wired to anything. Most of what they find isn't dangerous — it's *disconnected*. Wires that go nowhere, a light switch that was rewired during a renovation and never removed. That's exactly what's in this codebase, and it's in yours too. (Exclusive to this module — 1 photo lab, 2 theatre, 3 illustrator, 4 LEGO box.)
+- **Opening hook:** "Every single one of the five faults below is real, is in this app right now, and none of them crash anything. That's what makes them worth studying — the bugs that crash are easy."
+- **Key insight:** The most common bug in an AI-assisted codebase isn't broken logic — it's **two halves that were each written correctly and never introduced to each other.** A control that no longer sends its value. A CSS rule waiting for an attribute nobody stamps. A branch checking a field with a name that doesn't exist. Every one of these is invisible to the compiler and invisible in testing, because nothing errors — the code just quietly does nothing.
+- **"Why should I care?":** This is the module that pays for the other four. You now know the seven stations, both sides of the wall, the shape of the AI call and the four styling layers — so you can look at a symptom and name the station. That's how you escape a bug loop with an AI assistant: not by asking "why is it broken?" but by saying "this branch never runs because the server sends `message` and the client reads `msg` — fix the client."
+
+## The five faults (verified in the codebase — each is real)
+
+### Fault 1 — The reply nobody reads (the hero exhibit)
+
+The server, in `src/lib/resp.ts`, answers with a field called **`message`**. The client, in `imagen-client.tsx`, checks **`result.msg`**. Those are different words, so those branches can never run — the "you're in a queue, upgrade to skip it" message never appears, no matter how busy the service gets. The user just sees the generic "generation failed" toast.
+
+The cruel detail: **twenty lines later, in the same function, the same developer got it right** — the insufficient-credits branch checks `result.data` and `result.message`, which do exist. One works. One doesn't. Nothing warns you.
+
+There's a second layer: `respErr` always returns `code: -1`. So the whole `else if (result.code === 1)` branch is unreachable too — a `code` of 1 is a value this app never produces.
+
+### Fault 2 — Three controls with the wires cut
+
+```
+  const [aspectRatio, setAspectRatio] = useState('16:9');
+  const [outputFormat, setOutputFormat] = useState('jpeg');
+  const [selectedModel, setSelectedModel] = useState('pro');
+```
+`setAspectRatio`, `setOutputFormat` and `setSelectedModel` are **never called anywhere in the file.** These three values can never change from their starting values. The Generate button still cheerfully reads `selectedModel` to print "(10 credits)" next to itself.
+
+And on the other side, the server *validates* `aspectRatio` and `outputFormat` carefully — rejecting anything not in its allowed list — then never passes either one to Gemini. It echoes them back in the response. So even if the picker existed and worked, choosing 9:16 would change nothing about the picture.
+
+### Fault 3 — The CSS that's waiting for a phone call
+
+`src/app/theme.css` styles the app's chunky Charlie-and-Lola buttons with hard offset shadows via `[data-slot="button"][data-variant="default"]`. But `src/components/ui/button.tsx` only ever stamps `data-slot="button"` — it never writes a `data-variant` attribute. The selector requires both. It matches nothing. Those hand-written shadows and the translate-on-hover effect have never rendered once.
+
+Compare with the card rule from module 4 (`[data-slot="card"]`) which works perfectly, because `card.tsx` really does stamp `data-slot="card"`. Same technique, one letter of difference between working and dead.
+
+### Fault 4 — The button that lies about needing a login
+
+When nobody is signed in, the Generate button renders a padlock icon and the words "login required". But `disabled={uploadedImages.length === 0 || isGenerating}` says nothing about being signed in, and `generateImage()` doesn't check for a session either — it just runs. So the button says you must sign in, and then generates your image anyway. (The server *does* treat guests differently — it returns `requiresRegistration: true` and skips charging credits. So the behaviour is deliberate; only the label is stale.)
+
+### Fault 5 — The word that was never delivered
+
+`imagen-client.tsx` reads `t.buttons.limited_free` when free mode is switched on. The phrase exists in both translation files (`"limited_free": "Limited Free"` / `"限免"`). But the `Translations` interface at the top of the file doesn't list it, and `index.tsx` — the server wrapper that hand-copies every string into an object — never copies it across. The word is written, translated, and never picked up. Turn free mode on and the button reads `(undefined)`.
+
+This is the price of that hand-written wrapper from module 2: **every new piece of text has to be added in three places** (the JSON, the interface, the mapping), and forgetting one fails silently.
+
+## Code Snippets (pre-extracted — use VERBATIM, do not trim or reformat)
+
+**File: `src/lib/resp.ts` (lines 9–22)** — what the server actually sends
+```
+export function respErr(message: string, data?: any) {
+  return respJson(-1, message, data);
+}
+
+export function respJson(code: number, message: string, data?: any) {
+  let json: { code: number; message: string; data?: any } = {
+    code: code,
+    message: message,
+  };
+  if (data) {
+    json.data = data;
+  }
+
+  return Response.json(json);
+}
+```
+
+**File: `src/components/blocks/imagen-wrapper/imagen-client.tsx` (lines 369–378)** — what the client looks for. This is the "spot the bug" exhibit.
+```
+        if (result.data.requiresRegistration && !session) {
+          toast.success("Image generated! Sign in to download full resolution image.");
+        } else if (result.msg === 'QUEUE_REQUIRED') {
+          toast.warning("🚧 Service is busy. You're in the queue. Upgrade to premium to skip the queue!");
+        } else {
+          toast.success(t.messages.success.generated);
+          if (session) {
+            refreshCredits();
+          }
+        }
+```
+
+**File: `src/components/blocks/imagen-wrapper/imagen-client.tsx` (lines 390–396)** — the branch that works, for contrast
+```
+      } else if (result.code === -1) {
+        // Handle error responses (including insufficient credits)
+        if (result.data === 'INSUFFICIENT_CREDITS' || result.message?.includes('Insufficient credits')) {
+          toast.error(result.message || 'Insufficient credits to generate image');
+          return;
+        }
+        throw new Error(result.message || 'Generation failed');
+```
+
+**File: `src/components/blocks/imagen-wrapper/imagen-client.tsx` (lines 134–136)** — the cut wires
+```
+  const [aspectRatio, setAspectRatio] = useState('16:9');
+  const [outputFormat, setOutputFormat] = useState('jpeg');
+  const [selectedModel, setSelectedModel] = useState('pro');
+```
+
+**File: `src/app/theme.css` (lines 164–171)** — the CSS that never fires
+```
+[data-slot="button"][data-variant="default"] {
+  background: var(--primary);
+  color: var(--primary-foreground);
+  border: 2px solid var(--foreground);
+  border-radius: var(--radius);
+  box-shadow: 4px 4px 0px var(--foreground);
+  transition: all 0.2s ease;
+}
+```
+
+**File: `src/components/ui/button.tsx` (lines 50–56)** — the attribute that never gets stamped
+```
+  return (
+    <Comp
+      data-slot="button"
+      className={cn(buttonVariants({ variant, size, className }))}
+      {...props}
+    />
+  )
+```
+
+## Interactive Elements (all required)
+
+- **"Spot the Bug" challenge** (hero visual — `references/interactive-elements.md` → "Spot the Bug Challenge"). Use Fault 1: show the `respErr`/`respJson` snippet and the `result.msg` snippet side by side and ask the learner to find the line that can never run. Reveal explains the `message` vs `msg` mismatch and why no tool catches it (`result` comes back as untyped data from the network — as far as TypeScript is concerned, `result.msg` is a perfectly reasonable thing to ask for).
+- **Code ↔ English translation** — at minimum the `respErr`/`respJson` pair. The `data-slot` / `data-variant` pair is the strongest second.
+- **Quiz** — 4 questions, debugging style, drawing on all five modules. Suggested angles:
+  1. Users report the site "just says generation failed" during traffic spikes, though you know the queue logic exists. Where do you look, and what's the fix? (Answer: the client's `result.msg` check — one word. Not the server, not Gemini.)
+  2. A designer swears the Generate button used to have a chunky offset shadow and "someone removed it." What actually happened? (Answer: nobody removed it — it never rendered; the selector needs a `data-variant` attribute the component doesn't stamp.)
+  3. You ask an AI assistant to "make the aspect-ratio picker work." What do you need to tell it so it doesn't stop halfway? (Answer: three places — build the control and wire `setAspectRatio`; the client already sends the value; the *server* must actually pass it to Gemini instead of just validating and echoing it. Tests whether they can trace end-to-end.)
+  4. Free mode is switched on and the button reads "(undefined)". Which of the three places did someone forget? (Answer: the JSON has it — the `Translations` interface and the mapping in `index.tsx` don't. Ties back to module 2.)
+- **Callout boxes** — at least two:
+  - *aha!*: **Silence is a symptom.** A branch that never runs, a rule that never matches and a setter that's never called all produce zero errors. Working code and disconnected code look identical from the outside — which is why "it doesn't crash" is not evidence that it works.
+  - *for steering AI*: the three sentences that end bug loops — name the **station** ("the client's response handling"), name the **mismatch** ("server sends `message`, client reads `msg`"), name the **fix you want** ("change the client, not the server"). Guesses in, guesses out; specifics in, patches out.
+- **Optional extra:** pattern cards for a "tap the walls" checklist the learner can reuse on their own project — *Is this setter ever called? Does the field name on both sides of the network match exactly? Does this CSS selector match anything in the rendered page? Does the label match what the button does? Is this string wired all the way through?*
+- **Glossary tooltips** (first use in this module): dead code, unreachable branch, silent failure, CSS selector, attribute, `data-` attribute, TypeScript, type checking, `any`, state setter, toast, session, compiler, refactor, regression.
+
+## Closing (last screen of the last module — write a real ending)
+
+Close the whole course, not just the module. Two or three short beats:
+- What they can now do: read a generation end-to-end; tell client from server and know why the key stays put; recognise a rented model behind a written brief; name a design token instead of a hex code; spot a silent disconnection.
+- The habit worth keeping: when something looks wrong, name the station before proposing the fix.
+- A light send-off pointing back at the real files — `src/app/api/generate-cyberpunk/route.ts`, `src/components/blocks/imagen-wrapper/imagen-client.tsx`, `src/app/theme.css` — as the three worth opening first. No fake "congratulations, you're a developer now."
+
+## Reference Files to Read
+
+- `references/content-philosophy.md` — all of it
+- `references/gotchas.md` — all of it
+- `references/interactive-elements.md` → "Spot the Bug Challenge", "Code ↔ English Translation Blocks", "Multiple-Choice Quizzes", "Scenario Quiz", "Callout Boxes", "Pattern/Feature Cards", "Glossary Tooltips"
+- `references/design-system.md` → "Module Structure", "Syntax Highlighting (Catppuccin-inspired)"
+
+## Connections
+
+- **Previous module:** *The LEGO Box* — the four styling layers (tokens → bridge → Tailwind → Shadcn bricks), `cn()`, `cva` variants, and the `[data-slot="card"]` restyling trick that works. Fault 3 is the same trick failing, so call back to it explicitly.
+- **Next module:** none — this is the finale.
+- **Tone/style notes:** Accent colour is teal. **Never sneer at the code.** These faults are what every shipped product looks like under a torch, including good ones; the app works and people use it. The posture is a friendly inspector with a clipboard, not a critic. Keep actor names consistent with modules 2–4.

--- a/courses/image-generator-ui-course/build.sh
+++ b/courses/image-generator-ui-course/build.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# Assembles the course from parts.
+# Run from the course directory: bash build.sh
+set -e
+cat _base.html modules/*.html _footer.html > index.html
+echo "Built index.html — open it in your browser."

--- a/courses/image-generator-ui-course/index.html
+++ b/courses/image-generator-ui-course/index.html
@@ -1,0 +1,3264 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Inside the Image Generator</title>
+
+  <!-- Google Fonts: Bricolage Grotesque · DM Sans · JetBrains Mono -->
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:opsz,wght@12..96,400;12..96,600;12..96,700;12..96,800&family=DM+Sans:ital,opsz,wght@0,9..40,300;0,9..40,400;0,9..40,500;0,9..40,600;0,9..40,700;1,9..40,400;1,9..40,500&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+
+  <link rel="stylesheet" href="styles.css">
+
+  <!--
+    CUSTOMIZE PER COURSE — change only the three accent variables below.
+    Options:
+      vermillion  #D94F30 / #C4432A / #FDEEE9 / #E8836C  (default)
+      coral       #E06B56 / #C85A47 / #FDECEA / #E89585
+      teal        #2A7B9B / #1F6280 / #E4F2F7 / #5A9DB8
+      amber       #D4A843 / #BF9530 / #FDF5E0 / #E0C070
+      forest      #2D8B55 / #226B41 / #E8F5EE / #5AAD7A
+  -->
+  <style>
+    :root {
+      --color-accent:       #2A7B9B;
+      --color-accent-hover: #1F6280;
+      --color-accent-light: #E4F2F7;
+      --color-accent-muted: #5A9DB8;
+    }
+  </style>
+
+  <script src="main.js" defer></script>
+</head>
+<body>
+
+  <nav class="nav" id="nav">
+    <div class="progress-bar" id="progress-bar" role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100"></div>
+    <div class="nav-inner">
+      <span class="nav-title">Inside the Image Generator</span>
+      <div class="nav-dots" id="nav-dots" role="tablist">
+        <button class="nav-dot" data-target="module-1" data-tooltip="The Journey of One Photo" role="tab" aria-label="Module 1: The Journey of One Photo"></button>
+        <button class="nav-dot" data-target="module-2" data-tooltip="Front of House, Backstage" role="tab" aria-label="Module 2: Front of House, Backstage"></button>
+        <button class="nav-dot" data-target="module-3" data-tooltip="Commissioning the Artist" role="tab" aria-label="Module 3: Commissioning the Artist"></button>
+        <button class="nav-dot" data-target="module-4" data-tooltip="The LEGO Box" role="tab" aria-label="Module 4: The LEGO Box"></button>
+        <button class="nav-dot" data-target="module-5" data-tooltip="Tapping the Walls" role="tab" aria-label="Module 5: Tapping the Walls"></button>
+      </div>
+    </div>
+  </nav>
+
+  <main id="main">
+    <!-- modules/*.html content is assembled here by build.sh -->
+<section class="module" id="module-1" style="background: var(--color-bg-warm)">
+  <div class="module-content">
+
+    <header class="module-header animate-in">
+      <span class="module-number">01</span>
+      <h1 class="module-title">The Journey of One Photo</h1>
+      <p class="module-subtitle">You drop a photo onto the box and click Generate. For four seconds, nothing visible happens. Here is everything that happens in those four seconds.</p>
+    </header>
+
+    <div class="module-body">
+
+      <!-- ══════════════ SCREEN 1 ══════════════ -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">What this thing actually does</h2>
+
+        <p>Charlie &amp; Lola AI is a website with one job. You drag in a photo of yourself, or your dog, or a toy, and a few seconds later you get the same subject redrawn in the scratchy, flat-colour style of the British children's cartoon <em>Charlie and Lola</em>.</p>
+
+        <p>Then you download it, or copy a link to share it. That is the entire product.</p>
+
+        <div class="step-cards stagger-children">
+          <div class="step-card animate-in">
+            <div class="step-num">1</div>
+            <div class="step-body">
+              <strong>You drop in a photo</strong>
+              <p>A dashed box on the page accepts up to five images at once</p>
+            </div>
+          </div>
+          <div class="step-card animate-in">
+            <div class="step-num">2</div>
+            <div class="step-body">
+              <strong>You click Generate</strong>
+              <p>A spinner appears. Roughly four seconds pass.</p>
+            </div>
+          </div>
+          <div class="step-card animate-in">
+            <div class="step-num">3</div>
+            <div class="step-body">
+              <strong>A cartoon version appears</strong>
+              <p>Same subject, redrawn. Download it or copy the share link.</p>
+            </div>
+          </div>
+        </div>
+
+        <p>Everything in this course is about the machinery behind that one button — and about the visual building blocks the interface is made from.</p>
+
+        <h3 class="screen-heading">What it is built out of</h3>
+
+        <div class="icon-rows">
+          <div class="icon-row">
+            <div class="icon-circle" style="background: var(--color-actor-2)">🧱</div>
+            <div>
+              <strong>Next.js 15 + React</strong>
+              <p><span class="term" data-definition="Next.js is a framework — a big starter kit of pre-written code that handles the boring parts of building a website, like page addresses and talking to a server. You would say to an AI assistant: this is a Next.js app.">Next.js</span> is the website <span class="term" data-definition="A framework is a pre-built skeleton for an app. It already knows how to do the common jobs so you only write the parts unique to your product.">framework</span>; <span class="term" data-definition="React is the library that draws the screen. You describe what the page should look like for a given set of data, and React handles updating the actual pixels when that data changes.">React</span> draws what you see on screen.</p>
+            </div>
+          </div>
+          <div class="icon-row">
+            <div class="icon-circle" style="background: var(--color-actor-3)">🎨</div>
+            <div>
+              <strong>Tailwind CSS + Shadcn UI</strong>
+              <p><span class="term" data-definition="Tailwind CSS is a styling system where you set colours, spacing and sizes by adding short keyword labels directly onto an element, instead of writing separate style files.">Tailwind CSS</span> handles the looks; <span class="term" data-definition="Shadcn UI is a collection of ready-made interface pieces — buttons, sliders, dialogs — that you copy into your own project and then are free to edit.">Shadcn UI</span> supplies ready-made buttons, sliders and dialogs.</p>
+            </div>
+          </div>
+          <div class="icon-row">
+            <div class="icon-circle" style="background: var(--color-actor-4)">✏️</div>
+            <div>
+              <strong>Google Gemini</strong>
+              <p>The <span class="term" data-definition="A model is a trained AI system you send input to and get output back from. Gemini is Google&apos;s family of models; this app uses one that can look at a picture and draw a new one.">model</span> that does the actual drawing. It lives on Google's computers, not in this app.</p>
+            </div>
+          </div>
+        </div>
+
+        <p>This course has two halves: the <strong>generator engine</strong> (how a photo becomes a cartoon) and the <strong>interface</strong> it lives inside (how the page is assembled from reusable pieces). This module is the engine, end to end.</p>
+      </section>
+
+      <!-- ══════════════ SCREEN 2 ══════════════ -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">The seven stations</h2>
+
+        <p>Think of a one-hour photo lab. You hand your film over the counter, it disappears behind the wall into machines you never see, and twenty minutes later prints come back.</p>
+
+        <p>You have no idea what those machines do. But there <em>is</em> a fixed sequence back there, and every ruined photo has one specific station where it went wrong.</p>
+
+        <div class="callout callout-accent">
+          <div class="callout-icon">💡</div>
+          <div class="callout-content">
+            <strong class="callout-title">The key idea of this whole module</strong>
+            <p>A generation is not one magical event. It is a relay of seven hand-offs between separate pieces of software — three of which are not on your computer at all.</p>
+          </div>
+        </div>
+
+        <p>Press <strong>Next Step</strong> and walk behind the counter. Five machines, seven hand-offs.</p>
+
+        <div class="flow-animation" data-steps='[
+          {"highlight":"flow-actor-1","label":"You drop a photo onto the dashed box. The browser reads the file into one very long text string — a data URL. Nothing has left your computer yet."},
+          {"highlight":"flow-actor-2","label":"You click Generate. ImagenClient packs the photo plus your settings into a FormData parcel.","packet":true,"from":"actor-1","to":"actor-2"},
+          {"highlight":"flow-actor-3","label":"The parcel is POSTed to /api/generate-cyberpunk — the server that belongs to this app.","packet":true,"from":"actor-2","to":"actor-3"},
+          {"highlight":"flow-actor-3","label":"The server picks an unused Gemini API key from its pool, converts the photo to base64, and glues it to a written style instruction.","packet":true,"from":"actor-3","to":"actor-4"},
+          {"highlight":"flow-actor-4","label":"Gemini reads the picture and the instruction, then sends back a NEW picture — encoded as text.","packet":true,"from":"actor-4","to":"actor-3"},
+          {"highlight":"flow-actor-5","label":"The server uploads that picture to Cloudflare R2 storage and gets back a public web address.","packet":true,"from":"actor-3","to":"actor-5"},
+          {"highlight":"flow-actor-1","label":"The address travels back to the browser, lands in setGeneratedImage(...), and React repaints the right-hand panel.","packet":true,"from":"actor-3","to":"actor-1"}
+        ]'>
+          <div class="flow-actors">
+            <div class="flow-actor" id="flow-actor-1">
+              <div class="flow-actor-icon">🖱️</div>
+              <span>You<br>(the browser)</span>
+            </div>
+            <div class="flow-actor" id="flow-actor-2">
+              <div class="flow-actor-icon">📦</div>
+              <span>ImagenClient<br>(page code)</span>
+            </div>
+            <div class="flow-actor" id="flow-actor-3">
+              <div class="flow-actor-icon">⚙️</div>
+              <span>/api/generate-<br>cyberpunk</span>
+            </div>
+            <div class="flow-actor" id="flow-actor-4">
+              <div class="flow-actor-icon">✏️</div>
+              <span>Google<br>Gemini</span>
+            </div>
+            <div class="flow-actor" id="flow-actor-5">
+              <div class="flow-actor-icon">🗄️</div>
+              <span>Cloudflare R2<br>(storage)</span>
+            </div>
+          </div>
+
+          <div class="flow-packet" id="flow-packet"></div>
+
+          <div class="flow-step-label" id="flow-label">Click "Next Step" to begin</div>
+
+          <div class="flow-controls">
+            <button class="btn flow-next-btn">Next Step</button>
+            <button class="btn flow-reset-btn">Restart</button>
+            <span class="flow-progress"></span>
+          </div>
+        </div>
+
+        <p>Two of those five machines belong to other companies, reached over an <span class="term" data-definition="An API is the agreed list of requests one program is willing to accept from another — like a menu. Your server orders from Google&apos;s menu; your browser orders from your server&apos;s menu.">API</span>. Knowing the seven stations means that when something breaks, you can name the station instead of saying "the AI is broken."</p>
+
+        <div class="badge-list">
+          <div class="badge-item">
+            <code class="badge-code">the AI is broken</code>
+            <span class="badge-desc">What you get back: a shotgun of guesses from your AI coding assistant</span>
+          </div>
+          <div class="badge-item">
+            <code class="badge-code">the POST to /api/generate-cyberpunk returns fine but the preview stays empty</code>
+            <span class="badge-desc">What you get back: a fix</span>
+          </div>
+        </div>
+
+        <p>That second sentence is the actual skill this module teaches. Let us earn it, station by station.</p>
+      </section>
+
+      <!-- ══════════════ SCREEN 3 ══════════════ -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">Stations 1–2: the photo never leaves the page (yet)</h2>
+
+        <p>Here is the surprise. When you drop a photo on the box and the thumbnail appears instantly, <strong>nothing has been sent anywhere</strong>. Your film is still sitting on your side of the counter.</p>
+
+        <p>The <span class="term" data-definition="The browser is the program you are reading this in — Chrome, Safari, Firefox. It runs on your own machine and can only see what the page gives it.">browser</span> reads the file off your disk and turns it into text that the page can display immediately. That is stations 1 and 2, and they are entirely local.</p>
+
+        <div class="step-cards stagger-children">
+          <div class="step-card animate-in">
+            <div class="step-num">1</div>
+            <div class="step-body">
+              <strong>The file lands in the box</strong>
+              <p>Drag-and-drop, or the file picker — either way the browser hands over a File</p>
+            </div>
+          </div>
+          <div class="step-card animate-in">
+            <div class="step-num">2</div>
+            <div class="step-body">
+              <strong>FileReader converts it to text</strong>
+              <p>The picture becomes one enormous string of letters and numbers</p>
+            </div>
+          </div>
+          <div class="step-card animate-in">
+            <div class="step-num">3</div>
+            <div class="step-body">
+              <strong>The thumbnail appears</strong>
+              <p>That string can be pasted straight into an image tag, so the preview is instant</p>
+            </div>
+          </div>
+        </div>
+
+        <p>This is the <span class="term" data-definition="A function is a named chunk of code you can run on demand — like a recipe card. Point at it by name and it does its steps. Here, handleFileUpload runs every time a file arrives.">function</span> that does it, from the real file. Read the code on the left; the plain English on the right walks the same path.</p>
+
+        <div class="translation-block animate-in">
+          <div class="translation-code">
+            <span class="translation-label">src/components/blocks/imagen-wrapper/imagen-client.tsx</span>
+            <pre><code>  <span class="code-keyword">const</span> <span class="code-function">handleFileUpload</span> = (file: File) => {
+    <span class="code-keyword">if</span> (uploadedImages.length >= <span class="code-number">5</span>) {
+      toast.<span class="code-function">error</span>(t.upload.max_images_error);
+      <span class="code-keyword">return</span>;
+    }
+
+    <span class="code-keyword">const</span> reader = <span class="code-keyword">new</span> <span class="code-function">FileReader</span>();
+    reader.onload = (e) => {
+      <span class="code-keyword">const</span> imageData = e.target?.result <span class="code-keyword">as</span> <span class="code-keyword">string</span>;
+      <span class="code-function">setUploadedImages</span>(prev => [...prev, imageData]);
+      <span class="code-function">setGeneratedImage</span>(<span class="code-keyword">null</span>);
+    };
+    reader.<span class="code-function">readAsDataURL</span>(file);
+  };</code></pre>
+          </div>
+          <div class="translation-english">
+            <span class="translation-label">Plain English</span>
+            <div class="translation-lines">
+              <p class="tl">Whenever a file arrives, run these steps on it.</p>
+              <p class="tl">First, a bouncer check: if five pictures are already loaded, show a polite error and stop right here.</p>
+              <p class="tl">Otherwise, hire a FileReader — the browser's built-in tool for turning a file into something the page can use.</p>
+              <p class="tl">Reading takes a moment, so leave instructions for when it finishes: "when you're done, do this."</p>
+              <p class="tl">The finished result is a long text string. Grab it.</p>
+              <p class="tl">Add that string to the list of uploaded images, keeping the ones already there.</p>
+              <p class="tl">Clear any previous cartoon result, so the old output does not sit next to a new input.</p>
+              <p class="tl">And finally — the line that actually starts the work — read the file, as a data URL.</p>
+            </div>
+          </div>
+        </div>
+
+        <p>Two things in there are worth knowing by name.</p>
+
+        <div class="pattern-cards">
+          <div class="pattern-card" style="border-top: 3px solid var(--color-actor-2)">
+            <div class="pattern-icon" style="background: var(--color-actor-2)">📄</div>
+            <h4 class="pattern-title">data URL</h4>
+            <p class="pattern-desc">A <span class="term" data-definition="A data URL is a whole file — a picture, a sound — written out as one long line of text starting with data:image/png;base64,... It can be pasted anywhere a web address goes, and needs no server.">data URL</span> is the entire picture rewritten as text. It starts <code class="badge-code">data:image/png;base64,</code> and runs for thousands of characters.</p>
+          </div>
+          <div class="pattern-card" style="border-top: 3px solid var(--color-actor-3)">
+            <div class="pattern-icon" style="background: var(--color-actor-3)">🧠</div>
+            <h4 class="pattern-title">state</h4>
+            <p class="pattern-desc"><code class="badge-code">setUploadedImages</code> updates the <span class="term" data-definition="A component is one reusable chunk of interface — a button, an upload box, a whole panel — with its own code and its own memory. Pages are built by nesting components inside each other.">component</span>'s <span class="term" data-definition="State is a component&apos;s memory — the current values it is holding, like which images are loaded. Change the state and React automatically redraws the parts of the screen that depend on it.">state</span>. Change state, and React repaints the screen for you.</p>
+          </div>
+        </div>
+
+        <div class="callout callout-accent">
+          <div class="callout-icon">✨</div>
+          <div class="callout-content">
+            <strong class="callout-title">Aha: an image is just text if you squint</strong>
+            <p><span class="term" data-definition="Base64 is a way of rewriting any file using only ordinary letters, digits and a couple of symbols. Nothing is lost — it just gets about a third longer — so files can travel down pipes built for text.">Base64</span> and data URLs mean the exact same picture can travel as a string of letters through channels that only carry text. That is why an AI service can hand a picture back to you over a plain text connection.</p>
+          </div>
+        </div>
+      </section>
+
+      <!-- ══════════════ SCREEN 4 ══════════════ -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">Station 3: packing the parcel</h2>
+
+        <p>You click Generate. Now the film goes over the counter — and this is the moment the photo leaves your computer.</p>
+
+        <p>The page's code gathers the <span class="term" data-definition="An upload is the act of sending a file from your own machine to a server. Until that moment, the file is only ever on your side.">uploaded</span> images and every setting into one parcel, then hands it to the app's own <span class="term" data-definition="A server is a computer that belongs to the app, running somewhere in a data centre, that your browser sends requests to. It can hold secrets your browser never sees.">server</span>.</p>
+
+        <div class="translation-block animate-in">
+          <div class="translation-code">
+            <span class="translation-label">imagen-client.tsx · generateImage()</span>
+            <pre><code>      <span class="code-keyword">const</span> formData = <span class="code-keyword">new</span> <span class="code-function">FormData</span>();
+
+      formData.<span class="code-function">append</span>(<span class="code-string">'mode'</span>, <span class="code-string">'image2image'</span>);
+      formData.<span class="code-function">append</span>(<span class="code-string">'style'</span>, <span class="code-string">'charlie-lola'</span>); <span class="code-comment">// Fixed style for Charlie and Lola</span>
+      formData.<span class="code-function">append</span>(<span class="code-string">'aspectRatio'</span>, aspectRatio);
+      formData.<span class="code-function">append</span>(<span class="code-string">'outputFormat'</span>, outputFormat);
+      formData.<span class="code-function">append</span>(<span class="code-string">'model'</span>, <span class="code-string">'standard'</span>); <span class="code-comment">// Fixed model</span>
+
+      <span class="code-keyword">if</span> (customPrompt.<span class="code-function">trim</span>()) {
+        formData.<span class="code-function">append</span>(<span class="code-string">'customPrompt'</span>, customPrompt);
+      }
+
+      <span class="code-keyword">for</span> (<span class="code-keyword">let</span> i = <span class="code-number">0</span>; i &lt; uploadedImages.length; i++) {
+        <span class="code-keyword">const</span> response = <span class="code-keyword">await</span> <span class="code-function">fetch</span>(uploadedImages[i]);
+        <span class="code-keyword">const</span> blob = <span class="code-keyword">await</span> response.<span class="code-function">blob</span>();
+        formData.<span class="code-function">append</span>(<span class="code-string">`image_${i}`</span>, blob);
+      }
+
+      formData.<span class="code-function">append</span>(<span class="code-string">'imageCount'</span>, uploadedImages.length.<span class="code-function">toString</span>());
+
+      <span class="code-keyword">const</span> apiResponse = <span class="code-keyword">await</span> <span class="code-function">fetch</span>(<span class="code-string">'/api/generate-cyberpunk'</span>, {
+        <span class="code-property">method</span>: <span class="code-string">'POST'</span>,
+        <span class="code-property">body</span>: formData,
+      });</code></pre>
+          </div>
+          <div class="translation-english">
+            <span class="translation-label">Plain English</span>
+            <div class="translation-lines">
+              <p class="tl">Get an empty parcel. <span class="term" data-definition="FormData is a container for sending a mixed bag of things to a server in one go — text settings and real files side by side. It is the same machinery a normal web form uses when you attach a file.">FormData</span> can hold text labels and real files side by side.</p>
+              <p class="tl">Label it: we are turning an image into another image, not writing one from scratch.</p>
+              <p class="tl">Hard-code the style to charlie-lola. This app only makes one look, so this is never a choice the visitor makes.</p>
+              <p class="tl">Attach the shape you picked (square, portrait) and the file type you want back.</p>
+              <p class="tl">Hard-code the quality tier too — another decision the app makes for you.</p>
+              <p class="tl">If you typed anything into the extra-instructions box, and it is not just blank spaces, include it.</p>
+              <p class="tl">Now for the pictures. Walk through the uploaded ones, one at a time.</p>
+              <p class="tl">Remember each one is currently a long text string. Read that string back...</p>
+              <p class="tl">...and turn it into a <span class="term" data-definition="A blob is a raw lump of file data — the actual bytes of a picture — as opposed to a description of it. Servers want the bytes.">blob</span>: the real bytes of the file, rather than the text version.</p>
+              <p class="tl">Drop it into the parcel under a numbered name: image_0, image_1, and so on.</p>
+              <p class="tl">Note down how many pictures are in there, so the server does not have to guess.</p>
+              <p class="tl">Then hand the parcel over the counter — to <code class="badge-code">/api/generate-cyberpunk</code>, the app's own <span class="term" data-definition="An endpoint is one specific address on a server that does one specific job. /api/generate-cyberpunk is the address for &quot;make me a picture&quot;.">endpoint</span>.</p>
+              <p class="tl"><span class="term" data-definition="POST means &quot;here is some data, please do something with it&quot;, as opposed to GET which means &quot;please send me something&quot;. Uploads are always POST.">POST</span> means we are sending something, not just asking for something.</p>
+              <p class="tl">And the parcel itself is the body of the request.</p>
+            </div>
+          </div>
+        </div>
+
+        <p>Notice what is in the parcel: five text settings, then the images themselves. One container, two very different kinds of cargo.</p>
+
+        <div class="badge-list">
+          <div class="badge-item">
+            <code class="badge-code">mode</code>
+            <span class="badge-desc">image2image — start from a picture, do not invent one from words alone</span>
+          </div>
+          <div class="badge-item">
+            <code class="badge-code">style</code>
+            <span class="badge-desc">Always charlie-lola. Hard-coded, not a setting the visitor can change</span>
+          </div>
+          <div class="badge-item">
+            <code class="badge-code">aspectRatio</code>
+            <span class="badge-desc">The shape of the result — square, portrait, landscape</span>
+          </div>
+          <div class="badge-item">
+            <code class="badge-code">outputFormat</code>
+            <span class="badge-desc">Which kind of image file you get back</span>
+          </div>
+          <div class="badge-item">
+            <code class="badge-code">customPrompt</code>
+            <span class="badge-desc">Optional extra wording from you — only included if you actually typed something</span>
+          </div>
+          <div class="badge-item">
+            <code class="badge-code">image_0 … image_4</code>
+            <span class="badge-desc">The pictures, as real file data</span>
+          </div>
+        </div>
+
+        <div class="callout callout-info">
+          <div class="callout-icon">😅</div>
+          <div class="callout-content">
+            <strong class="callout-title">Yes, it says "cyberpunk"</strong>
+            <p>The <span class="term" data-definition="A route is a file on the server that handles requests to one address. In this app, src/app/api/generate-cyberpunk/route.ts is the file behind /api/generate-cyberpunk.">route</span> is called <code class="badge-code">/api/generate-cyberpunk</code> even though the app makes children's-book art. It is a leftover name from the template this app was built from. Module 5 takes stale naming seriously — for now, just enjoy it.</p>
+          </div>
+        </div>
+      </section>
+
+      <!-- ══════════════ SCREEN 5 ══════════════ -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">Stations 6–7: the picture comes back as text</h2>
+
+        <p>Behind the wall, Gemini has drawn something. It cannot post you a photograph down a wire, so it sends the picture the only way a text connection allows: as base64.</p>
+
+        <p>The server gives it a name and, if all else fails, wraps it straight back up as a data URL.</p>
+
+        <div class="translation-block animate-in">
+          <div class="translation-code">
+            <span class="translation-label">src/app/api/generate-cyberpunk/route.ts</span>
+            <pre><code>    <span class="code-comment">// Generate filename and store the image</span>
+    <span class="code-keyword">const</span> batch = <span class="code-function">getUuid</span>();
+    <span class="code-keyword">const</span> fileExtension = generatedImageMimeType.<span class="code-function">split</span>(<span class="code-string">'/'</span>)[<span class="code-number">1</span>];
+    <span class="code-keyword">const</span> filename = <span class="code-string">`charlie-lola-${batch}.${fileExtension}`</span>;
+
+    <span class="code-keyword">let</span> finalImageUrl = <span class="code-string">`data:${generatedImageMimeType};base64,${generatedImageData}`</span>;</code></pre>
+          </div>
+          <div class="translation-english">
+            <span class="translation-label">Plain English</span>
+            <div class="translation-lines">
+              <p class="tl">A note-to-self in the code, for whoever reads it next.</p>
+              <p class="tl">Mint a <span class="term" data-definition="A UUID is a long random ID like 3f2a-9c1b-… that is effectively guaranteed never to repeat. Handy when you need a unique filename and nobody is keeping a list.">unique ID</span> so this result gets a filename nobody else will ever collide with.</p>
+              <p class="tl">Gemini told us the picture is, say, image/png. Chop that in half and keep the second bit: png. That is the <span class="term" data-definition="A MIME type is a short label that says what kind of file something is — image/png, image/jpeg, application/json. Servers use it to know how to treat the data.">MIME type</span> becoming a file extension.</p>
+              <p class="tl">Glue them together: charlie-lola-3f2a9c1b.png.</p>
+              <p class="tl">And build a fallback address — the whole picture as a data URL — so there is always something to show, even before it reaches <span class="term" data-definition="A storage bucket is a folder in the cloud with a public web address. Cloudflare R2 is one such service — upload a file, get back a link anyone can open.">cloud storage</span>.</p>
+            </div>
+          </div>
+        </div>
+
+        <p>Whatever address wins — the storage link or the data URL — it travels back to the browser wrapped in <span class="term" data-definition="JSON is a plain-text way of writing structured data: labels and values in curly brackets. It is how a server and a browser most commonly talk.">JSON</span>. And then station 7 is four lines long.</p>
+
+        <div class="translation-block animate-in">
+          <div class="translation-code">
+            <span class="translation-label">imagen-client.tsx · back in the browser</span>
+            <pre><code>      <span class="code-keyword">const</span> result = <span class="code-keyword">await</span> apiResponse.<span class="code-function">json</span>();
+
+      <span class="code-keyword">if</span> (result.code === <span class="code-number">0</span> &amp;&amp; result.data?.imageUrl) {
+        <span class="code-function">setGeneratedImage</span>(result.data.imageUrl);
+</code></pre>
+          </div>
+          <div class="translation-english">
+            <span class="translation-label">Plain English</span>
+            <div class="translation-lines">
+              <p class="tl">Unwrap the <span class="term" data-definition="A response is what a server sends back after you ask it something: a status, plus usually some data. Getting a response does not by itself mean the answer was a good one.">response</span> from the server and read what is inside.</p>
+              <p class="tl">Two conditions, both of which must hold: the app's own status code says all-clear (zero means fine here), AND there is genuinely an image address in the reply.</p>
+              <p class="tl">Only then, put that address into state — and React repaints the right-hand panel with your cartoon.</p>
+            </div>
+          </div>
+        </div>
+
+        <p>Worth pausing on: the server can reply perfectly well and still be reporting a failure <em>inside</em> the message. "The request succeeded" and "the image appeared" are two separate claims.</p>
+
+        <h3 class="screen-heading">Name the station</h3>
+
+        <p>Three situations. In each one, work out which station is involved before you pick — that is the whole exercise.</p>
+
+        <div class="quiz-container" id="quiz-module1">
+
+          <div class="quiz-question-block"
+               data-correct="local-only"
+               data-explanation-right="Exactly. FileReader runs entirely inside the browser, on your own machine. Stations 1 and 2 never touch the internet — which is why the thumbnail is instant and works offline. The photo only crosses the counter at station 3."
+               data-explanation-wrong="Not quite — think about where the work happened. The thumbnail comes from FileReader turning the file into a data URL, and that all happens inside the browser on the visitor&apos;s own machine. No wifi needed. Nothing crosses the counter until the Generate click at station 3.">
+            <div class="scenario-block">
+              <div class="scenario-context">
+                <span class="scenario-label">Scenario</span>
+                <p>Someone tells you: "I dropped my photo in and the thumbnail appeared instantly — and my wifi was off at the time." Is that possible, and what does it tell you?</p>
+              </div>
+            </div>
+            <h3 class="quiz-question">Which stations had already run?</h3>
+            <div class="quiz-options">
+              <button class="quiz-option" data-value="local-only" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>Only 1 and 2 — reading the file into a data URL is entirely local, so it works with no connection at all</span>
+              </button>
+              <button class="quiz-option" data-value="through-server" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>1 through 3 — the thumbnail is proof the server received the upload and sent a preview back</span>
+              </button>
+              <button class="quiz-option" data-value="impossible" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>None — a thumbnail cannot appear without a connection, so they must be misremembering</span>
+              </button>
+            </div>
+            <div class="quiz-feedback"></div>
+          </div>
+
+          <div class="quiz-question-block"
+               data-correct="response-handling"
+               data-explanation-right="Right. The parcel went out and came back with an address in it, so stations 3 through 6 all did their jobs. What is left is station 7 — the check on result.code and the handing-off to setGeneratedImage. Naming that narrows the search from a whole app to a few lines."
+               data-explanation-wrong="Have another think about what the successful response proves. If the reply already contains an imageUrl, then the parcel arrived, Gemini drew something, and storage handed back an address — stations 3 to 6 are all fine. The only station left is the browser deciding what to do with that reply.">
+            <div class="scenario-block">
+              <div class="scenario-context">
+                <span class="scenario-label">Scenario</span>
+                <p>The preview panel stays stubbornly empty. But you look at the browser's <span class="term" data-definition="The network tab is a built-in browser panel that lists every request the page made and what came back. It is the single most useful place to look when something will not load.">network tab</span> and the POST to <code class="badge-code">/api/generate-cyberpunk</code> came back successfully, with an <code class="badge-code">imageUrl</code> right there in the reply.</p>
+              </div>
+            </div>
+            <h3 class="quiz-question">Where do you look first?</h3>
+            <div class="quiz-options">
+              <button class="quiz-option" data-value="gemini" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>Google Gemini — the model probably returned something malformed</span>
+              </button>
+              <button class="quiz-option" data-value="response-handling" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>Station 7 — how the browser handles the reply, starting with the <code class="badge-code">result.code === 0</code> check</span>
+              </button>
+              <button class="quiz-option" data-value="storage" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>Cloudflare R2 — the file never really made it into storage</span>
+              </button>
+            </div>
+            <div class="quiz-feedback"></div>
+          </div>
+
+          <div class="quiz-question-block"
+               data-correct="server-and-gemini"
+               data-explanation-right="Yes. The upload side already handles up to five images, and the panel already knows how to show a result. The real change is on the server: calling Gemini more than once and returning several addresses instead of one — which then makes the results panel plural."
+               data-explanation-wrong="Look at what already exists before assuming everything must change. handleFileUpload already accepts up to five images, so the drop box is not the bottleneck. The station that has to genuinely change shape is the one that talks to Gemini and decides what comes back.">
+            <div class="scenario-block">
+              <div class="scenario-context">
+                <span class="scenario-label">Scenario</span>
+                <p>You want to add a feature: "generate three variations at once." You are about to describe it to your AI coding assistant and want to point it at the right place.</p>
+              </div>
+            </div>
+            <h3 class="quiz-question">Which station's shape changes most?</h3>
+            <div class="quiz-options">
+              <button class="quiz-option" data-value="upload-ui" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>The upload box — it would need to accept multiple files for the first time</span>
+              </button>
+              <button class="quiz-option" data-value="server-and-gemini" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>The server route and its call to Gemini — it has to ask for several pictures and return several addresses</span>
+              </button>
+              <button class="quiz-option" data-value="filereader" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>FileReader — it would need to read each file three separate times</span>
+              </button>
+            </div>
+            <div class="quiz-feedback"></div>
+          </div>
+
+          <button class="quiz-check-btn" onclick="checkQuiz('quiz-module1')">Check Answers</button>
+          <button class="quiz-reset-btn" onclick="resetQuiz('quiz-module1')">Try Again</button>
+        </div>
+
+        <h3 class="screen-heading">Next: the line that station 3 crossed</h3>
+
+        <p>Look back at the seven stations. Stations 1 and 2 ran on your machine. Stations 4, 5 and 6 ran on machines owned by Google and Cloudflare.</p>
+
+        <p>Somewhere in the middle, station 3 crossed a line — and one of the things that stayed on the far side of it was the <span class="term" data-definition="An API key is a secret password that identifies your app to an outside service like Google. Anyone holding it can spend your money, which is why it must never reach a visitor&apos;s browser.">API key</span>.</p>
+
+        <div class="callout callout-info">
+          <div class="callout-icon">🚪</div>
+          <div class="callout-content">
+            <strong class="callout-title">Coming up in Module 2 — Front of House, Backstage</strong>
+            <p>Which of these stations run in the visitor's browser, which run on the company's server, and why the API key can only ever live on one side. That line is the single most important thing to understand about this app.</p>
+          </div>
+        </div>
+      </section>
+
+    </div>
+  </div>
+</section>
+<section class="module" id="module-2">
+  <div class="module-content">
+
+    <header class="module-header animate-in">
+      <span class="module-number">02</span>
+      <h1 class="module-title">Front of House, Backstage</h1>
+      <p class="module-subtitle">Every file in this app runs on one of two machines. Here's the wall between them — and how to tell, at a glance, which side any file is on.</p>
+    </header>
+
+    <div class="module-body">
+
+      <!-- ══════════════ SCREEN 1 — THE HOOK ══════════════ -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">The key that pays for everything</h2>
+
+        <p>The <span class="term" data-definition="An API key is a long secret password that identifies your account to an outside service. Whoever holds it can spend your money on that service — so it is treated like a credit card number.">API key</span> that pays Google for every image this app generates is sitting in a file right now. If it ever reached a visitor's <span class="term" data-definition="The browser is the program a visitor uses to view websites — Chrome, Safari, Firefox. It runs on their computer, which means they can inspect and change anything inside it.">browser</span>, a stranger could run up the bill on somebody else's card.</p>
+
+        <p>Module 1 followed one photo from the upload box to the moment it crossed from the browser to the <span class="term" data-definition="A server is a computer the company owns and runs, sitting in a data centre somewhere. Visitors never touch it directly — they can only send it requests and read what it chooses to send back.">server</span>. This module is about that crossing itself: what it is, why it exists, and how to tell which side of it you're standing on.</p>
+
+        <div class="callout callout-warning">
+          <div class="callout-icon">⚠️</div>
+          <div class="callout-content">
+            <strong class="callout-title">This is the #1 thing AI coding assistants get wrong</strong>
+            <p>Ask an AI for a feature in a <span class="term" data-definition="Next.js is the framework this app is built on — a big pre-made toolkit for building websites with React. It is the thing that decides which of your files run on the server and which get sent to browsers.">Next.js</span> app and it will happily put browser-only code in a server file, or read a secret in a browser file. The errors that come back are famously baffling — "useState is not a function", "<span class="term" data-definition="Hydration is the moment the browser takes the finished page the server sent and wires the buttons up so they actually work. A hydration mismatch means the server and the browser disagreed about what the page should say.">hydration</span> mismatch". Spotting the side a file belongs to lets you correct it in one sentence instead of ten rounds of guessing.</p>
+          </div>
+        </div>
+      </section>
+
+      <!-- ══════════════ SCREEN 2 — THE METAPHOR ══════════════ -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">A theatre has two halves</h2>
+
+        <p>Front of house is what the audience sees: the stage, the actors, the programme in their hands. Backstage is the fly system, the lighting desk, and the safe in the manager's office with the keys in it.</p>
+
+        <p>The audience can walk right up to the edge of the stage. They can never walk into that office. That single fact is the whole architecture of this app.</p>
+
+        <div class="icon-rows stagger-children">
+          <div class="icon-row animate-in">
+            <div class="icon-circle" style="background: var(--color-actor-3)">🎭</div>
+            <div>
+              <strong>Front of house = the visitor's browser</strong>
+              <p>Buttons, drag-and-drop, spinners, previews. Everything here was shipped to a stranger's laptop, and a stranger can read every line of it.</p>
+            </div>
+          </div>
+          <div class="icon-row animate-in">
+            <div class="icon-circle" style="background: var(--color-actor-5)">🔐</div>
+            <div>
+              <strong>Backstage = the company's server</strong>
+              <p>Translation files, database lookups, the API keys. Nothing here is ever sent out — only the <em>results</em> of what happens here.</p>
+            </div>
+          </div>
+          <div class="icon-row animate-in">
+            <div class="icon-circle" style="background: var(--color-accent)">🚪</div>
+            <div>
+              <strong>The stage door = one line of text</strong>
+              <p>A file that starts with <code class="badge-code">'use client'</code> is front of house. A file without it stays backstage. That's it — that's the whole mechanism.</p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- ══════════════ SCREEN 3 — THE CAST ══════════════ -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">Meet the cast</h2>
+
+        <p>Five files do almost all the work in this feature. Click any of them to hear what they do — and notice which side of the wall each one lives on.</p>
+
+        <div class="arch-diagram">
+          <h4 class="arch-zone-label">🎭 Front of house — the visitor's browser · anyone can read this</h4>
+          <div class="arch-zone">
+            <div class="arch-component" data-desc="ImagenClient (imagen-client.tsx, 893 lines) — everything you can touch: drag-and-drop, image previews, the Generate button, spinners, toasts, and remembering your last settings. It runs on a stranger's laptop, so it gets no secrets and no direct line to Google.">
+              <div class="arch-icon">🖐️</div>
+              <span>ImagenClient</span>
+            </div>
+          </div>
+
+          <h4 class="arch-zone-label">🚪 ── the stage door: <code>'use client'</code> ──</h4>
+
+          <h4 class="arch-zone-label">🔐 Backstage — the company's server · nobody outside can look in</h4>
+          <div class="arch-zone">
+            <div class="arch-component" data-desc="The Page (page.tsx) — the homepage itself. It renders the generator at the top plus about ten marketing sections below it. It runs entirely on the server and only its finished HTML is sent out.">
+              <div class="arch-icon">📄</div>
+              <span>The Page</span>
+            </div>
+            <div class="arch-component" data-desc="ImagenWrapper (index.tsx) — looks up every piece of English or Chinese text the generator needs, bundles it into one plain object, and hands it down to ImagenClient. Nothing interactive, no buttons — just fetching words.">
+              <div class="arch-icon">🎁</div>
+              <span>ImagenWrapper</span>
+            </div>
+            <div class="arch-component" data-desc="The route (api/generate-cyberpunk/route.ts) — the only door between the two worlds. It checks who you are, spends your credits, calls Gemini, and stores the result. Every request from the browser comes through here or not at all.">
+              <div class="arch-icon">🚦</div>
+              <span>The route</span>
+            </div>
+            <div class="arch-component" data-desc="The key pool (gemini-api-pool.ts) — holds the Gemini API keys read from the server's environment. It never leaves the building, and Module 3 covers how it rotates between up to six of them.">
+              <div class="arch-icon">🗝️</div>
+              <span>The key pool</span>
+            </div>
+          </div>
+
+          <div class="arch-description">Click any actor to see what it does.</div>
+        </div>
+      </section>
+
+      <!-- ══════════════ SCREEN 4 — HERO: GROUP CHAT ══════════════ -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">The backstage group chat</h2>
+
+        <p>Here's what those five say to each other in the half-second after a visitor loads the homepage. Play it through — the last four messages are the whole point of this module.</p>
+
+        <div class="chat-window" id="chat-module2">
+          <div class="chat-messages">
+
+            <div class="chat-message" data-msg="0" data-sender="page" style="display:none">
+              <div class="chat-avatar" style="background: var(--color-actor-1)">P</div>
+              <div class="chat-bubble">
+                <span class="chat-sender" style="color: var(--color-actor-1)">The Page</span>
+                <p>Visitor incoming, <span class="term" data-definition="A locale is the code for a visitor's language and region — 'en' for English, 'zh' for Chinese. The app uses it to decide which set of words to show.">locale</span> <code>en</code>. Wrapper, you're up.</p>
+              </div>
+            </div>
+
+            <div class="chat-message" data-msg="1" data-sender="wrapper" style="display:none">
+              <div class="chat-avatar" style="background: var(--color-actor-2)">W</div>
+              <div class="chat-bubble">
+                <span class="chat-sender" style="color: var(--color-actor-2)">ImagenWrapper</span>
+                <p>On it. Pulling all 40-odd strings from the <code>imagen</code> <span class="term" data-definition="A namespace is a labelled drawer that keeps names from colliding. All the text for the image generator lives in the 'imagen' drawer, so its 'title' does not clash with the pricing page's 'title'.">namespace</span>… badge, title, upload prompts, error messages. Bundling.</p>
+              </div>
+            </div>
+
+            <div class="chat-message" data-msg="2" data-sender="client" style="display:none">
+              <div class="chat-avatar" style="background: var(--color-actor-3)">C</div>
+              <div class="chat-bubble">
+                <span class="chat-sender" style="color: var(--color-actor-3)">ImagenClient</span>
+                <p>Just send me the finished words. I can't read translation files — I run on a stranger's laptop.</p>
+              </div>
+            </div>
+
+            <div class="chat-message" data-msg="3" data-sender="wrapper" style="display:none">
+              <div class="chat-avatar" style="background: var(--color-actor-2)">W</div>
+              <div class="chat-bubble">
+                <span class="chat-sender" style="color: var(--color-actor-2)">ImagenWrapper</span>
+                <p>Here. One plain object, already in English. 📦 <code>translations</code></p>
+              </div>
+            </div>
+
+            <div class="chat-message" data-msg="4" data-sender="client" style="display:none">
+              <div class="chat-avatar" style="background: var(--color-actor-3)">C</div>
+              <div class="chat-bubble">
+                <span class="chat-sender" style="color: var(--color-actor-3)">ImagenClient</span>
+                <p>Great. I'll take it from here — drag-and-drop, previews, the button. Route, stand by.</p>
+              </div>
+            </div>
+
+            <div class="chat-message" data-msg="5" data-sender="route" style="display:none">
+              <div class="chat-avatar" style="background: var(--color-actor-4)">R</div>
+              <div class="chat-bubble">
+                <span class="chat-sender" style="color: var(--color-actor-4)">The route</span>
+                <p>Standing by. Nobody talks to Gemini except me.</p>
+              </div>
+            </div>
+
+            <div class="chat-message" data-msg="6" data-sender="client" style="display:none">
+              <div class="chat-avatar" style="background: var(--color-actor-3)">C</div>
+              <div class="chat-bubble">
+                <span class="chat-sender" style="color: var(--color-actor-3)">ImagenClient</span>
+                <p>Can I just have the API key? It'd save a round trip.</p>
+              </div>
+            </div>
+
+            <div class="chat-message" data-msg="7" data-sender="keypool" style="display:none">
+              <div class="chat-avatar" style="background: var(--color-actor-5)">K</div>
+              <div class="chat-bubble">
+                <span class="chat-sender" style="color: var(--color-actor-5)">The key pool</span>
+                <p>Absolutely not. 😊</p>
+              </div>
+            </div>
+
+            <div class="chat-message" data-msg="8" data-sender="route" style="display:none">
+              <div class="chat-avatar" style="background: var(--color-actor-4)">R</div>
+              <div class="chat-bubble">
+                <span class="chat-sender" style="color: var(--color-actor-4)">The route</span>
+                <p>It'd be in the <span class="term" data-definition="Page source is the raw text of a web page. Right-click any website and choose View Page Source to see it — everything the site sent your browser, secrets included, if anyone was careless enough to send one.">page source</span> in about four seconds. Send me the photo, I'll send you a picture.</p>
+              </div>
+            </div>
+
+          </div>
+
+          <div class="chat-typing" id="chat-module2-typing" style="display:none">
+            <div class="chat-avatar" id="chat-module2-typing-avatar">?</div>
+            <div class="chat-typing-dots">
+              <span class="typing-dot"></span>
+              <span class="typing-dot"></span>
+              <span class="typing-dot"></span>
+            </div>
+          </div>
+
+          <div class="chat-controls">
+            <button class="btn chat-next-btn">Next Message</button>
+            <button class="btn btn-primary chat-all-btn">Play All</button>
+            <button class="btn chat-reset-btn">Replay</button>
+            <span class="chat-progress"></span>
+          </div>
+        </div>
+
+        <div class="callout callout-accent">
+          <div class="callout-icon">💡</div>
+          <div class="callout-content">
+            <strong class="callout-title">Aha — the browser is a hostile environment you don't control</strong>
+            <p>Everything you send to a browser can be read, edited and replayed by whoever's holding the laptop. The client/server line isn't bureaucracy — it's the only place a secret can actually hide.</p>
+          </div>
+        </div>
+      </section>
+
+      <!-- ══════════════ SCREEN 5 — THE STAGE DOOR ══════════════ -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">The stage door is one line long</h2>
+
+        <p>This is the top of <code class="badge-code">imagen-client.tsx</code>, the 893-line file behind every button in the generator. The first line is what makes it front of house.</p>
+
+        <div class="translation-block animate-in">
+          <div class="translation-code">
+            <span class="translation-label">CODE</span>
+            <pre><code><span class="code-line"><span class="code-string">'use client'</span>;</span>
+<span class="code-line"></span>
+<span class="code-line"><span class="code-keyword">import</span> React, { useState, useRef, useEffect } <span class="code-keyword">from</span> <span class="code-string">'react'</span>;</span>
+<span class="code-line"><span class="code-keyword">import</span> { useSession } <span class="code-keyword">from</span> <span class="code-string">'next-auth/react'</span>;</span>
+<span class="code-line"><span class="code-keyword">import</span> { Card, CardContent } <span class="code-keyword">from</span> <span class="code-string">'@/components/ui/card'</span>;</span>
+<span class="code-line"><span class="code-keyword">import</span> { Button } <span class="code-keyword">from</span> <span class="code-string">'@/components/ui/button'</span>;</span>
+<span class="code-line"><span class="code-keyword">import</span> { cn } <span class="code-keyword">from</span> <span class="code-string">'@/lib/utils'</span>;</span>
+<span class="code-line"><span class="code-keyword">import</span> { useUserCredits } <span class="code-keyword">from</span> <span class="code-string">'@/hooks/useUserCredits'</span>;</span></code></pre>
+          </div>
+          <div class="translation-english">
+            <span class="translation-label">PLAIN ENGLISH</span>
+            <div class="translation-lines">
+              <p class="tl">"Ship this whole file to the visitor's browser." That one line turns everything below it into a <span class="term" data-definition="A client component is a file that gets sent to the visitor's browser and runs there. It can respond to clicks and typing — but it can never hold a secret, because the visitor can read it.">client component</span>.</p>
+              <p class="tl">A blank line — just breathing room.</p>
+              <p class="tl">Borrow the tools for <span class="term" data-definition="State is a component's short-term memory — which image you uploaded, whether the spinner is showing. Only browser code can have it, because only the browser is watching the visitor in real time.">remembering things</span> and reacting to changes. These only work front of house, which is exactly why the file needs line 1.</p>
+              <p class="tl">Borrow a way to ask "is anyone logged in right now?"</p>
+              <p class="tl">Borrow the ready-made Card box that the generator panel sits inside.</p>
+              <p class="tl">Borrow the ready-made Button, so every button in the app looks the same.</p>
+              <p class="tl">Borrow a small helper for combining styling names tidily.</p>
+              <p class="tl">Borrow a way to read how many credits the logged-in visitor has left.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="callout callout-info">
+          <div class="callout-icon">📌</div>
+          <div class="callout-content">
+            <strong class="callout-title">Useful phrase for talking to an AI</strong>
+            <p>"Put the interactive part in a <code>'use client'</code> component and keep the data fetching on the server." That one sentence resolves most of the confusion an assistant will get into in a Next.js project.</p>
+          </div>
+        </div>
+      </section>
+
+      <!-- ══════════════ SCREEN 6 — THE WRAPPER ══════════════ -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">Backstage: fetching the words</h2>
+
+        <p><code class="badge-code">ImagenWrapper</code> has no line 1, so it stays backstage — it's a <span class="term" data-definition="A server component is a file that runs only on the company's server. It can read secrets and wait for slow lookups, and only its finished output is sent to the visitor. In Next.js this is the default for every file.">server component</span>. Its entire job is looking up text in the right language and handing it over.</p>
+
+        <div class="translation-block animate-in">
+          <div class="translation-code">
+            <span class="translation-label">CODE</span>
+            <pre><code><span class="code-line"><span class="code-keyword">export default async function</span> <span class="code-function">ImagenWrapper</span>({ locale = <span class="code-string">'en'</span> }: ImagenWrapperProps = {}) {</span>
+<span class="code-line">  <span class="code-comment">// Set the request locale for server-side translations</span></span>
+<span class="code-line">  <span class="code-function">setRequestLocale</span>(locale);</span>
+<span class="code-line"></span>
+<span class="code-line">  <span class="code-comment">// Get the translations on the server side with explicit locale</span></span>
+<span class="code-line">  <span class="code-keyword">const</span> t = <span class="code-keyword">await</span> <span class="code-function">getTranslations</span>({ locale, <span class="code-property">namespace</span>: <span class="code-string">'imagen'</span> });</span>
+<span class="code-line"></span>
+<span class="code-line">  <span class="code-comment">// Pass translations as props to the client component</span></span>
+<span class="code-line">  <span class="code-keyword">const</span> translations = {</span>
+<span class="code-line">    <span class="code-property">badge</span>: { <span class="code-property">text</span>: <span class="code-function">t</span>(<span class="code-string">'badge.text'</span>) },</span>
+<span class="code-line">    <span class="code-property">title</span>: { <span class="code-property">main</span>: <span class="code-function">t</span>(<span class="code-string">'title.main'</span>), <span class="code-property">subtitle</span>: <span class="code-function">t</span>(<span class="code-string">'title.subtitle'</span>) },</span></code></pre>
+          </div>
+          <div class="translation-english">
+            <span class="translation-label">PLAIN ENGLISH</span>
+            <div class="translation-lines">
+              <p class="tl">Define the wrapper. The word <span class="term" data-definition="Async is short for asynchronous — code that is allowed to pause, go do something slow like a lookup, and carry on when the answer arrives. Server components may do this; browser components may not.">async</span> is the giveaway that this runs on the server: only a backstage file is allowed to pause. If no language is given, use English.</p>
+              <p class="tl">A note from the original author explaining the next line.</p>
+              <p class="tl">Tell the translation system which language this particular visitor gets.</p>
+              <p class="tl">Blank line.</p>
+              <p class="tl">Another author's note.</p>
+              <p class="tl">Go and load the <span class="term" data-definition="Internationalisation, usually shortened to i18n, is the practice of keeping every visible sentence in separate language files so the same app can be shown in English, Chinese, or anything else without rewriting it.">translation</span> file, and <span class="term" data-definition="Await means pause here until the answer comes back, then continue. It is only legal in code that is allowed to wait — which browser components are not.">wait</span> for it. Then call the result <code>t</code> — a lookup tool for words in the <code>imagen</code> drawer.</p>
+              <p class="tl">Blank line.</p>
+              <p class="tl">The author telling us exactly what happens next.</p>
+              <p class="tl">Start building one plain package of finished text.</p>
+              <p class="tl">Look up the badge wording and put it in the package.</p>
+              <p class="tl">Look up the headline and subheadline too. About forty more lookups follow this one.</p>
+            </div>
+          </div>
+        </div>
+
+        <p>Seventy lines later, the package is complete and the hand-off happens on a single line:</p>
+
+        <div class="translation-block animate-in">
+          <div class="translation-code">
+            <span class="translation-label">CODE</span>
+            <pre><code><span class="code-line">  <span class="code-keyword">return</span> &lt;<span class="code-tag">ImagenClient</span> <span class="code-attr">translations</span>={translations} /&gt;;</span></code></pre>
+          </div>
+          <div class="translation-english">
+            <span class="translation-label">PLAIN ENGLISH</span>
+            <div class="translation-lines">
+              <p class="tl">Hand the finished package of words to ImagenClient as a <span class="term" data-definition="A prop is a value one component passes down to another, like handing over a labelled box. The receiving component can read it but not change it.">prop</span>, and let the front of house take over. Passing one bundled object rather than forty separate ones keeps this from turning into <span class="term" data-definition="Prop drilling is when a value has to be passed down through layer after layer of components to reach the one that needs it — tedious, and easy to break. Bundling everything into a single object is one common way to avoid it.">prop drilling</span>. This is the whole crossing: words go out, the translation files stay in.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="callout callout-info">
+          <div class="callout-icon">🎬</div>
+          <div class="callout-content">
+            <strong class="callout-title">Why not let ImagenClient fetch its own text?</strong>
+            <p>Because doing it backstage means the correct words are already in the page before any JavaScript runs — the visitor sees real text instantly, and search engines see real text too. Fetching it front of house would mean a flash of emptiness first.</p>
+          </div>
+        </div>
+      </section>
+
+      <!-- ══════════════ SCREEN 7 — SECRETS ══════════════ -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">What only backstage can see</h2>
+
+        <p>This is the key pool reading Google's API keys out of the server's <span class="term" data-definition="Environment variables are settings stored on the machine running the app rather than written into the code — the standard hiding place for passwords and keys, so they never end up in a shared code repository.">environment variables</span>. It has no <code>'use client'</code>, so no visitor will ever see it.</p>
+
+        <div class="translation-block animate-in">
+          <div class="translation-code">
+            <span class="translation-label">CODE</span>
+            <pre><code><span class="code-line">    <span class="code-comment">// Get all Gemini API keys from environment variables</span></span>
+<span class="code-line">    <span class="code-keyword">const</span> geminiKeys = [</span>
+<span class="code-line">      process.env.GEMINI_API_KEY,</span>
+<span class="code-line">      process.env.GEMINI_API_KEY_1,</span>
+<span class="code-line">      process.env.GEMINI_API_KEY_2, </span>
+<span class="code-line">      process.env.GEMINI_API_KEY_3,</span>
+<span class="code-line">      process.env.GEMINI_API_KEY_4,</span>
+<span class="code-line">      process.env.GEMINI_API_KEY_5,</span>
+<span class="code-line">    ].<span class="code-function">filter</span>(key =&gt; key &amp;&amp; key.<span class="code-function">trim</span>() !== <span class="code-string">''</span>);</span></code></pre>
+          </div>
+          <div class="translation-english">
+            <span class="translation-label">PLAIN ENGLISH</span>
+            <div class="translation-lines">
+              <p class="tl">The author's note: we're about to collect the keys.</p>
+              <p class="tl">Make a list to hold them.</p>
+              <p class="tl">Reach into <span class="term" data-definition="process.env is how code asks the machine it is running on for its settings. On the server it returns real values; anything read this way is invisible to visitors unless its name says otherwise.">the machine's settings</span> for the main key.</p>
+              <p class="tl">And the first spare.</p>
+              <p class="tl">And the second.</p>
+              <p class="tl">And the third.</p>
+              <p class="tl">And the fourth.</p>
+              <p class="tl">And the fifth — six slots in total, though most may be empty.</p>
+              <p class="tl">Throw away any slot that's missing or blank, so only real keys survive. Module 3 is entirely about what happens next.</p>
+            </div>
+          </div>
+        </div>
+
+        <h3 class="screen-heading">The one exception, and it's spelled out in the name</h3>
+
+        <p>Deep inside the browser file, there <em>is</em> a setting being read. It's allowed out only because of how it's named.</p>
+
+        <div class="translation-block animate-in">
+          <div class="translation-code">
+            <span class="translation-label">CODE</span>
+            <pre><code><span class="code-line">                    {t.buttons.generate}</span>
+<span class="code-line">                    &lt;<span class="code-tag">span</span> <span class="code-attr">className</span>=<span class="code-value">"text-cl-blue font-medium"</span>&gt;</span>
+<span class="code-line">                      {process.env.NEXT_PUBLIC_FREE_MODE_ENABLED === <span class="code-string">'true'</span> </span>
+<span class="code-line">                        ? <span class="code-string">`(${t.buttons.limited_free})`</span></span>
+<span class="code-line">                        : <span class="code-string">`(${modelOptions.<span class="code-function">find</span>(m =&gt; m.value === selectedModel)?.credits || <span class="code-number">10</span>} credits)`</span></span>
+<span class="code-line">                      }</span>
+<span class="code-line">                    &lt;/<span class="code-tag">span</span>&gt;</span></code></pre>
+          </div>
+          <div class="translation-english">
+            <span class="translation-label">PLAIN ENGLISH</span>
+            <div class="translation-lines">
+              <p class="tl">Print the button's label — "Generate", in whichever language the wrapper sent.</p>
+              <p class="tl">Open a small styled piece of text right next to it.</p>
+              <p class="tl">Check a setting: is the app currently in free mode? The <code>NEXT_PUBLIC_</code> prefix is why this one is readable here at all.</p>
+              <p class="tl">If yes, show the "limited free" wording in brackets.</p>
+              <p class="tl">If no, look up how many credits the chosen model costs and show that instead — falling back to 10 if it can't tell.</p>
+              <p class="tl">Done choosing.</p>
+              <p class="tl">Close the styled text.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="badge-list">
+          <div class="badge-item">
+            <code class="badge-code">GEMINI_API_KEY</code>
+            <span class="badge-desc">No prefix → stripped out of anything sent to browsers. Server only. This is the default and the safe one.</span>
+          </div>
+          <div class="badge-item">
+            <code class="badge-code">NEXT_PUBLIC_FREE_MODE_ENABLED</code>
+            <span class="badge-desc">Prefixed → baked into the <span class="term" data-definition="A bundle is the single big file of JavaScript — the code that makes a page interactive — that gets packed up and downloaded by every visitor. Anything inside it is readable by anyone who cares to look.">bundle</span> every visitor downloads. A promise you're making: "it is fine for strangers to read this."</span>
+          </div>
+        </div>
+
+        <div class="callout callout-warning">
+          <div class="callout-icon">✍️</div>
+          <div class="callout-content">
+            <strong class="callout-title">Naming is the entire security mechanism</strong>
+            <p>There's no vault and no permission list — the framework decides purely by reading the name. Which means adding six characters to the front of a key's name is a real, published leak.</p>
+          </div>
+        </div>
+      </section>
+
+      <!-- ══════════════ SCREEN 8 — HOW TO TELL ══════════════ -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">Three ways to tell which side you're on</h2>
+
+        <div class="pattern-cards">
+          <div class="pattern-card" style="border-top: 3px solid var(--color-actor-3)">
+            <div class="pattern-icon" style="background: var(--color-actor-3)">1️⃣</div>
+            <h4 class="pattern-title">Read the top line</h4>
+            <p class="pattern-desc"><code>'use client'</code> on line 1 means front of house. No line 1 means backstage — that's the default in this app.</p>
+          </div>
+          <div class="pattern-card" style="border-top: 3px solid var(--color-actor-4)">
+            <div class="pattern-icon" style="background: var(--color-actor-4)">2️⃣</div>
+            <h4 class="pattern-title">Look at what it touches</h4>
+            <p class="pattern-desc">Clicks, typing, remembering, spinners → must be front of house. Waiting on a lookup, reading secrets → must be backstage.</p>
+          </div>
+          <div class="pattern-card" style="border-top: 3px solid var(--color-actor-5)">
+            <div class="pattern-icon" style="background: var(--color-actor-5)">3️⃣</div>
+            <h4 class="pattern-title">Ask who's allowed to see it</h4>
+            <p class="pattern-desc">If a stranger reading this file would be a problem, it cannot be front of house. No exceptions, no clever workarounds.</p>
+          </div>
+        </div>
+
+        <div class="file-tree">
+          <div class="ft-folder open">
+            <span class="ft-name">src/</span>
+            <span class="ft-desc">All the app's own code</span>
+            <div class="ft-children">
+              <div class="ft-folder open">
+                <span class="ft-name">app/</span>
+                <span class="ft-desc">Pages visitors land on, and the doors they knock at</span>
+                <div class="ft-children">
+                  <div class="ft-file">
+                    <span class="ft-name">[locale]/(default)/page.tsx</span>
+                    <span class="ft-desc">🔐 backstage — the homepage</span>
+                  </div>
+                  <div class="ft-file">
+                    <span class="ft-name">api/generate-cyberpunk/route.ts</span>
+                    <span class="ft-desc">🔐 backstage — the only door between the two worlds</span>
+                  </div>
+                </div>
+              </div>
+              <div class="ft-folder open">
+                <span class="ft-name">components/blocks/imagen-wrapper/</span>
+                <span class="ft-desc">The generator panel, in two halves</span>
+                <div class="ft-children">
+                  <div class="ft-file">
+                    <span class="ft-name">index.tsx</span>
+                    <span class="ft-desc">🔐 backstage — fetches the words, hands them down</span>
+                  </div>
+                  <div class="ft-file">
+                    <span class="ft-name">imagen-client.tsx</span>
+                    <span class="ft-desc">🎭 front of house — 893 lines of everything you can touch</span>
+                  </div>
+                </div>
+              </div>
+              <div class="ft-folder open">
+                <span class="ft-name">lib/</span>
+                <span class="ft-desc">Shared helpers</span>
+                <div class="ft-children">
+                  <div class="ft-file">
+                    <span class="ft-name">gemini-api-pool.ts</span>
+                    <span class="ft-desc">🔐 backstage — the drawer with the keys in it</span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <p>One honest observation: 893 lines in a single front-of-house file is a lot. It works, and it shipped — but every visitor downloads all of it, and every change risks the whole panel.</p>
+      </section>
+
+      <!-- ══════════════ SCREEN 9 — QUIZ ══════════════ -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">Try it on real situations</h2>
+
+        <p>No score, no pass mark. Each of these is a thing that genuinely happens when you're building with an AI assistant.</p>
+
+        <div class="quiz-container" id="quiz-module2">
+
+          <div class="quiz-question-block"
+               data-correct="opt-b"
+               data-explanation-right="Exactly. Remembering a choice is state, and state only exists front of house. The one-line correction is: 'Put that dropdown in imagen-client.tsx instead — it needs state, so it has to be a client component.' You have just saved yourself six rounds of confusing error messages."
+               data-explanation-wrong="Not quite — think about what 'remembers' means. Remembering the last pick is state, and state only works in a file that ships to the browser. index.tsx is backstage, so it cannot hold any. The fix is a one-liner to the AI: put the dropdown in imagen-client.tsx, or make a new component with 'use client' at the top.">
+            <div class="scenario-block">
+              <div class="scenario-context">
+                <span class="scenario-label">Scenario</span>
+                <p>You ask an AI to "add a dropdown that remembers the last style the user picked." It writes the code into <code>index.tsx</code> — the wrapper. What happens, and what do you say back?</p>
+              </div>
+            </div>
+            <div class="quiz-options">
+              <button class="quiz-option" data-value="opt-a" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>It works, but the dropdown will be slow because the server has to re-render it every time.</span>
+              </button>
+              <button class="quiz-option" data-value="opt-b" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>It breaks — remembering means state, and state only exists front of house. Tell it to put the dropdown in <code>imagen-client.tsx</code> instead.</span>
+              </button>
+              <button class="quiz-option" data-value="opt-c" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>It works fine — the wrapper already handles the translations, so it can handle the dropdown too.</span>
+              </button>
+            </div>
+            <div class="quiz-feedback"></div>
+          </div>
+
+          <div class="quiz-question-block"
+               data-correct="opt-c"
+               data-explanation-right="Right on both counts. Without the prefix the value is stripped out and arrives as nothing, so the call to Google just fails. And the tempting 'fix' — renaming it to NEXT_PUBLIC_GEMINI_API_KEY — would publish the key to every single visitor. The honest fix is to leave the key backstage and let the route make the call."
+               data-explanation-wrong="Close, but there are two failures stacked here. First, without the NEXT_PUBLIC_ prefix the value never reaches the browser at all, so the code gets nothing and the call fails. Second, and worse, the obvious way to 'fix' that is to rename it with the prefix — which would publish the key to every visitor who loads the page.">
+            <div class="scenario-block">
+              <div class="scenario-context">
+                <span class="scenario-label">Scenario</span>
+                <p>A teammate adds <code>process.env.GEMINI_API_KEY</code> to <code>imagen-client.tsx</code> to "skip the round trip and speed things up." What actually happens?</p>
+              </div>
+            </div>
+            <div class="quiz-options">
+              <button class="quiz-option" data-value="opt-a" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>It works and is genuinely faster — one less hop through the server.</span>
+              </button>
+              <button class="quiz-option" data-value="opt-b" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>Next.js refuses to build the app and prints a security error.</span>
+              </button>
+              <button class="quiz-option" data-value="opt-c" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>It arrives empty because the name has no <code>NEXT_PUBLIC_</code> prefix — and "fixing" that by adding the prefix would publish the key to every visitor.</span>
+              </button>
+            </div>
+            <div class="quiz-feedback"></div>
+          </div>
+
+          <div class="quiz-question-block"
+               data-correct="opt-a"
+               data-explanation-right="Exactly. The right words are chosen per visitor, per language, backstage — so they are already sitting in the page before a single line of JavaScript runs. The visitor sees real text instantly, and search engines see real text too, not an empty box waiting to be filled."
+               data-explanation-wrong="Think about timing rather than tidiness. If ImagenClient fetched its own text, the visitor would get an empty panel first and the words a moment later. Doing the lookup backstage means the finished words are baked into the page before it is even sent — instant for the visitor, and readable by search engines.">
+            <div class="scenario-block">
+              <div class="scenario-context">
+                <span class="scenario-label">Scenario</span>
+                <p>Someone proposes deleting <code>ImagenWrapper</code> entirely and letting <code>ImagenClient</code> fetch its own text. Why does the wrapper exist?</p>
+              </div>
+            </div>
+            <div class="quiz-options">
+              <button class="quiz-option" data-value="opt-a" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>So the right words are already in the page before any JavaScript runs — instant for the visitor, and visible to search engines.</span>
+              </button>
+              <button class="quiz-option" data-value="opt-b" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>Because translation files contain secrets that visitors must never see.</span>
+              </button>
+              <button class="quiz-option" data-value="opt-c" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>Purely as a style choice — the team likes small files, and it makes no practical difference.</span>
+              </button>
+            </div>
+            <div class="quiz-feedback"></div>
+          </div>
+
+          <div class="quiz-question-block"
+               data-correct="opt-b"
+               data-explanation-right="That is the honest answer. It works, it shipped, and it is the file you would split first. Every visitor downloads all 893 lines whether they generate an image or not, and a small change to the download button sits in the same file as the upload logic."
+               data-explanation-wrong="It is tempting to call it a bug, but it is not — the app works. The real cost is quieter: everything in a front-of-house file ships to every visitor, so the whole 893 lines get downloaded by someone who only came to read the marketing copy. And with upload, preview, prompt editing, download and share all in one place, any change risks the entire panel.">
+            <div class="scenario-block">
+              <div class="scenario-context">
+                <span class="scenario-label">Scenario</span>
+                <p><code>imagen-client.tsx</code> is 893 lines holding upload, preview, prompt editing, download and share. What's the practical cost of that?</p>
+              </div>
+            </div>
+            <div class="quiz-options">
+              <button class="quiz-option" data-value="opt-a" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>None — file length is purely a matter of taste and has no effect on anything.</span>
+              </button>
+              <button class="quiz-option" data-value="opt-b" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>All of it ships to every visitor, and any change risks the whole panel. It works, but it's the file you'd split first.</span>
+              </button>
+              <button class="quiz-option" data-value="opt-c" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>The API keys inside it become easier for visitors to find.</span>
+              </button>
+            </div>
+            <div class="quiz-feedback"></div>
+          </div>
+
+          <button class="quiz-check-btn" onclick="checkQuiz('quiz-module2')">Check Answers</button>
+          <button class="quiz-reset-btn" onclick="resetQuiz('quiz-module2')">Try Again</button>
+        </div>
+      </section>
+
+      <!-- ══════════════ SCREEN 10 — HANDOFF ══════════════ -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">Next: through the stage door</h2>
+
+        <p>You can now look at any file in a Next.js project and say which machine it runs on — which is most of what you need to steer an AI assistant through one.</p>
+
+        <div class="callout callout-accent">
+          <div class="callout-icon">🗝️</div>
+          <div class="callout-content">
+            <strong class="callout-title">Module 3 — Commissioning the Artist</strong>
+            <p>Backstage, there's a drawer with up to six keys in it. Only one gets used per request, and the drawer remembers which ones are burnt.</p>
+          </div>
+        </div>
+      </section>
+
+    </div>
+  </div>
+</section>
+<section class="module" id="module-3" style="background: var(--color-bg-warm)">
+  <div class="module-content">
+
+    <header class="module-header animate-in">
+      <span class="module-number">03</span>
+      <h1 class="module-title">Commissioning the Artist</h1>
+      <p class="module-subtitle">The whole "Charlie &amp; Lola style" is one paragraph of English. Here is how it gets sent, and what the app does around it.</p>
+    </header>
+
+    <div class="module-body">
+
+      <!-- ============ SCREEN 1: THE HOOK ============ -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">There is no "Charlie &amp; Lola" button</h2>
+
+        <p>Open the generator and look at the prompt box on the right. You can read the entire product in there — and you are allowed to edit it.</p>
+
+        <p>Nobody trained a Charlie-and-Lola machine. Someone wrote a paragraph describing exactly how the drawing should look, and the app sends that paragraph plus your photo to a general-purpose artist, every single time you press the button.</p>
+
+        <div class="callout callout-accent">
+          <div class="callout-icon">🖍️</div>
+          <div class="callout-content">
+            <strong class="callout-title">The metaphor for this module: commissioning an illustrator</strong>
+            <p>You are not applying a filter. You are handing a freelance illustrator a written brief and a reference photo, and waiting for what comes back. The "style" you picked in the interface <em>is</em> the brief.</p>
+          </div>
+        </div>
+
+        <h2 class="screen-heading" style="margin-top: var(--space-12)">The intelligence is rented. These five jobs are the app.</h2>
+
+        <p>The drawing talent belongs to Google. Everything the app itself contributes fits on five cards — and every one of them is a place things break.</p>
+
+        <div class="pattern-cards stagger-children">
+          <div class="pattern-card animate-in" style="border-top: 3px solid var(--color-actor-2)">
+            <div class="pattern-icon" style="background: var(--color-actor-2)">🔑</div>
+            <h4 class="pattern-title">Choose a key</h4>
+            <p class="pattern-desc">Pick one of six <span class="term" data-definition="An API key is a long secret password that proves to an outside service that a request is coming from a paying, registered account. Whoever holds it can spend that account&apos;s money — which is why it never leaves the server.">API keys</span> that still has budget left for today.</p>
+          </div>
+          <div class="pattern-card animate-in" style="border-top: 3px solid var(--color-actor-1)">
+            <div class="pattern-icon" style="background: var(--color-actor-1)">✍️</div>
+            <h4 class="pattern-title">Write the brief</h4>
+            <p class="pattern-desc">One long paragraph of English describing the look, what to keep, and what to avoid.</p>
+          </div>
+          <div class="pattern-card animate-in" style="border-top: 3px solid var(--color-actor-3)">
+            <div class="pattern-icon" style="background: var(--color-actor-3)">📎</div>
+            <h4 class="pattern-title">Attach the photo</h4>
+            <p class="pattern-desc">Re-shape your upload into the exact parcel the artist expects to receive.</p>
+          </div>
+          <div class="pattern-card animate-in" style="border-top: 3px solid var(--color-actor-4)">
+            <div class="pattern-icon" style="background: var(--color-actor-4)">🔍</div>
+            <h4 class="pattern-title">Dig out the reply</h4>
+            <p class="pattern-desc">The answer is a mixed bag of parts. Find the one part that is actually a picture.</p>
+          </div>
+          <div class="pattern-card animate-in" style="border-top: 3px solid var(--color-actor-5)">
+            <div class="pattern-icon" style="background: var(--color-actor-5)">🗄️</div>
+            <h4 class="pattern-title">Store it somewhere</h4>
+            <p class="pattern-desc">Put the finished drawing at a permanent web address so it can be shown and shared.</p>
+          </div>
+        </div>
+      </section>
+
+      <!-- ============ SCREEN 2: HERO FLOW ANIMATION ============ -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">One commission, start to finish</h2>
+
+        <p>Module 2 left us at the door of the <span class="term" data-definition="A route is a single web address on the server that accepts requests and sends back an answer — like one specific desk in an office, with its own job and its own queue.">route</span> that lives on the server. Step through it. Click <strong>Next Step</strong> — the last two steps show the ending where things go wrong.</p>
+
+        <div class="flow-animation" data-steps='[
+          {"highlight":"flow-actor-1","label":"Your photo and the chosen style arrive at the server route. First question the route asks: does ANY key still have life left today?"},
+          {"highlight":"flow-actor-2","label":"The pool hands over key #3 — the next one in the circle — and immediately moves its pointer to #4, so the next visitor gets a different key.","packet":true,"from":"actor-1","to":"actor-2"},
+          {"highlight":"flow-actor-3","label":"The photo and the written style brief travel to Gemini together, as one sealed parcel.","packet":true,"from":"actor-2","to":"actor-3"},
+          {"highlight":"flow-actor-3","label":"Gemini answers with candidates: a list of parts. Some parts are text, one part holds the new picture."},
+          {"highlight":"flow-actor-3","label":"The route walks the list, grabs the first part that carries inlineData, and throws the rest away."},
+          {"highlight":"flow-actor-4","label":"The picture is uploaded to R2 storage, where it stops being data-in-transit and becomes a normal web address.","packet":true,"from":"actor-3","to":"actor-4"},
+          {"highlight":"flow-actor-5","label":"That address travels back to the browser, and the finished drawing appears on your screen.","packet":true,"from":"actor-4","to":"actor-5"},
+          {"highlight":"flow-actor-3","label":"ALTERNATE ENDING. Instead of a picture, Gemini answers 429 Too Many Requests. That key is out of budget for the day.","packet":true,"from":"actor-2","to":"actor-3"},
+          {"highlight":"flow-actor-2","label":"Key #3 is marked burnt out and skipped by every future request. You see the message: Too many users online!","packet":true,"from":"actor-3","to":"actor-2"}
+        ]'>
+          <div class="flow-actors">
+            <div class="flow-actor" id="flow-actor-1">
+              <div class="flow-actor-icon">📨</div>
+              <span>Request</span>
+            </div>
+            <div class="flow-actor" id="flow-actor-2">
+              <div class="flow-actor-icon">🔑</div>
+              <span>Key Pool<br>(6 slots)</span>
+            </div>
+            <div class="flow-actor" id="flow-actor-3">
+              <div class="flow-actor-icon">🎨</div>
+              <span>Gemini</span>
+            </div>
+            <div class="flow-actor" id="flow-actor-4">
+              <div class="flow-actor-icon">🗄️</div>
+              <span>R2 Storage</span>
+            </div>
+            <div class="flow-actor" id="flow-actor-5">
+              <div class="flow-actor-icon">🖼️</div>
+              <span>Response</span>
+            </div>
+          </div>
+
+          <div class="flow-packet" id="flow-packet"></div>
+
+          <div class="flow-step-label" id="flow-label">Click "Next Step" to send a commission</div>
+
+          <div class="flow-controls">
+            <button class="btn flow-next-btn">Next Step</button>
+            <button class="btn flow-reset-btn">Restart</button>
+            <span class="flow-progress"></span>
+          </div>
+        </div>
+
+        <div class="badge-list">
+          <div class="badge-item">
+            <code class="badge-code">Key Pool</code>
+            <span class="badge-desc">Six keys taking turns, so one account never carries the whole crowd</span>
+          </div>
+          <div class="badge-item">
+            <code class="badge-code">Gemini</code>
+            <span class="badge-desc">Google&apos;s image <span class="term" data-definition="A model is the trained AI system itself — the thing that actually generates the picture. You rent access to it by the request; you do not own it or keep a copy.">model</span>, rented by the request — the actual artist</span>
+          </div>
+          <div class="badge-item">
+            <code class="badge-code">R2 Storage</code>
+            <span class="badge-desc">Cloudflare&apos;s file warehouse — where finished images get a permanent web address</span>
+          </div>
+        </div>
+      </section>
+
+      <!-- ============ SCREEN 3: THE BRIEF ============ -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">The brief you are allowed to rewrite</h2>
+
+        <p>This is the actual <span class="term" data-definition="A prompt is the written instruction you give an AI model — plain English, no code. Changing the prompt is the single cheapest way to change what an AI feature produces.">prompt</span> the app sends, sitting in the source as one very long line. Read it as what it is: instructions to a freelancer.</p>
+
+        <div class="callout callout-info">
+          <div class="callout-icon">📜</div>
+          <div class="callout-content">
+            <strong class="callout-title">From the brief itself</strong>
+            <p>"…thin sketchy outlines, flat colors, childlike proportions, playful hand-drawn charm…"</p>
+            <p>"Retain the subject&apos;s original clothing, hairstyle, facial features, accessories, skin tone, pose, and expression…"</p>
+            <p>"Negative Prompt: No realistic shading, no detailed rendering, no anime or manga style, no 3D modeling, no photographic textures!"</p>
+          </div>
+        </div>
+
+        <p>Every good image brief has the same three-part shape. This structure transfers to any image model you will ever use.</p>
+
+        <div class="pattern-cards stagger-children">
+          <div class="pattern-card animate-in" style="border-top: 3px solid var(--color-actor-1)">
+            <div class="pattern-icon" style="background: var(--color-actor-1)">🎯</div>
+            <h4 class="pattern-title">What to make</h4>
+            <p class="pattern-desc">The look you want, in concrete visual words: sketchy outlines, flat colours, childlike proportions.</p>
+          </div>
+          <div class="pattern-card animate-in" style="border-top: 3px solid var(--color-actor-5)">
+            <div class="pattern-icon" style="background: var(--color-actor-5)">🔒</div>
+            <h4 class="pattern-title">What to preserve</h4>
+            <p class="pattern-desc">The things from the photo that must survive: clothing, hairstyle, skin tone, pose, expression.</p>
+          </div>
+          <div class="pattern-card animate-in" style="border-top: 3px solid var(--color-error)">
+            <div class="pattern-icon" style="background: var(--color-error)">🚫</div>
+            <h4 class="pattern-title">What to forbid</h4>
+            <p class="pattern-desc">The <span class="term" data-definition="A negative prompt is the list of things you explicitly do NOT want in the output. Image models drift toward glossy realism by default, so naming what to avoid is often more powerful than naming what you want.">negative prompt</span> — the list of default habits the model must resist.</p>
+          </div>
+        </div>
+
+        <p>Notice what this means for you: if the output keeps losing people&apos;s glasses, the fix is a few words added to the "retain" list. No new logic, no new <span class="term" data-definition="Deploying means pushing a new version of the app out to the live servers so real users get it. It is the moment a change stops being on your laptop and starts affecting everyone.">deploy</span> of clever code — just better writing.</p>
+      </section>
+
+      <!-- ============ SCREEN 4: SEALING THE PARCEL ============ -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">Sealing the parcel</h2>
+
+        <p>The brief and the photo have to travel together, in one shape the artist recognises. Here is that parcel being built.</p>
+
+        <div class="translation-block animate-in">
+          <div class="translation-code">
+            <span class="translation-label">CODE</span>
+            <pre><code><span class="code-line">    <span class="code-keyword">const</span> imageEditPrompt = [</span>
+<span class="code-line">      { <span class="code-property">text</span>: charlieLolaPrompt },</span>
+<span class="code-line">      {</span>
+<span class="code-line">        <span class="code-property">inlineData</span>: {</span>
+<span class="code-line">          <span class="code-property">mimeType</span>: mimeType,</span>
+<span class="code-line">          <span class="code-property">data</span>: base64Image,</span>
+<span class="code-line">        },</span>
+<span class="code-line">      },</span>
+<span class="code-line">    ];</span></code></pre>
+          </div>
+          <div class="translation-english">
+            <span class="translation-label">PLAIN ENGLISH</span>
+            <div class="translation-lines">
+              <p class="tl">Make the parcel we are about to hand the illustrator. It is a list with exactly two things in it.</p>
+              <p class="tl">Thing one: the written brief — that long Charlie &amp; Lola paragraph.</p>
+              <p class="tl">Thing two starts here: the reference photo.</p>
+              <p class="tl"><span class="term" data-definition="inlineData means the file travels inside the message itself, rather than as a link pointing somewhere else. Like stapling the photo to the letter instead of writing down where the photo can be found.">inlineData</span> = the photo rides inside the message, not as a link to fetch later.</p>
+              <p class="tl">Tell the artist what kind of file it is — the <span class="term" data-definition="A MIME type is a short label that says what kind of file something is, like image/png or image/jpeg. Without it, the receiving program has to guess, and guessing goes badly.">MIME type</span>, e.g. image/png.</p>
+              <p class="tl">And here is the photo itself, re-typed as one gigantic string of letters and numbers (<span class="term" data-definition="base64 is a way of rewriting a picture or any file as plain text characters, so it can travel inside a normal text message. It is about a third bigger than the original file — the price of being sendable as text.">base64</span>).</p>
+              <p class="tl">Close the photo item.</p>
+              <p class="tl">Close the list. Parcel sealed, ready to send.</p>
+            </div>
+          </div>
+        </div>
+
+        <h2 class="screen-heading" style="margin-top: var(--space-12)">The actual AI call is four lines</h2>
+
+        <p>All that hype, all that money, all that capability — and from the app&apos;s side it is one polite request with a name on it.</p>
+
+        <div class="translation-block animate-in">
+          <div class="translation-code">
+            <span class="translation-label">CODE</span>
+            <pre><code><span class="code-line">      response = <span class="code-keyword">await</span> ai.models.<span class="code-function">generateContent</span>({</span>
+<span class="code-line">        <span class="code-property">model</span>: <span class="code-string">"gemini-2.5-flash-image-preview"</span>,</span>
+<span class="code-line">        <span class="code-property">contents</span>: imageEditPrompt,</span>
+<span class="code-line">      });</span></code></pre>
+          </div>
+          <div class="translation-english">
+            <span class="translation-label">PLAIN ENGLISH</span>
+            <div class="translation-lines">
+              <p class="tl">Send the commission and wait for the reply. <code>await</code> means: stop here, do nothing else, until the artist answers.</p>
+              <p class="tl">Which artist? This exact one, by name. Swapping models is one word on this line.</p>
+              <p class="tl">And here is what we are sending: the parcel we just sealed.</p>
+              <p class="tl">End of the request. Everything after this is dealing with whatever comes back.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="badge-list">
+          <div class="badge-item">
+            <code class="badge-code">ai.models</code>
+            <span class="badge-desc">Comes from Google&apos;s <span class="term" data-definition="An SDK (Software Development Kit) is a ready-made bundle of code a company publishes so other people can use their service without writing the plumbing themselves. It is the difference between buying a kettle and building one.">SDK</span> — the ready-made toolkit Google publishes so nobody has to hand-write the plumbing</span>
+          </div>
+          <div class="badge-item">
+            <code class="badge-code">-flash-</code>
+            <span class="badge-desc">Google&apos;s name for the fast, cheap tier of the model family — a deliberate cost choice</span>
+          </div>
+          <div class="badge-item">
+            <code class="badge-code">-preview</code>
+            <span class="badge-desc">Not final. Google can change or retire it, and this line stops working the day they do</span>
+          </div>
+        </div>
+      </section>
+
+      <!-- ============ SCREEN 5: DIGGING OUT THE REPLY ============ -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">Opening the envelope</h2>
+
+        <p>Gemini does not reply with a picture. It replies with <span class="term" data-definition="Candidates are the alternative answers a model returns — usually just one. Each candidate is made of parts: some parts are text, some are files. You have to look through them to find what you wanted.">candidates</span>: a bag of parts, some text, hopefully one image. The route rummages until it finds the picture.</p>
+
+        <div class="translation-block animate-in">
+          <div class="translation-code">
+            <span class="translation-label">CODE</span>
+            <pre><code><span class="code-line">    <span class="code-keyword">for</span> (<span class="code-keyword">const</span> part <span class="code-keyword">of</span> response.candidates[<span class="code-number">0</span>].content.parts) {</span>
+<span class="code-line">      <span class="code-keyword">if</span> (part.inlineData) {</span>
+<span class="code-line">        generatedImageData = part.inlineData.data;</span>
+<span class="code-line">        generatedImageMimeType = part.inlineData.mimeType;</span>
+<span class="code-line">        <span class="code-keyword">break</span>;</span>
+<span class="code-line">      }</span>
+<span class="code-line">    }</span></code></pre>
+          </div>
+          <div class="translation-english">
+            <span class="translation-label">PLAIN ENGLISH</span>
+            <div class="translation-lines">
+              <p class="tl">Take the first answer Gemini sent, and go through its parts one at a time.</p>
+              <p class="tl">Is this part a file rather than words? (Text parts have no <code>inlineData</code>.)</p>
+              <p class="tl">Yes — so keep the picture data.</p>
+              <p class="tl">And keep the note saying what kind of image file it is.</p>
+              <p class="tl"><code>break</code> = stop looking. We found what we came for; ignore the rest.</p>
+              <p class="tl">Close the "if it is a file" check.</p>
+              <p class="tl">Close the loop. If we got all the way here without finding one, there is no image — and the app says so.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="icon-rows">
+          <div class="icon-row">
+            <div class="icon-circle" style="background: var(--color-actor-4)">🧭</div>
+            <div>
+              <strong>Worth remembering when you debug</strong>
+              <p>If a user ever sees "No image data found in Gemini API response", this loop ran and found nothing. The call worked, the key worked — the artist just replied with words instead of a drawing, usually a polite refusal.</p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- ============ SCREEN 6: THE KEY POOL ============ -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">Six keys, taking turns</h2>
+
+        <p>Google puts a daily ceiling on each account. So this app holds six keys and rotates through them — a pattern called <span class="term" data-definition="Round-robin means taking strict turns in a fixed circle: first, second, third, back to first. No favourites, no cleverness — just the next one along.">round-robin</span>, the same way a deck of chores rotates through a house of flatmates.</p>
+
+        <div class="translation-block animate-in">
+          <div class="translation-code">
+            <span class="translation-label">CODE</span>
+            <pre><code><span class="code-line">    <span class="code-comment">// Try each key starting from current index</span></span>
+<span class="code-line">    <span class="code-keyword">for</span> (<span class="code-keyword">let</span> i = <span class="code-number">0</span>; i &lt; <span class="code-keyword">this</span>.apiKeys.length; i++) {</span>
+<span class="code-line">      <span class="code-keyword">const</span> index = (<span class="code-keyword">this</span>.currentIndex + i) % <span class="code-keyword">this</span>.apiKeys.length;</span>
+<span class="code-line">      <span class="code-keyword">const</span> keyStatus = <span class="code-keyword">this</span>.apiKeys[index];</span>
+<span class="code-line"></span>
+<span class="code-line">      <span class="code-keyword">if</span> (keyStatus.isAvailable &amp;&amp; keyStatus.requestCount &lt; keyStatus.dailyLimit) {</span>
+<span class="code-line">        <span class="code-keyword">this</span>.currentIndex = (index + <span class="code-number">1</span>) % <span class="code-keyword">this</span>.apiKeys.length;</span>
+<span class="code-line">        keyStatus.lastUsed = <span class="code-keyword">new</span> <span class="code-function">Date</span>();</span>
+<span class="code-line">        keyStatus.requestCount++;</span>
+<span class="code-line">        <span class="code-keyword">return</span> keyStatus.key;</span>
+<span class="code-line">      }</span>
+<span class="code-line">    }</span></code></pre>
+          </div>
+          <div class="translation-english">
+            <span class="translation-label">PLAIN ENGLISH</span>
+            <div class="translation-lines">
+              <p class="tl">A note left by whoever wrote this, for whoever reads it next.</p>
+              <p class="tl">Walk around the circle of keys once — at most six tries, then give up.</p>
+              <p class="tl">Start from wherever we stopped last time. The <code>%</code> (<span class="term" data-definition="Modulo, written %, gives the remainder after dividing. Think of a clock face: 3 hours after 11 is 2, not 14. Run past the last key and you wrap around to the first.">modulo</span>) is a clock face — run past the last key and you wrap around to the first.</p>
+              <p class="tl">Pick up that key and its record card: is it healthy, how much has it spent today.</p>
+              <p class="tl">&nbsp;</p>
+              <p class="tl">Two conditions, both required: this key is not marked burnt out, AND it is still under its daily allowance.</p>
+              <p class="tl">Good one. Move the pointer to the NEXT key straight away, so the following visitor gets a different one.</p>
+              <p class="tl">Stamp the time it was last used.</p>
+              <p class="tl">Add one to its tally for today.</p>
+              <p class="tl">Hand the key over. Done — nobody looks at the remaining keys.</p>
+              <p class="tl">Close the check.</p>
+              <p class="tl">Close the circle. If we get past here, all six were unusable.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="callout callout-accent">
+          <div class="callout-icon">💡</div>
+          <div class="callout-content">
+            <strong class="callout-title">Aha: a rate limit is a nightclub capacity, not a fine</strong>
+            <p>A <span class="term" data-definition="A rate limit is a cap on how many requests you may make in a period of time. Go over it and the service simply refuses you until the window resets — it does not bill you extra.">rate limit</span> does not charge you more when you go over. It stops letting you in. That is why apps pool keys: six doors instead of one, same club.</p>
+          </div>
+        </div>
+
+        <div class="callout callout-warning">
+          <div class="callout-icon">⚠️</div>
+          <div class="callout-content">
+            <strong class="callout-title">The pool lives in memory, not in a database</strong>
+            <p>The counters are <span class="term" data-definition="In-memory means the information is held in the server&apos;s short-term working memory, not written to disk or a database. It is fast — and it vanishes completely the moment that server restarts.">in-memory</span>, held by a single copy of the pool object (a <span class="term" data-definition="A singleton is a thing the program deliberately creates only one of, so everybody shares the same copy. Handy for shared state — until you run several servers, and each one quietly gets its own singleton.">singleton</span>). Run three server copies and each has its own private pool with its own idea of which keys are burnt out. Restart, and the app forgets everything.</p>
+          </div>
+        </div>
+
+        <p>Those six keys are <span class="term" data-definition="An environment variable is a setting stored outside the code — on the server, in a config panel — so secrets never sit in the source files and can differ between test and live.">environment variables</span>, set on the server and never shipped to your browser.</p>
+
+        <div class="badge-list">
+          <div class="badge-item">
+            <code class="badge-code">GEMINI_API_KEY</code>
+            <span class="badge-desc">The first key. If only this one is set, the pool is a pool of one</span>
+          </div>
+          <div class="badge-item">
+            <code class="badge-code">GEMINI_API_KEY_2 … _5</code>
+            <span class="badge-desc">The extra doors — optional, and each one multiplies daily capacity</span>
+          </div>
+          <div class="badge-item">
+            <code class="badge-code">STORAGE_ENDPOINT</code>
+            <span class="badge-desc">Where finished pictures get uploaded — the address of the file warehouse</span>
+          </div>
+          <div class="badge-item">
+            <code class="badge-code">STORAGE_ACCESS_KEY</code>
+            <span class="badge-desc">The username half of the warehouse credentials</span>
+          </div>
+          <div class="badge-item">
+            <code class="badge-code">STORAGE_SECRET_KEY</code>
+            <span class="badge-desc">The password half. Server-side only, always</span>
+          </div>
+          <div class="badge-item">
+            <code class="badge-code">STORAGE_BUCKET</code>
+            <span class="badge-desc">Which shelf inside the warehouse these images belong on</span>
+          </div>
+        </div>
+      </section>
+
+      <!-- ============ SCREEN 7: WHEN THINGS GO WRONG ============ -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">When a key burns out</h2>
+
+        <p>Sooner or later a key hits its <span class="term" data-definition="A quota is the total allowance an account gets in a period — say 500 images a day. Spend it and you are done until the clock resets, no matter how much you are willing to pay.">quota</span> and Gemini refuses. Here is the app catching that and turning it into something a human can read.</p>
+
+        <div class="translation-block animate-in">
+          <div class="translation-code">
+            <span class="translation-label">CODE</span>
+            <pre><code><span class="code-line">      <span class="code-comment">// Check if it's a quota/limit error</span></span>
+<span class="code-line">      <span class="code-keyword">if</span> (error.message?.<span class="code-function">includes</span>(<span class="code-string">'quota'</span>) || error.message?.<span class="code-function">includes</span>(<span class="code-string">'limit'</span>) || error.status === <span class="code-number">429</span>) {</span>
+<span class="code-line">        geminiApiPool.<span class="code-function">markKeyAsUnavailable</span>(geminiApiKey, <span class="code-string">'Quota exceeded'</span>);</span>
+<span class="code-line">        <span class="code-keyword">return</span> <span class="code-function">respErr</span>(<span class="code-string">"Too many users online! VIP users get priority access. You're in queue, please wait a moment or upgrade to VIP for instant access."</span>, <span class="code-string">'QUEUE_REQUIRED'</span>);</span>
+<span class="code-line">      }</span></code></pre>
+          </div>
+          <div class="translation-english">
+            <span class="translation-label">PLAIN ENGLISH</span>
+            <div class="translation-lines">
+              <p class="tl">A note explaining the check below.</p>
+              <p class="tl">Three ways to recognise "you are out of budget": the word quota in the error, the word limit, or the code <span class="term" data-definition="HTTP 429 is the standard internet reply meaning Too Many Requests. It is the bouncer&apos;s hand on your chest — come back later, nothing personal.">429</span>. Any one of them counts.</p>
+              <p class="tl">Mark that key burnt out in the pool, so no future request wastes time on it.</p>
+              <p class="tl">Send the user a friendly message instead of a scary error — and a tag, <code>QUEUE_REQUIRED</code>, so the interface knows to show the queue and upgrade prompt.</p>
+              <p class="tl">Close the check. Any other kind of error falls through to the general handler below.</p>
+            </div>
+          </div>
+        </div>
+
+        <p>Note what that message really means: "too many users online" is one honest reading, and "we ran out of allowance on all six accounts" is another. Same code, different story.</p>
+
+        <h2 class="screen-heading" style="margin-top: var(--space-12)">Bending instead of breaking</h2>
+
+        <p>Storage is optional. If the warehouse is not set up, the app does not crash — it just carries the picture home in its pockets.</p>
+
+        <div class="translation-block animate-in">
+          <div class="translation-code">
+            <span class="translation-label">CODE</span>
+            <pre><code><span class="code-line">    <span class="code-keyword">const</span> hasStorageConfig = process.env.STORAGE_ENDPOINT &amp;&amp; </span>
+<span class="code-line">                            process.env.STORAGE_ACCESS_KEY &amp;&amp; </span>
+<span class="code-line">                            process.env.STORAGE_SECRET_KEY &amp;&amp; </span>
+<span class="code-line">                            process.env.STORAGE_BUCKET;</span></code></pre>
+          </div>
+          <div class="translation-english">
+            <span class="translation-label">PLAIN ENGLISH</span>
+            <div class="translation-lines">
+              <p class="tl">Before uploading anything, ask: do we actually have a warehouse address?</p>
+              <p class="tl">And a username for it?</p>
+              <p class="tl">And a password?</p>
+              <p class="tl">And a shelf to put things on? All four, or we skip uploading entirely.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="callout callout-info">
+          <div class="callout-icon">🪂</div>
+          <div class="callout-content">
+            <strong class="callout-title">A feature that degrades instead of dying</strong>
+            <p>With no storage configured, the image URL stays as a giant <code>data:image/png;base64,...</code> string and the app still works — the picture just travels inside the response instead of living at a web address. That is a <span class="term" data-definition="A fallback is the lesser-but-still-working path a program takes when the ideal one is unavailable — the stairs when the lift is out. Good software has them; brittle software just stops.">fallback</span>, and it is why a fresh developer can run this app with no cloud account at all.</p>
+          </div>
+        </div>
+      </section>
+
+      <!-- ============ SCREEN 8: THE DOCUMENTATION TRAP ============ -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">The documentation trap</h2>
+
+        <p>This project&apos;s own instructions file, <code>CLAUDE.md</code>, says in bold that the generator <em>requires a valid OpenAI API key to function</em>, and lists <code>OPENAI_API_KEY</code> as REQUIRED.</p>
+
+        <p>It does not. Nothing in the generator calls OpenAI. Everything you have just read calls Google Gemini.</p>
+
+        <div class="icon-rows">
+          <div class="icon-row">
+            <div class="icon-circle" style="background: var(--color-error)">📄</div>
+            <div>
+              <strong>What the docs say</strong>
+              <p>OPENAI_API_KEY is required. The feature is a "cyberpunk image generator".</p>
+            </div>
+          </div>
+          <div class="icon-row">
+            <div class="icon-circle" style="background: var(--color-success)">⚙️</div>
+            <div>
+              <strong>What the code does</strong>
+              <p>Reads GEMINI_API_KEY through the key pool and calls gemini-2.5-flash-image-preview.</p>
+            </div>
+          </div>
+          <div class="icon-row">
+            <div class="icon-circle" style="background: var(--color-actor-4)">🏷️</div>
+            <div>
+              <strong>Other honest leftovers</strong>
+              <p>The <span class="term" data-definition="An endpoint is one specific web address on the server that does one job — like a single phone extension in a company. Renaming one means updating every place that dials it.">endpoint</span> is still called generate-cyberpunk, and a whole unused video toolkit sits in the codebase with only a demo page importing it.</p>
+            </div>
+          </div>
+        </div>
+
+        <p>This is completely normal residue. A product got rebuilt — cyberpunk became Charlie &amp; Lola, OpenAI became Gemini — and the documentation stayed where it was, as documentation always does.</p>
+
+        <div class="callout callout-warning">
+          <div class="callout-icon">🤖</div>
+          <div class="callout-content">
+            <strong class="callout-title">Why this matters more for you than for a developer</strong>
+            <p>An AI coding assistant reads <code>CLAUDE.md</code> and README files as gospel. Ask one to "fix the image generation" and it may cheerfully add OpenAI code to a Gemini app — and be very confident about it.</p>
+          </div>
+        </div>
+
+        <p>So here is the habit worth building. Before you trust a doc, ask what the code actually calls — you can literally say this to your AI assistant:</p>
+
+        <div class="step-cards">
+          <div class="step-card">
+            <div class="step-num">1</div>
+            <div class="step-body">
+              <strong>"Search the codebase for which AI provider this feature actually imports."</strong>
+              <p>Searching for a word across every file is called <span class="term" data-definition="To grep is to search every file in a project for a word or pattern. It is the fastest way to find out what a codebase really does, as opposed to what its README claims.">grepping</span>, and it takes seconds.</p>
+            </div>
+          </div>
+          <div class="step-card">
+            <div class="step-num">2</div>
+            <div class="step-body">
+              <strong>"Show me the file the docs describe, and tell me where they disagree."</strong>
+              <p>Force the mismatch into the open before any code gets written.</p>
+            </div>
+          </div>
+          <div class="step-card">
+            <div class="step-num">3</div>
+            <div class="step-body">
+              <strong>"Update CLAUDE.md to match reality first, then make the change."</strong>
+              <p>Fixing the doc is a two-minute job that stops the next five confident mistakes.</p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- ============ SCREEN 9: QUIZ ============ -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">Think it through</h2>
+
+        <p>Four situations. None of them have appeared word-for-word above — that is the point.</p>
+
+        <div class="quiz-container" id="quiz-module3">
+
+          <div class="quiz-question-block"
+               data-correct="opt-memory"
+               data-explanation-right="Exactly. markKeyAsUnavailable writes to memory, and while markKeyAsAvailable and resetDailyLimits exist in the pool, nothing calls them on a schedule. Once a key is marked burnt, it stays burnt until the server restarts — which is why restarting the app is the accidental cure, and why this belongs in a database or on a timer, not in one server&apos;s head."
+               data-explanation-wrong="Not quite — and the clue is that Google says you have quota left. That means the refusal is not coming from Google at all any more; it is coming from the pool&apos;s own memory of a refusal it saw earlier. Nothing in the code ever un-marks a burnt key on a schedule.">
+            <h3 class="quiz-question">Every user suddenly sees "Too many users online!" — but your Google dashboard shows plenty of quota left on all six keys. What is the most likely cause?</h3>
+            <div class="quiz-options">
+              <button class="quiz-option" data-value="opt-google" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>Google is throttling the account behind the scenes and the dashboard is lagging</span>
+              </button>
+              <button class="quiz-option" data-value="opt-memory" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>The keys got marked unavailable in the pool&apos;s memory earlier, and nothing ever un-marks them</span>
+              </button>
+              <button class="quiz-option" data-value="opt-prompt" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>The prompt got too long, so requests are being rejected before they reach the model</span>
+              </button>
+              <button class="quiz-option" data-value="opt-storage" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>Storage is misconfigured, so finished images have nowhere to go</span>
+              </button>
+            </div>
+            <div class="quiz-feedback"></div>
+          </div>
+
+          <div class="quiz-question-block"
+               data-correct="opt-brief"
+               data-explanation-right="Exactly. Glasses are an accessory, and the brief already has a retain list. Adding a few words there costs one line of English, no new logic, no model change — and it is the single biggest quality lever in almost any AI feature."
+               data-explanation-wrong="Think about where the instructions actually live. The model is a rented generalist that does whatever the written brief asks — so the cheapest lever is almost always the wording, not the machinery around it.">
+            <h3 class="quiz-question">Users complain the output keeps dropping people&apos;s glasses. What is the cheapest place to fix it?</h3>
+            <div class="quiz-options">
+              <button class="quiz-option" data-value="opt-model" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>Switch to a more expensive, more capable Gemini model</span>
+              </button>
+              <button class="quiz-option" data-value="opt-brief" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>Add glasses to the "retain the subject&apos;s original…" list in the prompt paragraph</span>
+              </button>
+              <button class="quiz-option" data-value="opt-detect" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>Add code that detects glasses in the upload and pastes them back onto the result</span>
+              </button>
+              <button class="quiz-option" data-value="opt-retry" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>Call the model three times and pick whichever result kept the glasses</span>
+              </button>
+            </div>
+            <div class="quiz-feedback"></div>
+          </div>
+
+          <div class="quiz-question-block"
+               data-correct="opt-correct-premise"
+               data-explanation-right="Exactly. The request contains a false premise picked up from a stale doc. Correcting it first — and pointing at the route and the key pool — is the difference between a clean change and an assistant confidently bolting OpenAI onto a Gemini app."
+               data-explanation-wrong="Careful — the phrase &quot;matching how we do it today&quot; is doing a lot of damage here, because today the app uses Gemini, not OpenAI. Sorting out the premise before any code gets written is what saves the afternoon.">
+            <h3 class="quiz-question">You tell an AI assistant: "add support for the new OpenAI image model, matching how we do image generation today." What should you say first, before anything else?</h3>
+            <div class="quiz-options">
+              <button class="quiz-option" data-value="opt-tests" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>Ask it to write tests first, so the change is safe</span>
+              </button>
+              <button class="quiz-option" data-value="opt-correct-premise" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>Correct the premise: the app uses Gemini today, CLAUDE.md is out of date — read route.ts and the key pool</span>
+              </button>
+              <button class="quiz-option" data-value="opt-branch" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>Ask it to work on a separate branch so nothing breaks</span>
+              </button>
+              <button class="quiz-option" data-value="opt-docs" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>Paste in the OpenAI documentation so it has the latest reference</span>
+              </button>
+            </div>
+            <div class="quiz-feedback"></div>
+          </div>
+
+          <div class="quiz-question-block"
+               data-correct="opt-replied-text"
+               data-explanation-right="Exactly. A key was handed out, the call went through, and Gemini answered — the loop simply walked the parts and found no inlineData anywhere. The reply was words, most often a safety refusal. Look at the prompt and the uploaded photo, not at keys or networking."
+               data-explanation-wrong="Read the message literally: something came back, and code ran over it looking for a picture. That rules out the key and the network — the failure is at the far end of the journey, in what the model chose to reply with.">
+            <h3 class="quiz-question">A request comes back successfully, but the app reports "No image data found in Gemini API response." What does that tell you about where the failure happened?</h3>
+            <div class="quiz-options">
+              <button class="quiz-option" data-value="opt-key" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>The key pool handed out a burnt-out key</span>
+              </button>
+              <button class="quiz-option" data-value="opt-network" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>The connection to Google dropped partway through</span>
+              </button>
+              <button class="quiz-option" data-value="opt-replied-text" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>The call worked and the model replied — with text rather than a picture, most likely a refusal</span>
+              </button>
+              <button class="quiz-option" data-value="opt-upload" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>The upload to R2 storage failed, so the image URL is missing</span>
+              </button>
+            </div>
+            <div class="quiz-feedback"></div>
+          </div>
+
+          <button class="quiz-check-btn" onclick="checkQuiz('quiz-module3')">Check Answers</button>
+          <button class="quiz-reset-btn" onclick="resetQuiz('quiz-module3')">Try Again</button>
+        </div>
+      </section>
+
+      <!-- ============ SCREEN 10: WRAP + TEASE ============ -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">What you can do with this now</h2>
+
+        <div class="icon-rows">
+          <div class="icon-row">
+            <div class="icon-circle" style="background: var(--color-actor-1)">✍️</div>
+            <div>
+              <strong>Change the output without changing code</strong>
+              <p>The biggest quality lever in an AI feature is the wording of the brief: make / preserve / forbid.</p>
+            </div>
+          </div>
+          <div class="icon-row">
+            <div class="icon-circle" style="background: var(--color-actor-2)">🚪</div>
+            <div>
+              <strong>Reason about capacity before you build</strong>
+              <p>Rate limits are doors, not fines. Pooling keys buys more doors; it does not make the club bigger.</p>
+            </div>
+          </div>
+          <div class="icon-row">
+            <div class="icon-circle" style="background: var(--color-actor-3)">🔎</div>
+            <div>
+              <strong>Trust the code over the docs</strong>
+              <p>Ask what a feature actually imports before you accept what any README tells you it does.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="callout callout-info">
+          <div class="callout-icon">🧱</div>
+          <div class="callout-content">
+            <strong class="callout-title">Next: The LEGO Box</strong>
+            <p>The engine is rented. The interface around it is entirely the app&apos;s own — colour tokens, Tailwind, and about thirty reusable bricks that every panel in the generator is built from.</p>
+          </div>
+        </div>
+      </section>
+
+    </div>
+  </div>
+</section>
+<section class="module" id="module-4" style="background: var(--color-bg)">
+  <div class="module-content">
+
+    <header class="module-header animate-in">
+      <span class="module-number">04</span>
+      <h1 class="module-title">The LEGO Box</h1>
+      <p class="module-subtitle">Nobody wrote the colour yellow anywhere near the upload box. Here is how the glow gets there — through four layers of indirection, every one of them earning its keep.</p>
+    </header>
+
+    <div class="module-body">
+
+      <!-- ============ SCREEN 1: THE HOOK ============ -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">Drag a photo over the box. It glows yellow.</h2>
+
+        <p>Last module we watched the app hand a written brief to a rented artist. Now turn around and look at the dashboard the app built <em>around</em> that engine — the panel, the buttons, the glow.</p>
+
+        <p>Open the generator, pick up a photo, hold it over the upload area. The dashed outline goes solid lemon yellow and the inside washes faintly warm. Search the generator&apos;s file for the word "yellow" as a colour value and you will not find it.</p>
+
+        <div class="callout callout-accent">
+          <div class="callout-icon">🧱</div>
+          <div class="callout-content">
+            <strong class="callout-title">The metaphor for this module: a LEGO box with a paint chart taped inside the lid</strong>
+            <p>The tray of loose bricks is <code>src/components/ui/</code> — Button, Card, Input, about thirty of them. The finished models are <code>src/components/blocks/</code> — the hero section, the pricing table, the generator panel. And taped inside the lid is one paint chart: change a swatch there and every brick in every model repaints at once, because no brick names a colour directly.</p>
+          </div>
+        </div>
+
+        <h2 class="screen-heading" style="margin-top: var(--space-12)">The one idea, before the details</h2>
+
+        <p>Nothing in this interface names a colour, a corner radius or a shadow directly. Everything names a <em>role</em> — <code>primary</code>, <code>card</code>, <code>border</code>, <code>muted-foreground</code> — and the roles get their values in one file, twice: once for light mode, once for dark.</p>
+
+        <div class="icon-rows">
+          <div class="icon-row">
+            <div class="icon-circle" style="background: var(--color-actor-1)">🚫</div>
+            <div>
+              <strong>What the app never says</strong>
+              <p>"Paint this button <code>#F5D547</code>." A <span class="term" data-definition="A hex colour is a colour written as a # followed by six characters, like #F5D547. It is exact, and it is completely anonymous — nothing about it says what the colour is for.">hex colour</span> typed straight onto an element is a dead end: it looks right today and wrong after the next theme tweak.</p>
+            </div>
+          </div>
+          <div class="icon-row">
+            <div class="icon-circle" style="background: var(--color-actor-2)">✅</div>
+            <div>
+              <strong>What it says instead</strong>
+              <p>"Paint this button with whatever <code>primary</code> currently means." One sentence in one file decides what that is, for the whole app, in both light and dark.</p>
+            </div>
+          </div>
+          <div class="icon-row">
+            <div class="icon-circle" style="background: var(--color-actor-5)">🌗</div>
+            <div>
+              <strong>Which is why dark mode is free</strong>
+              <p>The whole app can flip to <span class="term" data-definition="Dark mode is the light-text-on-dark-background version of an interface. In a well-built app it is not a second design — it is the same design with a different set of colour values swapped in.">dark mode</span> without a single button, card or input knowing dark mode exists.</p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- ============ SCREEN 2: HERO — THE FOUR LAYERS ============ -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">Follow one yellow, all the way to the button</h2>
+
+        <p>Here is the actual journey of the app&apos;s lemon yellow, from the paint chart to the pixel under your cursor. Five hops, four of them are files you could open right now.</p>
+
+        <div class="flow-steps">
+          <div class="flow-step">
+            <div class="flow-step-num">1</div>
+            <p><code>oklch(0.9&nbsp;0.15&nbsp;85)</code></p>
+          </div>
+          <div class="flow-arrow">→</div>
+          <div class="flow-step">
+            <div class="flow-step-num">2</div>
+            <p><code>--primary</code></p>
+          </div>
+          <div class="flow-arrow">→</div>
+          <div class="flow-step">
+            <div class="flow-step-num">3</div>
+            <p><code>--color-primary</code></p>
+          </div>
+          <div class="flow-arrow">→</div>
+          <div class="flow-step">
+            <div class="flow-step-num">4</div>
+            <p><code>bg-primary</code></p>
+          </div>
+          <div class="flow-arrow">→</div>
+          <div class="flow-step">
+            <div class="flow-step-num">5</div>
+            <p>the Generate button</p>
+          </div>
+        </div>
+
+        <p>Four layers make that journey possible. Click through them — each tab is a real file in this project.</p>
+
+        <div class="layer-demo">
+          <div class="layer-tabs">
+            <button class="layer-tab active" onclick="showLayer('m4-layer-paint', this)">1 · Paint chart</button>
+            <button class="layer-tab" onclick="showLayer('m4-layer-bridge', this)">2 · Bridge</button>
+            <button class="layer-tab" onclick="showLayer('m4-layer-utility', this)">3 · Utility classes</button>
+            <button class="layer-tab" onclick="showLayer('m4-layer-bricks', this)">4 · Bricks</button>
+          </div>
+
+          <!-- LAYER 1 -->
+          <div class="layer" id="m4-layer-paint" style="display:block">
+            <p><strong>The paint chart —</strong> <code>src/app/theme.css</code>. Inside the <span class="term" data-definition="&#58;root is CSS shorthand for the very top of the page — the outermost element everything else lives inside. Values set there are visible to every element on the page, which makes it the natural home for app-wide settings.">:root</span> block, raw colour values get given role names. A second block further down, <code>.dark</code>, redefines the same names with different values.</p>
+
+            <div class="translation-block">
+              <div class="translation-code">
+                <span class="translation-label">CODE</span>
+                <pre><code><span class="code-line">  <span class="code-property">--primary</span>: <span class="code-function">oklch</span>(<span class="code-number">0.9 0.15 85</span>);            <span class="code-comment">/* Lemon Yellow */</span></span>
+<span class="code-line">  <span class="code-property">--primary-foreground</span>: <span class="code-function">oklch</span>(<span class="code-number">0.17 0 0</span>);</span>
+<span class="code-line">  <span class="code-property">--secondary</span>: <span class="code-function">oklch</span>(<span class="code-number">0.8 0.08 200</span>);         <span class="code-comment">/* Sky Blue */</span></span>
+<span class="code-line">  <span class="code-property">--secondary-foreground</span>: <span class="code-function">oklch</span>(<span class="code-number">0.17 0 0</span>);</span>
+<span class="code-line">  <span class="code-property">--muted</span>: <span class="code-function">oklch</span>(<span class="code-number">0.95 0.02 90</span>);            <span class="code-comment">/* Lighter gray */</span></span>
+<span class="code-line">  <span class="code-property">--muted-foreground</span>: <span class="code-function">oklch</span>(<span class="code-number">0.4 0.02 50</span>);</span>
+<span class="code-line">  <span class="code-property">--accent</span>: <span class="code-function">oklch</span>(<span class="code-number">0.8 0.15 60</span>);             <span class="code-comment">/* Coral Orange */</span></span>
+<span class="code-line">  <span class="code-property">--accent-foreground</span>: <span class="code-function">oklch</span>(<span class="code-number">0.17 0 0</span>);</span>
+<span class="code-line">  <span class="code-property">--destructive</span>: <span class="code-function">oklch</span>(<span class="code-number">0.7 0.2 25</span>);           <span class="code-comment">/* Tomato Red */</span></span></code></pre>
+              </div>
+              <div class="translation-english">
+                <span class="translation-label">PLAIN ENGLISH</span>
+                <div class="translation-lines">
+                  <p class="tl">Each of these is a <span class="term" data-definition="A CSS variable (properly: a custom property) is a named value you set once and reuse everywhere, written with two dashes in front — like --primary. Change it in one place and every element reading it updates.">CSS variable</span> — a named value. This one is not called "yellow", it is called "the main colour", and today the main colour happens to be lemon.</p>
+                  <p class="tl">Every background role gets a matching <em>foreground</em> — the ink that goes on top. Near-black here, so text on yellow stays readable.</p>
+                  <p class="tl">The app&apos;s second voice: sky blue, with its own matching ink. This is what the <code>secondary</code> buttons use.</p>
+                  <p class="tl">The quiet pair: a pale background and a soft grey text colour, for captions, hints and placeholder text.</p>
+                  <p class="tl">Coral orange for highlights and hover states — plus, again, the ink that belongs on it.</p>
+                  <p class="tl">And the "are you sure?" red. Every delete button in the app reads this one name.</p>
+                  <p class="tl"><span class="term" data-definition="oklch(lightness chroma hue) is a newer way of writing colours. The first number is how light it is, the second how vivid, the third which hue on the colour wheel. Its advantage over hex: nudging the lightness of two different hues by the same amount actually looks like the same amount.">oklch</span> is just a way of spelling a colour: how light, how vivid, which hue.</p>
+                </div>
+              </div>
+            </div>
+
+            <p class="layer-description">Nine role names, nine values. Swap the values, and every screen in the app is wearing a new outfit.</p>
+          </div>
+
+          <!-- LAYER 2 -->
+          <div class="layer" id="m4-layer-bridge" style="display:none">
+            <p><strong>The bridge —</strong> further down the same file. This block is what turns a role name into something you can actually type on an element.</p>
+
+            <div class="translation-block">
+              <div class="translation-code">
+                <span class="translation-label">CODE</span>
+                <pre><code><span class="code-line"><span class="code-keyword">@theme</span> inline {</span>
+<span class="code-line">  <span class="code-property">--color-background</span>: <span class="code-function">var</span>(--background);</span>
+<span class="code-line">  <span class="code-property">--color-foreground</span>: <span class="code-function">var</span>(--foreground);</span>
+<span class="code-line">  <span class="code-property">--color-card</span>: <span class="code-function">var</span>(--card);</span>
+<span class="code-line">  <span class="code-property">--color-card-foreground</span>: <span class="code-function">var</span>(--card-foreground);</span>
+<span class="code-line">  <span class="code-property">--color-popover</span>: <span class="code-function">var</span>(--popover);</span>
+<span class="code-line">  <span class="code-property">--color-popover-foreground</span>: <span class="code-function">var</span>(--popover-foreground);</span>
+<span class="code-line">  <span class="code-property">--color-primary</span>: <span class="code-function">var</span>(--primary);</span>
+<span class="code-line">  <span class="code-property">--color-primary-foreground</span>: <span class="code-function">var</span>(--primary-foreground);</span></code></pre>
+              </div>
+              <div class="translation-english">
+                <span class="translation-label">PLAIN ENGLISH</span>
+                <div class="translation-lines">
+                  <p class="tl">"Here is my palette, Tailwind — register every one of these as a colour you know about."</p>
+                  <p class="tl">The page background and the main text colour get registered first.</p>
+                  <p class="tl">Then the card surface and the ink that sits on cards.</p>
+                  <p class="tl">Then popovers — the little floating panels that appear over the page.</p>
+                  <p class="tl"><code>var(--primary)</code> means "go and read whatever <code>--primary</code> currently is". It does not copy the yellow, it points at it.</p>
+                  <p class="tl">That pointing is the whole trick: registered once here, the value can still change underneath — which is exactly what the <code>.dark</code> block does.</p>
+                  <p class="tl">The payoff of this one line: the class name <code>bg-primary</code> now exists and works.</p>
+                </div>
+              </div>
+            </div>
+
+            <p class="layer-description">Layer 1 decides <em>what</em> the colour is. Layer 2 decides <em>that you can type it</em>.</p>
+          </div>
+
+          <!-- LAYER 3 -->
+          <div class="layer" id="m4-layer-utility" style="display:none">
+            <p><strong>The utility classes —</strong> <span class="term" data-definition="Tailwind is a styling toolkit. Instead of writing a separate stylesheet, you attach lots of tiny single-purpose class names directly to the element — one for padding, one for colour, one for rounded corners.">Tailwind</span>. Honestly: it looks noisy. In exchange you never have to invent a name like <code>.upload-box-inner-wrapper</code> again.</p>
+
+            <p>Traditional <span class="term" data-definition="CSS is the language that decides how a web page looks — colours, spacing, sizes, fonts. Historically it lives in its own file, separate from the page structure.">CSS</span> means writing the look in one file and the <span class="term" data-definition="A class is a label you attach to an element so styling rules can find it — like putting a coloured sticker on a box so you can say &quot;paint every box with a red sticker&quot;.">class</span> names in another, then keeping the two in sync forever. Tailwind puts tiny single-purpose classes directly on the element instead.</p>
+
+            <div class="badge-list">
+              <div class="badge-item">
+                <code class="badge-code">bg-primary</code>
+                <span class="badge-desc">Background = the <code>primary</code> role. This is hop 4 of the yellow&apos;s journey.</span>
+              </div>
+              <div class="badge-item">
+                <code class="badge-code">text-muted-foreground</code>
+                <span class="badge-desc">Text = the quiet grey. Used on every hint and caption in the generator.</span>
+              </div>
+              <div class="badge-item">
+                <code class="badge-code">border-2 border-dashed</code>
+                <span class="badge-desc">A 2-pixel dashed outline — the resting state of the upload box.</span>
+              </div>
+              <div class="badge-item">
+                <code class="badge-code">rounded-xl</code>
+                <span class="badge-desc">Extra-large rounded corners, sized from the app&apos;s single <code>--radius</code> setting.</span>
+              </div>
+              <div class="badge-item">
+                <code class="badge-code">grid lg:grid-cols-2</code>
+                <span class="badge-desc">One column normally; two side-by-side once the screen is wide. <code>lg:</code> is a <span class="term" data-definition="A responsive breakpoint is a screen width at which the layout is allowed to change. In Tailwind you write it as a prefix — lg&#58; means &quot;from large screens upward&quot;.">responsive breakpoint</span>.</span>
+              </div>
+              <div class="badge-item">
+                <code class="badge-code">hover:bg-primary/90</code>
+                <span class="badge-desc">On hover, the same yellow at 90% strength. Prefixes stack conditions onto a class.</span>
+              </div>
+            </div>
+
+            <p class="layer-description">Every one of these is real, copied from the generator panel and the button file you are about to see.</p>
+          </div>
+
+          <!-- LAYER 4 -->
+          <div class="layer" id="m4-layer-bricks" style="display:none">
+            <p><strong>The bricks —</strong> <span class="term" data-definition="Shadcn UI is a collection of ready-made interface pieces — buttons, cards, dialogs. Unlike a normal library, you do not install it and import from it: you copy the pieces into your own project as ordinary files you own and can edit.">Shadcn UI</span>. The crucial, easily-missed part: it is <em>not</em> a library you install and import from. Its components are copied into your own repository as ordinary files you own.</p>
+
+            <p>That is why <code>src/components/ui/button.tsx</code> is only 59 lines and sitting right there in the project. Here is a whole brick, in full.</p>
+
+            <div class="translation-block">
+              <div class="translation-code">
+                <span class="translation-label">CODE</span>
+                <pre><code><span class="code-line"><span class="code-keyword">function</span> <span class="code-function">Card</span>({ className, ...props }: React.ComponentProps&lt;<span class="code-string">"div"</span>&gt;) {</span>
+<span class="code-line">  <span class="code-keyword">return</span> (</span>
+<span class="code-line">    &lt;<span class="code-tag">div</span></span>
+<span class="code-line">      <span class="code-attr">data-slot</span>=<span class="code-value">"card"</span></span>
+<span class="code-line">      <span class="code-attr">className</span>={<span class="code-function">cn</span>(</span>
+<span class="code-line">        <span class="code-string">"bg-card text-card-foreground flex flex-col gap-6 rounded-xl border py-6 shadow-sm"</span>,</span>
+<span class="code-line">        className</span>
+<span class="code-line">      )}</span>
+<span class="code-line">      {...props}</span>
+<span class="code-line">    /&gt;</span>
+<span class="code-line">  )</span>
+<span class="code-line">}</span></code></pre>
+              </div>
+              <div class="translation-english">
+                <span class="translation-label">PLAIN ENGLISH</span>
+                <div class="translation-lines">
+                  <p class="tl">Define a <span class="term" data-definition="A component is one reusable piece of interface — a button, a card, a search box — defined once and used in many places. Think of it as a LEGO brick: same shape every time, whatever you build with it.">component</span> called <code>Card</code>. It accepts a <code>className</code> (extra classes the caller wants to add) plus anything else passed to it.</p>
+                  <p class="tl">Here is what it puts on the screen…</p>
+                  <p class="tl">…a plain <code>div</code>. That is all a Card really is: a box.</p>
+                  <p class="tl">Stamp it with a <span class="term" data-definition="A data- attribute is a custom label you can attach to any element on a page — invisible to the user, but findable by styling rules, tests and scripts. Here it says &quot;this thing is a card&quot;.">data- attribute</span> that says "this is a card". Remember this line — it becomes a back door in a moment.</p>
+                  <p class="tl">Now build the class list with <code>cn()</code>, the next screen&apos;s star.</p>
+                  <p class="tl">Card&apos;s own opinions: card background, matching ink, children stacked with a gap, rounded corners, a border, vertical padding, small shadow.</p>
+                  <p class="tl">…followed by whatever the caller passed in, which is allowed to override the opinions above.</p>
+                  <p class="tl">Close the class list.</p>
+                  <p class="tl">Pass everything else straight through — the click handler, the id, the contents, all of it.</p>
+                </div>
+              </div>
+            </div>
+
+            <p class="layer-description">Notice: not one colour, size or shadow value in that file. Only role names.</p>
+          </div>
+        </div>
+      </section>
+
+      <!-- ============ SCREEN 3: cn() ============ -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">The six-line file that shows up everywhere</h2>
+
+        <p>You just saw <code>cn()</code> inside Card. It is in essentially every component in this project. Here is the entire thing.</p>
+
+        <div class="translation-block animate-in">
+          <div class="translation-code">
+            <span class="translation-label">CODE</span>
+            <pre><code><span class="code-line"><span class="code-keyword">import</span> { clsx, <span class="code-keyword">type</span> ClassValue } <span class="code-keyword">from</span> <span class="code-string">"clsx"</span>;</span>
+<span class="code-line"><span class="code-keyword">import</span> { twMerge } <span class="code-keyword">from</span> <span class="code-string">"tailwind-merge"</span>;</span>
+<span class="code-line"></span>
+<span class="code-line"><span class="code-keyword">export function</span> <span class="code-function">cn</span>(...inputs: ClassValue[]) {</span>
+<span class="code-line">  <span class="code-keyword">return</span> <span class="code-function">twMerge</span>(<span class="code-function">clsx</span>(inputs));</span>
+<span class="code-line">}</span></code></pre>
+          </div>
+          <div class="translation-english">
+            <span class="translation-label">PLAIN ENGLISH</span>
+            <div class="translation-lines">
+              <p class="tl">Borrow <span class="term" data-definition="clsx is a tiny helper that glues a list of class names into one string and quietly drops any entry that turned out to be false or empty. It saves you from writing &quot;undefined&quot; into your HTML.">clsx</span> — it glues class names together and drops any that are false.</p>
+              <p class="tl">Borrow <code>twMerge</code> — the referee that settles fights between conflicting classes.</p>
+              <p class="tl">(Blank line. The imports are done.)</p>
+              <p class="tl">Make a <span class="term" data-definition="A function is a named piece of behaviour you can run whenever you like, usually giving it some input and getting something back. Here: give it class names, get back one tidy class name string.">function</span> called <code>cn</code> that accepts any number of class-name bits — strings, or conditions that may produce nothing.</p>
+              <p class="tl">Glue them all together, then hand the result to the referee and return the verdict.</p>
+              <p class="tl">Done. Six lines, used thousands of times.</p>
+            </div>
+          </div>
+        </div>
+
+        <h2 class="screen-heading" style="margin-top: var(--space-12)">Why the referee matters</h2>
+
+        <p>If a component bakes in <code>px-4</code> and you pass <code>px-8</code>, plain gluing would put both in the page and leave the browser to decide by an obscure rulebook.</p>
+
+        <div class="step-cards">
+          <div class="step-card">
+            <div class="step-num">✕</div>
+            <div class="step-body">
+              <strong>Without twMerge</strong>
+              <p><code>"px-4 px-8"</code> — both survive. Which one wins depends on <span class="term" data-definition="Specificity is the browser&apos;s tie-breaking rulebook for deciding which style wins when two rules apply to the same element. It is famously fiddly, and relying on it is how interfaces get mysterious.">specificity</span> and stylesheet order. Fun to debug at 11pm.</p>
+            </div>
+          </div>
+          <div class="step-card">
+            <div class="step-num">✓</div>
+            <div class="step-body">
+              <strong>With twMerge</strong>
+              <p><code>"px-8"</code> — the referee notices the two are arguing about the same thing, deletes the earlier one, keeps the later one. Every time, predictably.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="callout callout-info">
+          <div class="callout-icon">🎛️</div>
+          <div class="callout-content">
+            <strong class="callout-title">This is the rule that makes bricks reusable</strong>
+            <p>A component can hold strong opinions about how it looks <em>and</em> still let any caller override them, because the caller&apos;s classes always go last into <code>cn()</code>. Opinionated by default, overridable on request.</p>
+          </div>
+        </div>
+      </section>
+
+      <!-- ============ SCREEN 4: CVA ============ -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">One button component, six different looks</h2>
+
+        <p>The app does not have six button files. It has one, plus a lookup table that turns a word like <code>outline</code> into a string of classes.</p>
+
+        <p>The table lives in <code>src/components/ui/button.tsx</code> and is built with <span class="term" data-definition="cva stands for &quot;class variance authority&quot; — a small tool for mapping option names to sets of classes. In plain terms: a menu that says &quot;if someone asks for the outline look, here are the classes that make it&quot;.">cva</span>.</p>
+
+        <div class="translation-block animate-in">
+          <div class="translation-code">
+            <span class="translation-label">CODE</span>
+            <pre><code><span class="code-line">    <span class="code-property">variants</span>: {</span>
+<span class="code-line">      <span class="code-property">variant</span>: {</span>
+<span class="code-line">        <span class="code-property">default</span>:</span>
+<span class="code-line">          <span class="code-string">"bg-primary text-primary-foreground shadow-xs hover:bg-primary/90"</span>,</span>
+<span class="code-line">        <span class="code-property">destructive</span>:</span>
+<span class="code-line">          <span class="code-string">"bg-destructive text-white shadow-xs hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60"</span>,</span>
+<span class="code-line">        <span class="code-property">outline</span>:</span>
+<span class="code-line">          <span class="code-string">"border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50"</span>,</span>
+<span class="code-line">        <span class="code-property">secondary</span>:</span>
+<span class="code-line">          <span class="code-string">"bg-secondary text-secondary-foreground shadow-xs hover:bg-secondary/80"</span>,</span>
+<span class="code-line">        <span class="code-property">ghost</span>:</span>
+<span class="code-line">          <span class="code-string">"hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50"</span>,</span>
+<span class="code-line">        <span class="code-property">link</span>: <span class="code-string">"text-primary underline-offset-4 hover:underline"</span>,</span>
+<span class="code-line">      },</span></code></pre>
+          </div>
+          <div class="translation-english">
+            <span class="translation-label">PLAIN ENGLISH</span>
+            <div class="translation-lines">
+              <p class="tl">"Here are the ways this button is allowed to differ."</p>
+              <p class="tl">The first way is called <span class="term" data-definition="A variant is one named version of a component — the outline button, the small button, the danger button. Same component, different look, chosen by name.">variant</span> — the word you type as <code>variant="…"</code> when you use the button.</p>
+              <p class="tl"><strong>default</strong> — the yellow one. Background = <code>primary</code>, ink = the matching foreground, tiny shadow, and on hover the same yellow at 90% strength. This is the Generate button.</p>
+              <p class="tl"><strong>destructive</strong> — the red one, with a red focus ring, and slightly different values when the page is in dark mode (that is what the <code>dark:</code> prefix means).</p>
+              <p class="tl"><strong>outline</strong> — a border and the page background, going coral on hover. Quiet until you touch it.</p>
+              <p class="tl"><strong>secondary</strong> — identical shape, sky blue instead of lemon. One token swapped.</p>
+              <p class="tl"><strong>ghost</strong> — nothing at all until hover. Used for icon buttons that should not shout.</p>
+              <p class="tl"><strong>link</strong> — not a box at all; it looks like a text link and underlines on hover.</p>
+              <p class="tl">End of the look menu. Six entries, one component, zero duplicate files.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="callout callout-accent">
+          <div class="callout-icon">💡</div>
+          <div class="callout-content">
+            <strong class="callout-title">Aha! Indirection is a superpower you can ask for</strong>
+            <p>"Use the <code>secondary</code> token, not a hex value" and "add a <code>variant</code> to the existing <code>buttonVariants</code>, don&apos;t write a new component" are two of the highest-value sentences you can say to an AI coding assistant. They are the difference between a change that lands in one place and a change that lands in forty.</p>
+          </div>
+        </div>
+      </section>
+
+      <!-- ============ SCREEN 5: THE GLOW ============ -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">Back to the glow</h2>
+
+        <p>Now the opening hook decodes. This is the real upload box from <code>imagen-client.tsx</code> — one true-or-false value swapping one set of class names for another.</p>
+
+        <div class="translation-block animate-in">
+          <div class="translation-code">
+            <span class="translation-label">CODE</span>
+            <pre><code><span class="code-line">                    <span class="code-attr">className</span>={<span class="code-function">cn</span>(</span>
+<span class="code-line">                      <span class="code-string">"relative min-h-[400px] rounded-xl border-2 border-dashed transition-all duration-300 cursor-pointer"</span>,</span>
+<span class="code-line">                      uploadedImages.length &gt; <span class="code-number">0</span> ? <span class="code-string">"flex"</span> : <span class="code-string">"flex items-center justify-center"</span>,</span>
+<span class="code-line">                      dragActive </span>
+<span class="code-line">                        ? <span class="code-string">"border-cl-yellow bg-cl-yellow/10"</span> </span>
+<span class="code-line">                        : <span class="code-string">"border-muted hover:border-cl-yellow hover:bg-cl-yellow/5"</span></span>
+<span class="code-line">                    )}</span></code></pre>
+          </div>
+          <div class="translation-english">
+            <span class="translation-label">PLAIN ENGLISH</span>
+            <div class="translation-lines">
+              <p class="tl">Work out this box&apos;s classes fresh, every time the screen redraws.</p>
+              <p class="tl">Always true: at least 400 pixels tall, extra-rounded corners, a 2-pixel dashed outline, animate any change over 300 milliseconds, show a pointer cursor.</p>
+              <p class="tl">Are there already photos in the box? Then just lay them out. If it is empty, centre the "drop a photo here" message instead.</p>
+              <p class="tl"><code>dragActive</code> is a <span class="term" data-definition="A boolean is a value that can only be true or false — a light switch, not a dial. Most on/off behaviour in an interface is one boolean somewhere.">boolean</span>: is a file being dragged over the box <em>right now</em>?</p>
+              <p class="tl">Yes → solid yellow outline plus a 10%-strength yellow wash. <strong>That is the glow.</strong></p>
+              <p class="tl">No → muted grey outline, turning yellow only when the mouse hovers, with an even fainter 5% wash.</p>
+              <p class="tl">Hand the finished class list to the box.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="icon-rows">
+          <div class="icon-row">
+            <div class="icon-circle" style="background: var(--color-actor-4)">🔀</div>
+            <div>
+              <strong>State goes in, classes come out</strong>
+              <p><code>dragActive</code> is flipped true by <code>onDragOver</code> and false by <code>onDragLeave</code>. Everything else follows automatically.</p>
+            </div>
+          </div>
+          <div class="icon-row">
+            <div class="icon-circle" style="background: var(--color-actor-3)">🚫</div>
+            <div>
+              <strong>No animation library. No manual page editing.</strong>
+              <p>Nothing here reaches into the page and repaints a pixel. The app describes what the box should look like; the browser does the rest.</p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- ============ SCREEN 6: BRICKS VS MODELS ============ -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">The tray of bricks and the finished models</h2>
+
+        <p>Two folders, two completely different jobs. Getting this distinction right is most of what "keeping a codebase tidy" means in practice.</p>
+
+        <div class="file-tree">
+          <div class="ft-folder open">
+            <span class="ft-name">components/</span>
+            <span class="ft-desc">everything the user looks at</span>
+            <div class="ft-children">
+              <div class="ft-folder open">
+                <span class="ft-name">ui/</span>
+                <span class="ft-desc">the loose bricks — generic, reusable, know nothing about this app</span>
+                <div class="ft-children">
+                  <div class="ft-file"><span class="ft-name">button.tsx</span><span class="ft-desc">59 lines, six variants</span></div>
+                  <div class="ft-file"><span class="ft-name">card.tsx</span><span class="ft-desc">a box with a border and a gap</span></div>
+                  <div class="ft-file"><span class="ft-name">input.tsx</span><span class="ft-desc">a text field, styled</span></div>
+                </div>
+              </div>
+              <div class="ft-folder open">
+                <span class="ft-name">blocks/</span>
+                <span class="ft-desc">the finished models — built from bricks, and they know this app</span>
+                <div class="ft-children">
+                  <div class="ft-file"><span class="ft-name">imagen-wrapper/</span><span class="ft-desc">the whole generator panel</span></div>
+                  <div class="ft-file"><span class="ft-name">form/</span><span class="ft-desc">the feedback and settings forms</span></div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="pattern-cards stagger-children">
+          <div class="pattern-card animate-in" style="border-top: 3px solid var(--color-actor-2)">
+            <div class="pattern-icon" style="background: var(--color-actor-2)">🧱</div>
+            <h4 class="pattern-title">Bricks (<code>ui/</code>)</h4>
+            <p class="pattern-desc">No business logic, no app text, no data. You could lift <code>button.tsx</code> into a completely different project tomorrow. Safe to reuse anywhere.</p>
+          </div>
+          <div class="pattern-card animate-in" style="border-top: 3px solid var(--color-actor-1)">
+            <div class="pattern-icon" style="background: var(--color-actor-1)">🏰</div>
+            <h4 class="pattern-title">Models (<code>blocks/</code>)</h4>
+            <p class="pattern-desc">These know about <em>this</em> app — its wording, its uploads, its Generate button. Reusing one somewhere else would drag the whole app along with it.</p>
+          </div>
+          <div class="pattern-card animate-in" style="border-top: 3px solid var(--color-actor-5)">
+            <div class="pattern-icon" style="background: var(--color-actor-5)">🗣️</div>
+            <h4 class="pattern-title">How to say it</h4>
+            <p class="pattern-desc">"Build this out of the existing <code>ui/</code> components and put the new panel in <code>blocks/</code>" is a one-sentence architecture instruction an AI will follow happily.</p>
+          </div>
+        </div>
+
+        <h2 class="screen-heading" style="margin-top: var(--space-12)">The back door: restyling every brick without touching it</h2>
+
+        <p>Remember <code>data-slot="card"</code> stamped on the Card component? Shadcn stamps one on every component it ships. This project uses those stamps as a back door.</p>
+
+        <div class="translation-block animate-in">
+          <div class="translation-code">
+            <span class="translation-label">CODE</span>
+            <pre><code><span class="code-line">[<span class="code-attr">data-slot</span>=<span class="code-value">"card"</span>] {</span>
+<span class="code-line">  <span class="code-property">background</span>: <span class="code-function">var</span>(--card);</span>
+<span class="code-line">  <span class="code-property">border</span>: <span class="code-number">2px</span> solid <span class="code-function">var</span>(--border);</span>
+<span class="code-line">  <span class="code-property">border-radius</span>: <span class="code-function">var</span>(--radius);</span>
+<span class="code-line">  <span class="code-property">box-shadow</span>: none;</span>
+<span class="code-line">}</span></code></pre>
+          </div>
+          <div class="translation-english">
+            <span class="translation-label">PLAIN ENGLISH</span>
+            <div class="translation-lines">
+              <p class="tl">"Find every element in the entire app carrying the card stamp."</p>
+              <p class="tl">Give it whatever <code>--card</code> currently means as its background.</p>
+              <p class="tl">Give it a chunky 2-pixel outline instead of the default hairline — this app wants a drawn-on-paper look.</p>
+              <p class="tl">Corner roundness comes from the one <code>--radius</code> knob, so it stays in step with everything else.</p>
+              <p class="tl">And kill the soft drop shadow entirely. Flat, not floaty.</p>
+              <p class="tl">Result: every card in the app restyled, and <code>card.tsx</code> was never opened.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="callout callout-warning">
+          <div class="callout-icon">🔨</div>
+          <div class="callout-content">
+            <strong class="callout-title">A lovely trick with a sharp edge</strong>
+            <p>This works because the rule and the stamp agree with each other. When they quietly stop agreeing, nothing errors — the styling just never happens. Module 5 has the version of this that fails in exactly that way.</p>
+          </div>
+        </div>
+      </section>
+
+      <!-- ============ SCREEN 7: THE TWO TOGGLES ============ -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">The two switches in the header</h2>
+
+        <p>Both toggles look like magic and are, in fact, one small change repeated at scale. Neither one asks any component to cooperate.</p>
+
+        <div class="step-cards">
+          <div class="step-card">
+            <div class="step-num">1</div>
+            <div class="step-body">
+              <strong>🌗 Dark mode — one class on the page root</strong>
+              <p><code>ThemeProvider</code> in <code>src/contexts/theme-context.tsx</code> adds the class <code>dark</code> to the outermost element of the page. The <code>.dark</code> block in <code>theme.css</code> then takes over every role name at once. One class, whole app repainted, and <code>button.tsx</code> never hears about it.</p>
+            </div>
+          </div>
+          <div class="step-card">
+            <div class="step-num">2</div>
+            <div class="step-body">
+              <strong>🌍 Language — one segment of the URL</strong>
+              <p><code>LocaleSwitcher</code> in <code>src/components/ui/locale-switcher.tsx</code> rewrites the language prefix in the web address (<code>/zh/showcase</code>). Next.js re-renders the page on the server in that language and sends it back. The language is not hidden in the app&apos;s memory — it is in the link, so it can be shared.</p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- ============ SCREEN 8: TWO WAYS TO BUILD A FORM ============ -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">Two ways to build a form, both correct</h2>
+
+        <p>The generator panel is hand-rolled: a plain text box, a plain state value per control, no <span class="term" data-definition="Validation is checking that what someone typed is acceptable before doing anything with it — not empty, actually an email address, at least eight characters. Doing it badly is how forms become infuriating.">validation</span> tool. The app&apos;s <em>other</em> forms take the opposite route.</p>
+
+        <div class="translation-block animate-in">
+          <div class="translation-code">
+            <span class="translation-label">CODE</span>
+            <pre><code><span class="code-line"><span class="code-keyword">function</span> <span class="code-function">buildFieldSchema</span>(field: FormFieldType) {</span>
+<span class="code-line">  <span class="code-keyword">let</span> schema = z.<span class="code-function">string</span>();</span>
+<span class="code-line"></span>
+<span class="code-line">  <span class="code-keyword">if</span> (field.validation?.required) {</span>
+<span class="code-line">    schema = schema.<span class="code-function">min</span>(<span class="code-number">1</span>, {</span>
+<span class="code-line">      <span class="code-property">message</span>: field.validation.message || <span class="code-string">`${field.title} is required`</span>,</span>
+<span class="code-line">    });</span>
+<span class="code-line">  }</span></code></pre>
+          </div>
+          <div class="translation-english">
+            <span class="translation-label">PLAIN ENGLISH</span>
+            <div class="translation-lines">
+              <p class="tl">Take one field&apos;s description and turn it into a <span class="term" data-definition="A schema is a written-down description of what acceptable data looks like — which fields exist, what type each one is, what counts as valid. Declare it once and the app can check itself against it.">schema</span> — a rule-sheet the form can check itself against.</p>
+              <p class="tl">Start from the loosest possible rule: "this answer is some text". <code>z</code> is <span class="term" data-definition="Zod is a tool for describing what valid data looks like, in code. You write the rules once — required, minimum length, must be an email — and it does the checking and produces the error messages.">Zod</span>, the rule-writing tool.</p>
+              <p class="tl">(Blank line, just for breathing room.)</p>
+              <p class="tl">Did whoever defined this field mark it as required? The <code>?.</code> means "look, but do not crash if there are no validation settings at all".</p>
+              <p class="tl">Then tighten the rule: the answer must be at least 1 character long.</p>
+              <p class="tl">And if it is not, show this message — the custom one if someone wrote it, otherwise fall back to "<em>Field name</em> is required".</p>
+              <p class="tl">Done with this field. The red outline, the error text and the blocked submit button all follow from that one rule, automatically.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="pattern-cards stagger-children">
+          <div class="pattern-card animate-in" style="border-top: 3px solid var(--color-actor-4)">
+            <div class="pattern-icon" style="background: var(--color-actor-4)">✋</div>
+            <h4 class="pattern-title">Hand-rolled (the generator)</h4>
+            <p class="pattern-desc">A prompt box, a style picker, an upload area. You hold each value yourself and check nothing. Perfectly fine for three controls you fully own.</p>
+          </div>
+          <div class="pattern-card animate-in" style="border-top: 3px solid var(--color-actor-5)">
+            <div class="pattern-icon" style="background: var(--color-actor-5)">📋</div>
+            <h4 class="pattern-title">Declared (feedback, API keys)</h4>
+            <p class="pattern-desc"><span class="term" data-definition="React Hook Form is a tool that keeps track of everything a form needs — what has been typed, what has been touched, what is invalid, whether submitting is allowed — so you do not write that plumbing by hand.">React Hook Form</span> plus Zod. State the rules out loud once; errors, outlines and blocked submits come free.</p>
+          </div>
+          <div class="pattern-card animate-in" style="border-top: 3px solid var(--color-actor-2)">
+            <div class="pattern-icon" style="background: var(--color-actor-2)">⚖️</div>
+            <h4 class="pattern-title">The deciding factor</h4>
+            <p class="pattern-desc">Not the size of the form — the complexity of its rules. The moment a rule is worth stating out loud, declaring it beats hand-checking it.</p>
+          </div>
+        </div>
+      </section>
+
+      <!-- ============ SCREEN 9: QUIZ ============ -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">Four decisions</h2>
+
+        <p>Not a memory test. Each one is a request you could plausibly get on a Tuesday — decide what you would ask an AI assistant to do.</p>
+
+        <div class="quiz-container" id="quiz-module4">
+
+          <div class="quiz-question-block"
+               data-correct="radius-token"
+               data-explanation-right="Exactly. --radius is the one knob, and --radius-sm / md / lg / xl are all calculated from it, so every rounded-* class in the app moves together. This is the whole point of the paint chart: one swatch, every model repainted."
+               data-explanation-wrong="Not quite — think about where roundness is actually decided. Nothing in card.tsx or button.tsx names a pixel value; they say rounded-xl, which is derived from a single --radius setting in theme.css. Change the source, not the forty places that read it.">
+            <h3 class="quiz-question">A designer wants every card in the app to have corners twice as round. Where is the one-line change?</h3>
+            <div class="quiz-options">
+              <button class="quiz-option" data-value="find-replace" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>Search the project for <code>rounded-xl</code> and replace each one with <code>rounded-3xl</code></span>
+              </button>
+              <button class="quiz-option" data-value="radius-token" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>Change <code>--radius</code> in <code>theme.css</code> — every <code>rounded-*</code> size is calculated from it</span>
+              </button>
+              <button class="quiz-option" data-value="inline-style" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>Add a border-radius style directly onto each card where it is used</span>
+              </button>
+            </div>
+            <div class="quiz-feedback"></div>
+          </div>
+
+          <div class="quiz-question-block"
+               data-correct="add-variant"
+               data-explanation-right="Yes — and notice both halves matter. &quot;Add a variant to buttonVariants&quot; stops the AI inventing a second button component, and &quot;use a token&quot; stops it hardcoding a green that will not survive dark mode."
+               data-explanation-wrong="Not the best option. A whole new component means a second thing to maintain that will drift out of sync; a hardcoded green means a colour that nobody else can reuse and that dark mode knows nothing about. The button already has a menu of looks — add an entry to it.">
+            <h3 class="quiz-question">You need a button that looks like all the others but is green, for "Export". What is the best instruction to give an AI assistant?</h3>
+            <div class="quiz-options">
+              <button class="quiz-option" data-value="new-component" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>"Create a new <code>GreenButton</code> component styled like the existing button"</span>
+              </button>
+              <button class="quiz-option" data-value="inline-hex" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>"Add <code>className="bg-[#2D8B55]"</code> to that button where it is used"</span>
+              </button>
+              <button class="quiz-option" data-value="add-variant" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>"Add a <code>success</code> variant to the existing <code>buttonVariants</code>, using a colour token rather than a hex value"</span>
+              </button>
+            </div>
+            <div class="quiz-feedback"></div>
+          </div>
+
+          <div class="quiz-question-block"
+               data-correct="px8"
+               data-explanation-right="Right. twMerge spots that px-4 and px-8 are arguing about the same property, deletes the earlier one and keeps yours. That predictability is the entire reason cn() exists — without it you would be at the mercy of stylesheet order."
+               data-explanation-wrong="Have another look at cn(). The component&apos;s own classes go in first and yours go in last, then twMerge deletes the loser of any conflict. So px-8 wins — reliably, not by luck. Nothing ends up in the page for the browser to guess about.">
+            <h3 class="quiz-question">A component has <code>px-4</code> baked into its own class list. You pass it <code>className="px-8"</code>. What actually renders — and why is it not a coin flip?</h3>
+            <div class="quiz-options">
+              <button class="quiz-option" data-value="px4" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span><code>px-4</code> — the component&apos;s own styling always wins over anything passed in</span>
+              </button>
+              <button class="quiz-option" data-value="px8" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span><code>px-8</code> — <code>twMerge</code> deletes the conflicting earlier class, and the caller&apos;s classes go in last</span>
+              </button>
+              <button class="quiz-option" data-value="both" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>Both land in the page and the browser picks whichever rule it happens to read last</span>
+              </button>
+            </div>
+            <div class="quiz-feedback"></div>
+          </div>
+
+          <div class="quiz-question-block"
+               data-correct="rules"
+               data-explanation-right="Exactly. It is the complexity of the rules, not the number of fields. A ten-field form with no rules is easy by hand; a two-field form with a valid-email rule and a matching-passwords rule is not."
+               data-explanation-wrong="Close, but size is the wrong yardstick. The generator&apos;s prompt box has no rule worth stating — any text is fine — so hand-rolling costs nothing. The moment you can say a rule out loud (&quot;must be a real email&quot;, &quot;at least 8 characters&quot;), declaring it once beats hand-checking it in three places.">
+            <h3 class="quiz-question">The generator&apos;s prompt box is a plain text area with a plain state value. The feedback form uses Zod. What actually decides which approach a new form should use?</h3>
+            <div class="quiz-options">
+              <button class="quiz-option" data-value="count" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>How many fields it has — anything over five should use Zod</span>
+              </button>
+              <button class="quiz-option" data-value="rules" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>Whether it has rules worth stating out loud — required, valid email, minimum length</span>
+              </button>
+              <button class="quiz-option" data-value="visibility" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>Whether the form is on a public page or behind a login</span>
+              </button>
+            </div>
+            <div class="quiz-feedback"></div>
+          </div>
+
+          <button class="quiz-check-btn" onclick="checkQuiz('quiz-module4')">Check Answers</button>
+          <button class="quiz-reset-btn" onclick="resetQuiz('quiz-module4')">Try Again</button>
+        </div>
+      </section>
+
+      <!-- ============ SCREEN 10: WRAP + TEASE ============ -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">What you can do with this now</h2>
+
+        <div class="icon-rows">
+          <div class="icon-row">
+            <div class="icon-circle" style="background: var(--color-actor-1)">🎨</div>
+            <div>
+              <strong>Ask for tokens, never for hex</strong>
+              <p>"Use the <code>muted-foreground</code> token" gets you a change that survives the next theme tweak and works in dark mode for free.</p>
+            </div>
+          </div>
+          <div class="icon-row">
+            <div class="icon-circle" style="background: var(--color-actor-2)">🧱</div>
+            <div>
+              <strong>Ask for a variant, not a new component</strong>
+              <p>Extending an existing brick keeps forty buttons in agreement. Cloning one is how an interface drifts into forty shades of almost-yellow.</p>
+            </div>
+          </div>
+          <div class="icon-row">
+            <div class="icon-circle" style="background: var(--color-actor-3)">📍</div>
+            <div>
+              <strong>Say where new work should live</strong>
+              <p>Generic and reusable goes in <code>ui/</code>. Knows-about-this-app goes in <code>blocks/</code>. One sentence, and the codebase stays navigable.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="callout callout-info">
+          <div class="callout-icon">🔨</div>
+          <div class="callout-content">
+            <strong class="callout-title">Next: Tapping the Walls</strong>
+            <p>You have now seen how this interface is supposed to work. Next: five places where it doesn&apos;t — including a <code>data-slot</code> rule exactly like the card one above that never fires, and nobody gets an error. And how you would have caught each one.</p>
+          </div>
+        </div>
+      </section>
+
+    </div>
+  </div>
+</section>
+<section class="module" id="module-5" style="background: var(--color-bg-warm)">
+  <div class="module-content">
+
+    <header class="module-header animate-in">
+      <span class="module-number">05</span>
+      <h1 class="module-title">Tapping the Walls</h1>
+      <p class="module-subtitle">Five real faults in this app. Not one of them crashes anything — which is exactly why they are all still here.</p>
+    </header>
+
+    <div class="module-body">
+
+      <!-- ============ SCREEN 1: THE INSPECTION ============ -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">Nothing here is on fire</h2>
+
+        <p>Every one of the five faults on this page is real, is in the app right now, and none of them crash anything. The bugs that crash are the easy ones — they announce themselves.</p>
+
+        <div class="callout callout-accent">
+          <div class="callout-icon">🔦</div>
+          <div class="callout-content">
+            <strong class="callout-title">The metaphor for this module: a home inspection</strong>
+            <p>An inspector does not wait for the ceiling to come down. They walk the house tapping walls, listening for the hollow spot, checking whether the switch by the door is wired to anything at all. Most of what they find is not dangerous — it is <em>disconnected</em>.</p>
+          </div>
+        </div>
+
+        <p>Wires that go nowhere. A light switch left over from a renovation that nobody removed. That is what is in this house — and in yours, and in every shipped product ever looked at under a torch.</p>
+
+        <div class="pattern-cards stagger-children">
+          <div class="pattern-card animate-in" style="border-top: 3px solid var(--color-actor-1)">
+            <div class="pattern-icon" style="background: var(--color-actor-1)">📬</div>
+            <h4 class="pattern-title">1. The reply nobody reads</h4>
+            <p class="pattern-desc">The server writes <code>message</code>. The browser asks for <code>msg</code>. One word apart, so one whole branch never runs.</p>
+          </div>
+          <div class="pattern-card animate-in" style="border-top: 3px solid var(--color-actor-2)">
+            <div class="pattern-icon" style="background: var(--color-actor-2)">🔌</div>
+            <h4 class="pattern-title">2. Three switches, no wires</h4>
+            <p class="pattern-desc">Aspect ratio, file format and model tier can never change from the values they were born with.</p>
+          </div>
+          <div class="pattern-card animate-in" style="border-top: 3px solid var(--color-actor-3)">
+            <div class="pattern-icon" style="background: var(--color-actor-3)">🎨</div>
+            <h4 class="pattern-title">3. A style rule waiting by the phone</h4>
+            <p class="pattern-desc">Hand-written chunky shadows for the buttons that have never once appeared on screen.</p>
+          </div>
+          <div class="pattern-card animate-in" style="border-top: 3px solid var(--color-actor-4)">
+            <div class="pattern-icon" style="background: var(--color-actor-4)">🔒</div>
+            <h4 class="pattern-title">4. A label that tells a fib</h4>
+            <p class="pattern-desc">The button says you must sign in. Then it generates your picture anyway.</p>
+          </div>
+          <div class="pattern-card animate-in" style="border-top: 3px solid var(--color-actor-5)">
+            <div class="pattern-icon" style="background: var(--color-actor-5)">🈳</div>
+            <h4 class="pattern-title">5. A word that was never delivered</h4>
+            <p class="pattern-desc">Written in English, translated into Chinese, and never carried the last few metres to the button.</p>
+          </div>
+        </div>
+
+        <p>One pattern accounts for all five: <strong>two halves that were each written correctly and never introduced to each other.</strong></p>
+      </section>
+
+      <!-- ============ SCREEN 2: FAULT 1 — HERO ============ -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">Fault 1 — the reply nobody reads</h2>
+
+        <p>When something goes wrong on the server, the app writes back a small note. Every failure note in the whole codebase is built by these fifteen lines.</p>
+
+        <div class="translation-block animate-in">
+          <div class="translation-code">
+            <span class="translation-label">CODE · src/lib/resp.ts</span>
+            <pre><code><span class="code-line"><span class="code-keyword">export</span> <span class="code-keyword">function</span> <span class="code-function">respErr</span>(message: <span class="code-keyword">string</span>, data?: <span class="code-keyword">any</span>) {</span>
+<span class="code-line">  <span class="code-keyword">return</span> <span class="code-function">respJson</span>(<span class="code-number">-1</span>, message, data);</span>
+<span class="code-line">}</span>
+<span class="code-line"></span>
+<span class="code-line"><span class="code-keyword">export</span> <span class="code-keyword">function</span> <span class="code-function">respJson</span>(code: <span class="code-keyword">number</span>, message: <span class="code-keyword">string</span>, data?: <span class="code-keyword">any</span>) {</span>
+<span class="code-line">  <span class="code-keyword">let</span> json: { code: <span class="code-keyword">number</span>; message: <span class="code-keyword">string</span>; data?: <span class="code-keyword">any</span> } = {</span>
+<span class="code-line">    <span class="code-property">code</span>: code,</span>
+<span class="code-line">    <span class="code-property">message</span>: message,</span>
+<span class="code-line">  };</span>
+<span class="code-line">  <span class="code-keyword">if</span> (data) {</span>
+<span class="code-line">    json.data = data;</span>
+<span class="code-line">  }</span>
+<span class="code-line"></span>
+<span class="code-line">  <span class="code-keyword">return</span> Response.<span class="code-function">json</span>(json);</span>
+<span class="code-line">}</span></code></pre>
+          </div>
+          <div class="translation-english">
+            <span class="translation-label">PLAIN ENGLISH</span>
+            <div class="translation-lines">
+              <p class="tl">Every error in the app leaves through this little door. It takes one thing: a sentence meant for a human.</p>
+              <p class="tl">It passes that sentence on, always stamped with the number <code>-1</code>. Hold on to that <code>-1</code> — it is the <em>only</em> failure number this app ever sends.</p>
+              <p class="tl">End of the door.</p>
+              <p class="tl">&nbsp;</p>
+              <p class="tl">The thing that actually writes the note. Three things go in: a number, a sentence, and optionally some extra data.</p>
+              <p class="tl">Here is the note spelled out in advance — this is <span class="term" data-definition="TypeScript is JavaScript with labels attached: you write down what shape your data is supposed to be, and the editor warns you before you run anything if you break your own rules.">TypeScript</span> describing the exact shape of what is about to be sent.</p>
+              <p class="tl">Slot one: the number.</p>
+              <p class="tl">Slot two: the sentence — and the label on this slot is the word <strong>message</strong>. That word is the whole fault.</p>
+              <p class="tl">Close the note.</p>
+              <p class="tl">Was there extra data to include?</p>
+              <p class="tl">Then tuck it in under the label <code>data</code>.</p>
+              <p class="tl">Close that check.</p>
+              <p class="tl">&nbsp;</p>
+              <p class="tl">Send it back to the browser as <span class="term" data-definition="JSON is a plain-text way of writing labelled data — names and values in curly brackets. It is how a server and a browser usually talk to each other.">JSON</span>: labelled text the browser can unpack.</p>
+              <p class="tl">Done. Every failure in this app arrives in the browser in exactly this shape.</p>
+            </div>
+          </div>
+        </div>
+
+        <p>So: every reply carries a field called <code>message</code>, and every failure carries the code <code>-1</code>. Now here is the browser side, reading that reply.</p>
+
+        <div class="bug-challenge">
+          <h3>One of these lines can never run — no matter how busy the service gets. Click it.</h3>
+          <div class="bug-code">
+            <div class="bug-line" data-line="369" data-hint="This one runs all the time — requiresRegistration really is a field the server really sends. Keep looking for a line whose condition can never be true." onclick="checkBugLine(this, false)">
+              <span class="line-num">369</span>
+              <code>        if (result.data.requiresRegistration &amp;&amp; !session) {</code>
+            </div>
+            <div class="bug-line" data-line="370" data-hint="That is only the wording of a message. Look for a condition — a line that decides whether something happens at all." onclick="checkBugLine(this, false)">
+              <span class="line-num">370</span>
+              <code>          toast.success("Image generated! Sign in to download full resolution image.");</code>
+            </div>
+            <div class="bug-line bug-target" data-line="371" data-explanation="The server never sends a field called <code>msg</code>. Look back at <code>resp.ts</code> — it is called <code>message</code>. So <code>result.msg</code> is always empty, empty is never equal to QUEUE_REQUIRED, and this warning has never appeared on anyone&apos;s screen. When all six Gemini keys are exhausted, users get the generic failure toast instead of the queue message and the upgrade offer. And nothing complains: the reply arrives from the network as untyped data, so as far as TypeScript is concerned, asking for <code>result.msg</code> is a perfectly reasonable thing to want." onclick="checkBugLine(this, true)">
+              <span class="line-num">371</span>
+              <code>        } else if (result.msg === 'QUEUE_REQUIRED') {</code>
+            </div>
+            <div class="bug-line" data-line="372" data-hint="Warm — this is the message nobody has ever seen. But it is not the reason. Look one line up, at the condition guarding it." onclick="checkBugLine(this, false)">
+              <span class="line-num">372</span>
+              <code>          toast.warning("🚧 Service is busy. You're in the queue. Upgrade to premium to skip the queue!");</code>
+            </div>
+            <div class="bug-line" data-line="373" data-hint="This is the ordinary happy path, and it runs constantly — in fact it runs in cases where it should not. Look above it." onclick="checkBugLine(this, false)">
+              <span class="line-num">373</span>
+              <code>        } else {</code>
+            </div>
+            <div class="bug-line" data-line="374" data-hint="This is the normal success message, and it works. The broken line is a condition, not an action." onclick="checkBugLine(this, false)">
+              <span class="line-num">374</span>
+              <code>          toast.success(t.messages.success.generated);</code>
+            </div>
+            <div class="bug-line" data-line="375" data-hint="This one is fine — session is a real thing the browser genuinely knows about. Look for a field that only exists on one side of the wall." onclick="checkBugLine(this, false)">
+              <span class="line-num">375</span>
+              <code>          if (session) {</code>
+            </div>
+            <div class="bug-line" data-line="376" data-hint="This runs whenever a signed-in person generates something — it is what makes the credit counter tick down on screen." onclick="checkBugLine(this, false)">
+              <span class="line-num">376</span>
+              <code>            refreshCredits();</code>
+            </div>
+            <div class="bug-line" data-line="377" data-hint="A closing bracket cannot be the bug. Look at the lines that ask questions." onclick="checkBugLine(this, false)">
+              <span class="line-num">377</span>
+              <code>          }</code>
+            </div>
+            <div class="bug-line" data-line="378" data-hint="A closing bracket cannot be the bug. Look at the lines that ask questions." onclick="checkBugLine(this, false)">
+              <span class="line-num">378</span>
+              <code>        }</code>
+            </div>
+          </div>
+          <div class="bug-feedback" id="bug-feedback"></div>
+        </div>
+
+        <p>The word for a branch like that is <span class="term" data-definition="An unreachable branch is an if/else path whose condition can never be true, so the code inside it never runs. It is not broken code — it is code nobody ever calls on.">unreachable branch</span>, and the reason it survives is that it produces a <span class="term" data-definition="A silent failure is something going wrong with no error message anywhere — no red text, no crash, no log line. The feature simply does not happen, and everyone assumes it did.">silent failure</span>: nothing errors, nothing logs, the feature just quietly is not there.</p>
+
+        <div class="callout callout-warning">
+          <div class="callout-icon">🔐</div>
+          <div class="callout-content">
+            <strong class="callout-title">There is a second lock on the same door</strong>
+            <p>Elsewhere in the same function sits a branch guarded by <code>result.code === 1</code>. But <code>respErr</code> only ever sends <code>-1</code>, and successes carry their own number — so <code>1</code> is a value this app never produces. Two independent reasons, one dead branch.</p>
+          </div>
+        </div>
+
+        <h3 class="screen-heading" style="margin-top: var(--space-12)">Twenty lines later, the same person got it right</h3>
+
+        <p>This is the cruel part, and the reason nobody caught it. In the very same function, the insufficient-credits branch reads exactly the fields the server actually sends.</p>
+
+        <div class="translation-block animate-in">
+          <div class="translation-code">
+            <span class="translation-label">CODE · imagen-client.tsx</span>
+            <pre><code><span class="code-line">      } <span class="code-keyword">else</span> <span class="code-keyword">if</span> (result.code === <span class="code-number">-1</span>) {</span>
+<span class="code-line">        <span class="code-comment">// Handle error responses (including insufficient credits)</span></span>
+<span class="code-line">        <span class="code-keyword">if</span> (result.data === <span class="code-string">'INSUFFICIENT_CREDITS'</span> || result.message?.<span class="code-function">includes</span>(<span class="code-string">'Insufficient credits'</span>)) {</span>
+<span class="code-line">          toast.<span class="code-function">error</span>(result.message || <span class="code-string">'Insufficient credits to generate image'</span>);</span>
+<span class="code-line">          <span class="code-keyword">return</span>;</span>
+<span class="code-line">        }</span>
+<span class="code-line">        <span class="code-keyword">throw</span> <span class="code-keyword">new</span> <span class="code-function">Error</span>(result.message || <span class="code-string">'Generation failed'</span>);</span></code></pre>
+          </div>
+          <div class="translation-english">
+            <span class="translation-label">PLAIN ENGLISH</span>
+            <div class="translation-lines">
+              <p class="tl">Did the note come back stamped <code>-1</code>? That is the number <code>respErr</code> really sends — so this branch really runs.</p>
+              <p class="tl">A note left by whoever wrote it.</p>
+              <p class="tl">Two ways to recognise a credits problem: the tag in <code>data</code>, or the words inside <code>message</code>. Both of those field names exist. Both work.</p>
+              <p class="tl">Show the person the server&apos;s own sentence as a <span class="term" data-definition="A toast is the small message that slides into a corner of the screen and fades away by itself — Saved, Copied, Something went wrong. Named after bread popping out of a toaster.">toast</span>, or a sensible stand-in if it is missing.</p>
+              <p class="tl">Stop here. Nothing else in this function should run.</p>
+              <p class="tl">Close the credits check.</p>
+              <p class="tl">Any other failure: raise it properly so the catch block below can show the generic error.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="icon-rows">
+          <div class="icon-row">
+            <div class="icon-circle" style="background: var(--color-success)">✅</div>
+            <div>
+              <strong><code>result.message</code> and <code>result.data</code></strong>
+              <p>Both spelled the way the server spells them. This branch has worked from the day it was written.</p>
+            </div>
+          </div>
+          <div class="icon-row">
+            <div class="icon-circle" style="background: var(--color-error)">🚫</div>
+            <div>
+              <strong><code>result.msg</code></strong>
+              <p>Twenty lines earlier, in the same file, in the same function. Never fires. Nothing warns anybody.</p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- ============ SCREEN 3: FAULT 2 ============ -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">Fault 2 — three switches with the wires cut</h2>
+
+        <p>The generator carries three settings around with it: a shape for the picture, a file format, and which tier of model to use.</p>
+
+        <div class="translation-block animate-in">
+          <div class="translation-code">
+            <span class="translation-label">CODE · imagen-client.tsx</span>
+            <pre><code><span class="code-line">  <span class="code-keyword">const</span> [aspectRatio, setAspectRatio] = <span class="code-function">useState</span>(<span class="code-string">'16:9'</span>);</span>
+<span class="code-line">  <span class="code-keyword">const</span> [outputFormat, setOutputFormat] = <span class="code-function">useState</span>(<span class="code-string">'jpeg'</span>);</span>
+<span class="code-line">  <span class="code-keyword">const</span> [selectedModel, setSelectedModel] = <span class="code-function">useState</span>(<span class="code-string">'pro'</span>);</span></code></pre>
+          </div>
+          <div class="translation-english">
+            <span class="translation-label">PLAIN ENGLISH</span>
+            <div class="translation-lines">
+              <p class="tl">Two things come out of every one of these: the current value, and a <span class="term" data-definition="A state setter is the one function allowed to change a piece of a screen&apos;s memory. If nothing ever calls it, that value is frozen at whatever it started as, forever.">state setter</span> — the only hand allowed to change it. Shape starts at 16:9, and <code>setAspectRatio</code> is the only way it will ever move.</p>
+              <p class="tl">Same again for the file format: starts at jpeg, and only <code>setOutputFormat</code> can change it.</p>
+              <p class="tl">And the model tier: starts at pro, movable only by <code>setSelectedModel</code>. The Generate button reads this one to print (10 credits) beside itself.</p>
+            </div>
+          </div>
+        </div>
+
+        <p>Search the whole file for those three setter names and you find one mention each — the line that created them. Nothing else ever calls them, so nothing can ever move those values.</p>
+
+        <p>Now follow one of them all the way through the house. Click <strong>Next Step</strong>.</p>
+
+        <div class="flow-animation" data-steps='[
+          {"highlight":"flow-actor-1","label":"There is no picker on the screen. Nothing anywhere calls setAspectRatio, so the value is welded to 16:9 for every visitor, forever."},
+          {"highlight":"flow-actor-2","label":"The value sits in the page memory, exactly as it was born. This half is not broken — it is simply never touched.","packet":true,"from":"actor-1","to":"actor-2"},
+          {"highlight":"flow-actor-3","label":"The browser really does send aspectRatio along with the photo. This wire is connected and working.","packet":true,"from":"actor-2","to":"actor-3"},
+          {"highlight":"flow-actor-3","label":"The server checks it carefully against a list of allowed shapes and rejects anything unexpected. Careful, deliberate, correct work."},
+          {"highlight":"flow-actor-4","label":"The parcel goes to Gemini: the written brief plus the photo. The aspect ratio is not in that parcel. Gemini is never told.","packet":true,"from":"actor-3","to":"actor-4"},
+          {"highlight":"flow-actor-5","label":"The reply politely echoes aspectRatio back. The answer says 16:9. The picture was drawn without ever hearing about it.","packet":true,"from":"actor-4","to":"actor-5"}
+        ]'>
+          <div class="flow-actors">
+            <div class="flow-actor" id="flow-actor-1">
+              <div class="flow-actor-icon">🎛️</div>
+              <span>Picker<br>(missing)</span>
+            </div>
+            <div class="flow-actor" id="flow-actor-2">
+              <div class="flow-actor-icon">📌</div>
+              <span>Page memory<br>16:9</span>
+            </div>
+            <div class="flow-actor" id="flow-actor-3">
+              <div class="flow-actor-icon">🛃</div>
+              <span>Server<br>validates</span>
+            </div>
+            <div class="flow-actor" id="flow-actor-4">
+              <div class="flow-actor-icon">🎨</div>
+              <span>Gemini</span>
+            </div>
+            <div class="flow-actor" id="flow-actor-5">
+              <div class="flow-actor-icon">📤</div>
+              <span>Reply</span>
+            </div>
+          </div>
+
+          <div class="flow-packet" id="flow-packet"></div>
+
+          <div class="flow-step-label" id="flow-label">Click "Next Step" to follow the aspect ratio</div>
+
+          <div class="flow-controls">
+            <button class="btn flow-next-btn">Next Step</button>
+            <button class="btn flow-reset-btn">Restart</button>
+            <span class="flow-progress"></span>
+          </div>
+        </div>
+
+        <div class="callout callout-info">
+          <div class="callout-icon">🧰</div>
+          <div class="callout-content">
+            <strong class="callout-title">Nobody was being lazy here</strong>
+            <p>Writing that validation list on the server is real, careful work — someone was clearly planning the picker. The chain is missing two pieces at opposite ends: a control at the front, and one line at the back that hands the value to Gemini.</p>
+          </div>
+        </div>
+      </section>
+
+      <!-- ============ SCREEN 4: FAULT 3 ============ -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">Fault 3 — a style rule waiting by the phone</h2>
+
+        <p>Module 4 showed the trick: every Shadcn brick stamps a small label on itself, and <code>theme.css</code> grabs everything wearing that label and restyles it in one go. <code>[data-slot="card"]</code> does this beautifully. Here is the same trick, one step further.</p>
+
+        <div class="translation-block animate-in">
+          <div class="translation-code">
+            <span class="translation-label">CODE · src/app/theme.css</span>
+            <pre><code><span class="code-line">[<span class="code-attr">data-slot</span>=<span class="code-value">"button"</span>][<span class="code-attr">data-variant</span>=<span class="code-value">"default"</span>] {</span>
+<span class="code-line">  <span class="code-property">background</span>: <span class="code-function">var</span>(--primary);</span>
+<span class="code-line">  <span class="code-property">color</span>: <span class="code-function">var</span>(--primary-foreground);</span>
+<span class="code-line">  <span class="code-property">border</span>: <span class="code-number">2px</span> solid <span class="code-function">var</span>(--foreground);</span>
+<span class="code-line">  <span class="code-property">border-radius</span>: <span class="code-function">var</span>(--radius);</span>
+<span class="code-line">  <span class="code-property">box-shadow</span>: <span class="code-number">4px</span> <span class="code-number">4px</span> <span class="code-number">0px</span> <span class="code-function">var</span>(--foreground);</span>
+<span class="code-line">  <span class="code-property">transition</span>: all <span class="code-number">0.2s</span> ease;</span>
+<span class="code-line">}</span></code></pre>
+          </div>
+          <div class="translation-english">
+            <span class="translation-label">PLAIN ENGLISH</span>
+            <div class="translation-lines">
+              <p class="tl">This first line is the <span class="term" data-definition="A CSS selector is the sentence at the top of a style rule that says which things on the page it applies to. If it describes nothing on the page, the rule below it is simply skipped — no error, no warning.">CSS selector</span>: find every element wearing <em>both</em> of these labels. Two <span class="term" data-definition="An attribute is a small labelled note written onto an element in the page, like id=&quot;submit&quot; or disabled. Style rules and scripts use them to find things.">attributes</span>, not one — and both are required.</p>
+              <p class="tl">Paint it with the primary colour role, not a hard-coded yellow.</p>
+              <p class="tl">Text in the matching foreground role, so it stays readable if the palette changes.</p>
+              <p class="tl">A fat two-pixel outline in the ink colour — that Charlie-and-Lola storybook edge.</p>
+              <p class="tl">Corners from the shared radius token, so every corner in the app moves together.</p>
+              <p class="tl">And the signature: a hard shadow offset down and right, like a sticker peeled off the page.</p>
+              <p class="tl">Animate any change over a fifth of a second.</p>
+              <p class="tl">End of a rule that has never once been applied to anything.</p>
+            </div>
+          </div>
+        </div>
+
+        <p>Here is why. This is the entire output of the Button component — everything it ever stamps onto the page.</p>
+
+        <div class="translation-block animate-in">
+          <div class="translation-code">
+            <span class="translation-label">CODE · src/components/ui/button.tsx</span>
+            <pre><code><span class="code-line">  <span class="code-keyword">return</span> (</span>
+<span class="code-line">    &lt;<span class="code-tag">Comp</span></span>
+<span class="code-line">      <span class="code-attr">data-slot</span>=<span class="code-value">"button"</span></span>
+<span class="code-line">      <span class="code-attr">className</span>={<span class="code-function">cn</span>(<span class="code-function">buttonVariants</span>({ variant, size, className }))}</span>
+<span class="code-line">      {...props}</span>
+<span class="code-line">    /&gt;</span>
+<span class="code-line">  )</span></code></pre>
+          </div>
+          <div class="translation-english">
+            <span class="translation-label">PLAIN ENGLISH</span>
+            <div class="translation-lines">
+              <p class="tl">Hand back the thing to be drawn on the page.</p>
+              <p class="tl">Usually a real <code>&lt;button&gt;</code>, sometimes a link wearing a button costume.</p>
+              <p class="tl">Stamp on the label <span class="term" data-definition="A data- attribute is a custom label you invent and attach to an element — data-slot, data-state, data-variant. The browser ignores them, but your style rules and scripts can use them as handles.">data-slot</span> = button. This is the <em>only</em> label it ever writes. There is no <code>data-variant</code> here, and never has been.</p>
+              <p class="tl">Work out the Tailwind classes for the chosen look and size, and let anything passed in override them.</p>
+              <p class="tl">Pass through everything else the caller gave us — the click handler, the disabled flag, and so on.</p>
+              <p class="tl">Close the element.</p>
+              <p class="tl">Done. One label out, two labels required by the style rule.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="icon-rows">
+          <div class="icon-row">
+            <div class="icon-circle" style="background: var(--color-success)">🎯</div>
+            <div>
+              <strong><code>[data-slot="card"]</code> → matches every card</strong>
+              <p><code>card.tsx</code> really does stamp <code>data-slot="card"</code>. One label asked for, one label stamped. This is the rule from module 4 that works.</p>
+            </div>
+          </div>
+          <div class="icon-row">
+            <div class="icon-circle" style="background: var(--color-error)">👻</div>
+            <div>
+              <strong><code>[data-slot="button"][data-variant="default"]</code> → matches nothing</strong>
+              <p>Two labels asked for, one stamped. Zero elements on the page qualify, so those chunky shadows and the nudge-on-hover have never rendered — not once, on anybody&apos;s screen.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="callout callout-info">
+          <div class="callout-icon">🖼️</div>
+          <div class="callout-content">
+            <strong class="callout-title">The buttons still look fine, by the way</strong>
+            <p>Their colour comes from the <code>cva</code> table inside <code>button.tsx</code> — <code>bg-primary text-primary-foreground shadow-xs</code>. What never arrived is the hand-written storybook shadow described above. Nobody misses a thing they have never seen.</p>
+          </div>
+        </div>
+      </section>
+
+      <!-- ============ SCREEN 5: FAULT 4 ============ -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">Fault 4 — the button that asks you to sign in, then does it anyway</h2>
+
+        <p>Signed out, the Generate button shows a padlock and the words <em>login required</em>. Then you click it, and it generates your picture.</p>
+
+        <div class="badge-list">
+          <div class="badge-item">
+            <code class="badge-code">disabled={uploadedImages.length === 0 || isGenerating}</code>
+            <span class="badge-desc">The complete list of reasons the button ever refuses: no photo yet, or one is already being drawn. Being signed out is not on it.</span>
+          </div>
+        </div>
+
+        <div class="icon-rows">
+          <div class="icon-row">
+            <div class="icon-circle" style="background: var(--color-error)">🔒</div>
+            <div>
+              <strong>What the label promises</strong>
+              <p>Padlock icon, the words "login required". A clear statement that nothing will happen until you sign in.</p>
+            </div>
+          </div>
+          <div class="icon-row">
+            <div class="icon-circle" style="background: var(--color-actor-2)">▶️</div>
+            <div>
+              <strong>What the button does</strong>
+              <p>Runs <code>generateImage()</code>, which never checks for a <span class="term" data-definition="A session is the app&apos;s memory that you are signed in and who you are — the wristband you get at the door. No session means the app treats you as a guest.">session</span> at all. The picture gets made.</p>
+            </div>
+          </div>
+          <div class="icon-row">
+            <div class="icon-circle" style="background: var(--color-success)">🎟️</div>
+            <div>
+              <strong>What the server does</strong>
+              <p>Treats guests deliberately: sends back <code>requiresRegistration: true</code> and charges no credits. The behaviour was designed. Only the wording is out of date.</p>
+            </div>
+          </div>
+        </div>
+
+        <p>You have already met the branch that handles this properly — it was line 369 in the spot-the-bug exhibit, the one that offers a full-resolution download in exchange for signing in. That branch works. The label beside it is a leftover from when guests really were turned away.</p>
+
+        <div class="callout callout-warning">
+          <div class="callout-icon">🏷️</div>
+          <div class="callout-content">
+            <strong class="callout-title">A stale label is a real fault, not a cosmetic one</strong>
+            <p>Some people read "login required", decide they cannot be bothered, and leave — never discovering that the free try was one click away. Nothing in the code is wrong. The product still loses.</p>
+          </div>
+        </div>
+      </section>
+
+      <!-- ============ SCREEN 6: FAULT 5 ============ -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">Fault 5 — the word that was never delivered</h2>
+
+        <p>Switch free mode on and the Generate button reads <code>(undefined)</code>. The phrase exists. Someone wrote it, someone translated it — it just never travelled the last few metres.</p>
+
+        <div class="step-cards">
+          <div class="step-card">
+            <div class="step-num">1</div>
+            <div class="step-body">
+              <strong>The translation files — present ✅</strong>
+              <p><code>"limited_free": "Limited Free"</code> in English, <code>"限免"</code> in Chinese. Both written, both correct, both sitting there.</p>
+            </div>
+          </div>
+          <div class="step-card">
+            <div class="step-num">2</div>
+            <div class="step-body">
+              <strong>The <code>Translations</code> <span class="term" data-definition="An interface is a written list of exactly which pieces of information a component expects to be handed, and what type each one is. It is a contract — and like any contract, it only covers what somebody remembered to write into it.">interface</span> — missing ❌</strong>
+              <p>The list at the top of <code>imagen-client.tsx</code> declaring every string the component expects. <code>limited_free</code> is not on the list.</p>
+            </div>
+          </div>
+          <div class="step-card">
+            <div class="step-num">3</div>
+            <div class="step-body">
+              <strong>The mapping in <code>index.tsx</code> — missing ❌</strong>
+              <p>The wrapper from module 2 that hand-copies each string into one object before handing it to the browser. This one never gets copied.</p>
+            </div>
+          </div>
+        </div>
+
+        <p>So the button asks for <code>t.buttons.limited_free</code>, is handed nothing at all, and prints the word JavaScript uses for nothing at all: <code>undefined</code>. No error. No warning. Just a strange word on a button.</p>
+
+        <div class="callout callout-warning">
+          <div class="callout-icon">📮</div>
+          <div class="callout-content">
+            <strong class="callout-title">This is the bill for the hand-written wrapper</strong>
+            <p>Module 2 showed the wrapper copying translations across the client/server wall by hand. The cost: every new piece of text has to be added in <strong>three</strong> places — the JSON file, the interface, the mapping. Forget one and it fails without a sound.</p>
+          </div>
+        </div>
+      </section>
+
+      <!-- ============ SCREEN 7: THE CLIPBOARD ============ -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">What the five have in common</h2>
+
+        <div class="callout callout-accent">
+          <div class="callout-icon">💡</div>
+          <div class="callout-content">
+            <strong class="callout-title">Aha: silence is a symptom</strong>
+            <p>A branch that never runs, a rule that matches nothing and a setter that is never called all produce exactly zero errors. Working code and disconnected code look identical from the outside — which is why "it does not crash" is not evidence that it works.</p>
+          </div>
+        </div>
+
+        <p>An inspector does not need to know how a house was built to tap the walls. Here is the clipboard — five questions you can ask about your own project this afternoon.</p>
+
+        <div class="pattern-cards stagger-children">
+          <div class="pattern-card animate-in" style="border-top: 3px solid var(--color-actor-1)">
+            <div class="pattern-icon" style="background: var(--color-actor-1)">🔌</div>
+            <h4 class="pattern-title">Is this setter ever called?</h4>
+            <p class="pattern-desc">"Search the file for every place <code>setAspectRatio</code> is used." If the only hit is where it was created, the control is decorative.</p>
+          </div>
+          <div class="pattern-card animate-in" style="border-top: 3px solid var(--color-actor-2)">
+            <div class="pattern-icon" style="background: var(--color-actor-2)">🔤</div>
+            <h4 class="pattern-title">Do both sides spell it the same?</h4>
+            <p class="pattern-desc">"List the exact field names the server sends and the ones the client reads." Data crossing a network is never spell-checked by anybody.</p>
+          </div>
+          <div class="pattern-card animate-in" style="border-top: 3px solid var(--color-actor-3)">
+            <div class="pattern-icon" style="background: var(--color-actor-3)">🎯</div>
+            <h4 class="pattern-title">Does this selector match anything?</h4>
+            <p class="pattern-desc">"Show me an element that has both of these attributes." A style rule for a thing that does not exist is silent, tidy and useless.</p>
+          </div>
+          <div class="pattern-card animate-in" style="border-top: 3px solid var(--color-actor-4)">
+            <div class="pattern-icon" style="background: var(--color-actor-4)">🏷️</div>
+            <h4 class="pattern-title">Does the label match the behaviour?</h4>
+            <p class="pattern-desc">Read the button out loud, then read what it actually does. Words go stale faster than logic, and nothing checks them.</p>
+          </div>
+          <div class="pattern-card animate-in" style="border-top: 3px solid var(--color-actor-5)">
+            <div class="pattern-icon" style="background: var(--color-actor-5)">🔗</div>
+            <h4 class="pattern-title">Is it wired all the way through?</h4>
+            <p class="pattern-desc">Anything hand-copied from place to place has as many failure points as it has hops. Count the hops before you add the sixth one.</p>
+          </div>
+        </div>
+
+        <div class="callout callout-info">
+          <div class="callout-icon">🤖</div>
+          <div class="callout-content">
+            <strong class="callout-title">For steering AI: the three sentences that end a bug loop</strong>
+            <p>"Why is this broken?" gets you guesses, and the next twenty minutes get you more guesses. Say these three things instead, in this order.</p>
+          </div>
+        </div>
+
+        <div class="step-cards">
+          <div class="step-card">
+            <div class="step-num">1</div>
+            <div class="step-body">
+              <strong>Name the station</strong>
+              <p>"This is the client-side handling of the response, in <code>imagen-client.tsx</code>." You learned the seven stations in module 1 for exactly this sentence.</p>
+            </div>
+          </div>
+          <div class="step-card">
+            <div class="step-num">2</div>
+            <div class="step-body">
+              <strong>Name the mismatch</strong>
+              <p>"The server sends a field called <code>message</code>. The client reads <code>result.msg</code>." A fact, not a symptom. Nothing left to diagnose.</p>
+            </div>
+          </div>
+          <div class="step-card">
+            <div class="step-num">3</div>
+            <div class="step-body">
+              <strong>Name the fix you want</strong>
+              <p>"Change the client to read <code>result.message</code>. Do not touch <code>resp.ts</code> — everything else in the app depends on it." Otherwise a helpful assistant may fix it from the wrong end and cause a <span class="term" data-definition="A regression is something that used to work and stopped working because of a change made somewhere else. The classic way to create one is to fix a bug at the wrong end of the chain.">regression</span> in ten other places.</p>
+            </div>
+          </div>
+        </div>
+
+        <p>Guesses in, guesses out. Specifics in, patches out.</p>
+      </section>
+
+      <!-- ============ SCREEN 8: QUIZ ============ -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">Four calls from the field</h2>
+
+        <p>Each of these is a message you might actually receive. Name the station before you pick.</p>
+
+        <div class="quiz-container" id="quiz-module5">
+
+          <div class="quiz-question-block"
+               data-correct="opt-client-msg"
+               data-explanation-right="Exactly — and notice you worked it out without reproducing the traffic spike. The server does its job: it marks the burnt key and sends the QUEUE_REQUIRED tag inside a field called message. The one word that does not line up is on the browser side, which makes this a one-line change in one file."
+               data-explanation-wrong="Have another look at what the symptom proves. A generic failure toast means the reply arrived and the client read it — it just did not recognise what it was holding. Anything further upstream would fail in a different, louder way.">
+            <h3 class="quiz-question">Traffic spikes and users report the site "just says generation failed". You know the queue-and-upgrade message exists — you can read it in the server code. Where do you look first?</h3>
+            <div class="quiz-options">
+              <button class="quiz-option" data-value="opt-pool" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>The Gemini key pool — all six keys must be burning out at once</span>
+              </button>
+              <button class="quiz-option" data-value="opt-client-msg" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>The client&apos;s response handling — it reads <code>result.msg</code>, and the server sends <code>message</code></span>
+              </button>
+              <button class="quiz-option" data-value="opt-server-text" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>The server route — <code>respErr</code> must be sending the wrong wording</span>
+              </button>
+              <button class="quiz-option" data-value="opt-toast" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>The toast library — warning-style messages are probably being suppressed</span>
+              </button>
+            </div>
+            <div class="quiz-feedback"></div>
+          </div>
+
+          <div class="quiz-question-block"
+               data-correct="opt-never-rendered"
+               data-explanation-right="Exactly. The rule asks for two labels; the Button component stamps one. Saying this out loud matters, because it changes the job from find what broke it to stamp the attribute or rewrite the selector — and it stops anyone hunting through the history for a change that was never made."
+               data-explanation-wrong="Be careful with the word removed — it quietly assumes the shadow once worked. Before searching the history, compare the style rule against the component: the rule wants data-slot AND data-variant, and only one of those is ever written onto the element.">
+            <h3 class="quiz-question">A designer is certain the Generate button used to have a chunky offset shadow and that "someone removed it in a refactor". You look and find the shadow rule sitting in <code>theme.css</code>, untouched. What actually happened?</h3>
+            <div class="quiz-options">
+              <button class="quiz-option" data-value="opt-twmerge" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>A Tailwind class overrode it — <code>twMerge</code> kept the wrong one of the two</span>
+              </button>
+              <button class="quiz-option" data-value="opt-never-rendered" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>Nobody removed it. The rule needs a <code>data-variant</code> attribute the component never stamps, so it has never matched anything</span>
+              </button>
+              <button class="quiz-option" data-value="opt-dark" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>It only applies in dark mode, and the designer was looking at light mode</span>
+              </button>
+              <button class="quiz-option" data-value="opt-notloaded" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span><code>theme.css</code> is not loaded on that particular page</span>
+              </button>
+            </div>
+            <div class="quiz-feedback"></div>
+          </div>
+
+          <div class="quiz-question-block"
+               data-correct="opt-three-places"
+               data-explanation-right="Exactly. Two ends of the chain are missing and one middle section already works. If you only ask for the control, you get a beautiful dropdown that changes nothing — and then a long confusing conversation about why. Tracing end to end before you ask is the whole skill."
+               data-explanation-wrong="Follow the value the whole way. A control that sets the value is not enough on its own: the browser already sends it, the server already validates it — and then the server never mentions it to Gemini. Leave that last piece out and the picker will look perfect and do nothing.">
+            <h3 class="quiz-question">You ask an AI assistant to "make the aspect-ratio picker work". What do you need to tell it so it does not stop halfway?</h3>
+            <div class="quiz-options">
+              <button class="quiz-option" data-value="opt-just-ask" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>Nothing more — it can read the code and work out the rest</span>
+              </button>
+              <button class="quiz-option" data-value="opt-dropdown-only" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>Add the dropdown and wire <code>setAspectRatio</code> — the rest of the chain already works</span>
+              </button>
+              <button class="quiz-option" data-value="opt-three-places" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>Add the dropdown and wire <code>setAspectRatio</code>; the value is already sent and validated; but the server must actually pass it to Gemini instead of just echoing it back</span>
+              </button>
+              <button class="quiz-option" data-value="opt-db" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>Add the dropdown and save the choice to the database so it is remembered next visit</span>
+              </button>
+            </div>
+            <div class="quiz-feedback"></div>
+          </div>
+
+          <div class="quiz-question-block"
+               data-correct="opt-wrapper"
+               data-explanation-right="Exactly — and the giveaway is that only this one word is missing. The JSON has it in both languages; the interface and the hand-written mapping in index.tsx do not. That is the standing cost of the wrapper from module 2: three places per string, and forgetting one is completely silent."
+               data-explanation-wrong="Look at the scope of the damage before you pick. If the files or the language switch were broken, every label on the page would be blank — not one word on one button. Something is wrong with this string specifically, somewhere on its way across.">
+            <h3 class="quiz-question">Free mode is switched on and the Generate button reads <code>(undefined)</code>. Every other label on the page is fine, and you have confirmed the phrase exists in both translation files. What happened?</h3>
+            <div class="quiz-options">
+              <button class="quiz-option" data-value="opt-files" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>The translation files failed to load for this visitor</span>
+              </button>
+              <button class="quiz-option" data-value="opt-locale" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>The language switch broke and fell back to a language with no text in it</span>
+              </button>
+              <button class="quiz-option" data-value="opt-wrapper" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>It was never carried across: it is missing from the <code>Translations</code> interface and from the hand-written mapping in <code>index.tsx</code></span>
+              </button>
+              <button class="quiz-option" data-value="opt-typo" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>Gemini returned a malformed response and the button is showing part of it</span>
+              </button>
+            </div>
+            <div class="quiz-feedback"></div>
+          </div>
+
+          <button class="quiz-check-btn" onclick="checkQuiz('quiz-module5')">Check Answers</button>
+          <button class="quiz-reset-btn" onclick="resetQuiz('quiz-module5')">Try Again</button>
+        </div>
+      </section>
+
+      <!-- ============ SCREEN 9: CLOSING THE COURSE ============ -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">Five modules ago, this was a box you dropped a photo into</h2>
+
+        <p>You have not learned to write this app. You were never trying to. Here is what you can actually do now.</p>
+
+        <div class="icon-rows">
+          <div class="icon-row">
+            <div class="icon-circle" style="background: var(--color-actor-1)">🧭</div>
+            <div>
+              <strong>Trace one generation end to end</strong>
+              <p>Seven stations, from the file landing on the page to the finished drawing coming back as a web address. When something breaks, you can name the station.</p>
+            </div>
+          </div>
+          <div class="icon-row">
+            <div class="icon-circle" style="background: var(--color-actor-2)">🎭</div>
+            <div>
+              <strong>Tell the browser half from the server half</strong>
+              <p>And say why the API key can only ever live on one side of that wall — the single most useful line you can draw through any web app.</p>
+            </div>
+          </div>
+          <div class="icon-row">
+            <div class="icon-circle" style="background: var(--color-actor-3)">✍️</div>
+            <div>
+              <strong>Recognise a rented model behind a written brief</strong>
+              <p>The whole Charlie &amp; Lola look is one paragraph of English sent to a general-purpose artist. Change the paragraph, change the product.</p>
+            </div>
+          </div>
+          <div class="icon-row">
+            <div class="icon-circle" style="background: var(--color-actor-4)">🎨</div>
+            <div>
+              <strong>Name a design token instead of a hex code</strong>
+              <p>"Use the <code>secondary</code> token" and "add a variant to <code>buttonVariants</code>" are two sentences that keep an interface from drifting into forty shades of almost-yellow.</p>
+            </div>
+          </div>
+          <div class="icon-row">
+            <div class="icon-circle" style="background: var(--color-actor-5)">🔦</div>
+            <div>
+              <strong>Spot a silent disconnection</strong>
+              <p>Two halves, each written correctly, never introduced. No crash, no error, no clue — until you tap the wall.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="callout callout-accent">
+          <div class="callout-icon">📋</div>
+          <div class="callout-content">
+            <strong class="callout-title">The one habit worth keeping</strong>
+            <p>When something looks wrong, name the station before you propose the fix. That single reordering is what separates a five-minute exchange with an AI assistant from a two-hour loop of confident, plausible, wrong suggestions.</p>
+          </div>
+        </div>
+
+        <p>The app in this course is real and running, and the files are sitting on the same disk as this page. These three are the ones worth opening first.</p>
+
+        <div class="badge-list">
+          <div class="badge-item">
+            <code class="badge-code">src/app/api/generate-cyberpunk/route.ts</code>
+            <span class="badge-desc">The server side of the whole feature: the key pool, the written brief, the call to Gemini, the upload. Still named after a product that no longer exists.</span>
+          </div>
+          <div class="badge-item">
+            <code class="badge-code">src/components/blocks/imagen-wrapper/imagen-client.tsx</code>
+            <span class="badge-desc">Everything you see and touch — and the home of faults 1, 2, 4 and half of 5. Long, honest, and completely readable once you know the stations.</span>
+          </div>
+          <div class="badge-item">
+            <code class="badge-code">src/app/theme.css</code>
+            <span class="badge-desc">The paint chart. Every colour, corner and shadow in the app, defined twice — once for light mode, once for dark.</span>
+          </div>
+        </div>
+
+        <p>Open one of them, scroll slowly, and see how much of it you can now read out loud. That is the whole send-off — no certificate, no new job title. Just a house you can walk through in the dark.</p>
+      </section>
+
+    </div>
+  </div>
+</section>
+  </main>
+
+</body>
+</html>

--- a/courses/image-generator-ui-course/main.js
+++ b/courses/image-generator-ui-course/main.js
@@ -1,0 +1,498 @@
+/**
+ * CODEBASE-TO-COURSE — COMPLETE JS ENGINE
+ * Copy this file verbatim into the course output directory.
+ * Never regenerate it. It handles all interactivity generically.
+ *
+ * Engines included:
+ *  - Navigation & progress bar
+ *  - Scroll-triggered reveal animations
+ *  - Keyboard navigation
+ *  - Glossary tooltips
+ *  - Quiz (multiple-choice & scenario)
+ *  - Drag-and-drop matching
+ *  - Group chat animation
+ *  - Data flow / message flow animation
+ *  - Architecture diagram
+ *  - "Spot the bug" challenge
+ *  - Layer toggle
+ */
+(function () {
+  'use strict';
+
+  /* ── HELPERS ──────────────────────────────────────────────── */
+  function $(sel, ctx) { return (ctx || document).querySelector(sel); }
+  function $$(sel, ctx) { return Array.from((ctx || document).querySelectorAll(sel)); }
+
+  /* ── NAVIGATION & PROGRESS BAR ────────────────────────────── */
+  const progressBar = $('#progress-bar');
+  const navDots     = $$('.nav-dot');
+  const modules     = $$('.module');
+
+  function updateProgress() {
+    if (!progressBar) return;
+    const scrollTop    = window.scrollY;
+    const scrollHeight = document.documentElement.scrollHeight - window.innerHeight;
+    const pct          = scrollHeight > 0 ? (scrollTop / scrollHeight) * 100 : 0;
+    progressBar.style.width = pct + '%';
+    progressBar.setAttribute('aria-valuenow', Math.round(pct));
+    updateNavDots();
+  }
+
+  function updateNavDots() {
+    const scrollMid = window.scrollY + window.innerHeight / 2;
+    modules.forEach((mod, i) => {
+      const dot = navDots[i];
+      if (!dot) return;
+      const top    = mod.offsetTop;
+      const bottom = top + mod.offsetHeight;
+      if (scrollMid >= top && scrollMid < bottom) {
+        dot.classList.add('active');
+        dot.classList.remove('visited');
+      } else if (window.scrollY + window.innerHeight > top) {
+        dot.classList.remove('active');
+        dot.classList.add('visited');
+      } else {
+        dot.classList.remove('active', 'visited');
+      }
+    });
+  }
+
+  window.addEventListener('scroll', () => requestAnimationFrame(updateProgress), { passive: true });
+  updateProgress();
+
+  // Nav dot click → scroll to module
+  navDots.forEach(dot => {
+    dot.addEventListener('click', () => {
+      const target = $('#' + dot.dataset.target);
+      if (target) target.scrollIntoView({ behavior: 'smooth' });
+    });
+  });
+
+  /* ── KEYBOARD NAVIGATION ───────────────────────────────────── */
+  function currentModuleIndex() {
+    const scrollMid = window.scrollY + window.innerHeight / 2;
+    for (let i = 0; i < modules.length; i++) {
+      const top    = modules[i].offsetTop;
+      const bottom = top + modules[i].offsetHeight;
+      if (scrollMid >= top && scrollMid < bottom) return i;
+    }
+    return 0;
+  }
+
+  document.addEventListener('keydown', e => {
+    if (['INPUT', 'TEXTAREA', 'SELECT'].includes(e.target.tagName)) return;
+    if (e.key === 'ArrowDown' || e.key === 'ArrowRight') {
+      const next = modules[currentModuleIndex() + 1];
+      if (next) { next.scrollIntoView({ behavior: 'smooth' }); e.preventDefault(); }
+    }
+    if (e.key === 'ArrowUp' || e.key === 'ArrowLeft') {
+      const prev = modules[currentModuleIndex() - 1];
+      if (prev) { prev.scrollIntoView({ behavior: 'smooth' }); e.preventDefault(); }
+    }
+  });
+
+  /* ── SCROLL-TRIGGERED REVEAL ───────────────────────────────── */
+  const revealObserver = new IntersectionObserver(entries => {
+    entries.forEach(entry => {
+      if (entry.isIntersecting) {
+        entry.target.classList.add('visible');
+        revealObserver.unobserve(entry.target);
+      }
+    });
+  }, { rootMargin: '0px 0px -8% 0px', threshold: 0.08 });
+
+  $$('.animate-in').forEach(el => revealObserver.observe(el));
+
+  // Stagger children
+  $$('.stagger-children').forEach(parent => {
+    Array.from(parent.children).forEach((child, i) => {
+      child.style.setProperty('--stagger-index', i);
+    });
+  });
+
+  /* ── GLOSSARY TOOLTIPS ─────────────────────────────────────── */
+  let activeTooltip = null;
+
+  function positionTooltip(term, tip) {
+    const rect     = term.getBoundingClientRect();
+    const tipWidth = Math.min(320, Math.max(200, window.innerWidth * 0.8));
+    let left = rect.left + rect.width / 2 - tipWidth / 2;
+    left = Math.max(8, Math.min(left, window.innerWidth - tipWidth - 8));
+    tip.style.left  = left + 'px';
+    tip.style.width = tipWidth + 'px';
+    document.body.appendChild(tip);
+    const tipHeight = tip.offsetHeight;
+    if (rect.top - tipHeight - 12 < 0) {
+      tip.style.top = (rect.bottom + 8) + 'px';
+      tip.classList.add('flip');
+    } else {
+      tip.style.top = (rect.top - tipHeight - 8) + 'px';
+      tip.classList.remove('flip');
+    }
+  }
+
+  function showTooltip(term, tip) {
+    if (activeTooltip && activeTooltip !== tip) {
+      activeTooltip.classList.remove('visible');
+      activeTooltip.remove();
+    }
+    positionTooltip(term, tip);
+    requestAnimationFrame(() => tip.classList.add('visible'));
+    activeTooltip = tip;
+  }
+
+  function hideTooltip(tip) {
+    tip.classList.remove('visible');
+    setTimeout(() => { if (!tip.classList.contains('visible')) tip.remove(); }, 150);
+    if (activeTooltip === tip) activeTooltip = null;
+  }
+
+  $$('.term').forEach(term => {
+    const tip = document.createElement('span');
+    tip.className = 'term-tooltip';
+    tip.textContent = term.dataset.definition;
+
+    term.addEventListener('mouseenter', () => showTooltip(term, tip));
+    term.addEventListener('mouseleave', () => hideTooltip(tip));
+    term.addEventListener('click', e => {
+      e.stopPropagation();
+      tip.classList.contains('visible') ? hideTooltip(tip) : showTooltip(term, tip);
+    });
+  });
+
+  document.addEventListener('click', () => {
+    if (activeTooltip) { activeTooltip.classList.remove('visible'); activeTooltip.remove(); activeTooltip = null; }
+  });
+
+  /* ── QUIZ ENGINE ───────────────────────────────────────────── */
+  window.selectOption = function (btn) {
+    const block = btn.closest('.quiz-question-block');
+    $$('.quiz-option', block).forEach(o => o.classList.remove('selected'));
+    btn.classList.add('selected');
+  };
+
+  window.checkQuiz = function (containerId) {
+    const container = $('#' + containerId);
+    if (!container) return;
+    $$('.quiz-question-block', container).forEach(q => {
+      const selected  = $('.quiz-option.selected', q);
+      const feedback  = $('.quiz-feedback', q);
+      const correct   = q.dataset.correct;
+      const rightExp  = q.dataset.explanationRight  || '';
+      const wrongExp  = q.dataset.explanationWrong  || '';
+
+      if (!selected) {
+        feedback.textContent = 'Pick an answer first!';
+        feedback.className = 'quiz-feedback show warning';
+        return;
+      }
+      $$('.quiz-option', q).forEach(o => o.disabled = true);
+
+      if (selected.dataset.value === correct) {
+        selected.classList.add('correct');
+        feedback.innerHTML = '<strong>Exactly!</strong> ' + rightExp;
+        feedback.className = 'quiz-feedback show success';
+      } else {
+        selected.classList.add('incorrect');
+        const correctBtn = $(`.quiz-option[data-value="${correct}"]`, q);
+        if (correctBtn) correctBtn.classList.add('correct');
+        feedback.innerHTML = '<strong>Not quite.</strong> ' + wrongExp;
+        feedback.className = 'quiz-feedback show error';
+      }
+    });
+  };
+
+  window.resetQuiz = function (containerId) {
+    const container = $('#' + containerId);
+    if (!container) return;
+    $$('.quiz-option', container).forEach(o => {
+      o.classList.remove('selected', 'correct', 'incorrect');
+      o.disabled = false;
+    });
+    $$('.quiz-feedback', container).forEach(f => { f.className = 'quiz-feedback'; f.textContent = ''; });
+  };
+
+  /* ── DRAG-AND-DROP ENGINE ──────────────────────────────────── */
+  function initDnD(containerEl) {
+    if (!containerEl) return;
+    const chips = $$('.dnd-chip', containerEl);
+    const zones = $$('.dnd-zone', containerEl);
+
+    // Mouse (HTML5 Drag API)
+    chips.forEach(chip => {
+      chip.addEventListener('dragstart', e => {
+        e.dataTransfer.setData('text/plain', chip.dataset.answer);
+        chip.classList.add('dragging');
+      });
+      chip.addEventListener('dragend', () => chip.classList.remove('dragging'));
+    });
+
+    zones.forEach(zone => {
+      const target = $('.dnd-zone-target', zone);
+      if (!target) return;
+      target.addEventListener('dragover',  e => { e.preventDefault(); target.classList.add('drag-over'); });
+      target.addEventListener('dragleave', ()  => target.classList.remove('drag-over'));
+      target.addEventListener('drop', e => {
+        e.preventDefault();
+        target.classList.remove('drag-over');
+        const answer = e.dataTransfer.getData('text/plain');
+        const chip   = $(`.dnd-chip[data-answer="${answer}"]`, containerEl);
+        if (!chip) return;
+        target.textContent    = chip.textContent;
+        target.dataset.placed = answer;
+        chip.classList.add('placed');
+      });
+    });
+
+    // Touch
+    chips.forEach(chip => {
+      chip.addEventListener('touchstart', e => {
+        e.preventDefault();
+        const touch = e.touches[0];
+        const ghost = chip.cloneNode(true);
+        ghost.classList.add('touch-ghost');
+        ghost.style.cssText = `position:fixed;z-index:9999;pointer-events:none;left:${touch.clientX - 40}px;top:${touch.clientY - 20}px;`;
+        document.body.appendChild(ghost);
+        chip._ghost  = ghost;
+        chip._answer = chip.dataset.answer;
+      }, { passive: false });
+
+      chip.addEventListener('touchmove', e => {
+        e.preventDefault();
+        const touch = e.touches[0];
+        if (chip._ghost) {
+          chip._ghost.style.left = (touch.clientX - 40) + 'px';
+          chip._ghost.style.top  = (touch.clientY - 20) + 'px';
+        }
+        zones.forEach(z => { const t = $('.dnd-zone-target', z); if (t) t.classList.remove('drag-over'); });
+        const el = document.elementFromPoint(touch.clientX, touch.clientY);
+        const zt = el && el.closest('.dnd-zone-target');
+        if (zt) zt.classList.add('drag-over');
+      }, { passive: false });
+
+      chip.addEventListener('touchend', e => {
+        if (chip._ghost) { chip._ghost.remove(); chip._ghost = null; }
+        const touch = e.changedTouches[0];
+        const el    = document.elementFromPoint(touch.clientX, touch.clientY);
+        const zt    = el && el.closest('.dnd-zone-target');
+        if (zt) {
+          zt.textContent    = chip.textContent;
+          zt.dataset.placed = chip._answer;
+          chip.classList.add('placed');
+        }
+        zones.forEach(z => { const t = $('.dnd-zone-target', z); if (t) t.classList.remove('drag-over'); });
+      });
+    });
+  }
+
+  window.checkDnD = function (containerId) {
+    const container = $('#' + containerId);
+    if (!container) return;
+    $$('.dnd-zone', container).forEach(zone => {
+      const target  = $('.dnd-zone-target', zone);
+      if (!target || !target.dataset.placed) return;
+      if (target.dataset.placed === zone.dataset.correct) {
+        target.classList.add('correct-placed');
+      } else {
+        target.classList.add('incorrect-placed');
+      }
+    });
+  };
+
+  window.resetDnD = function (containerId) {
+    const container = $('#' + containerId);
+    if (!container) return;
+    $$('.dnd-zone-target', container).forEach(t => {
+      t.textContent = 'Drop here';
+      delete t.dataset.placed;
+      t.classList.remove('correct-placed', 'incorrect-placed');
+    });
+    $$('.dnd-chip', container).forEach(c => c.classList.remove('placed', 'dragging'));
+  };
+
+  // Auto-init all dnd containers
+  $$('.dnd-container').forEach(el => initDnD(el));
+
+  /* ── GROUP CHAT ENGINE ─────────────────────────────────────── */
+  function initChat(containerEl) {
+    if (!containerEl) return;
+    const messages    = $$('.chat-message', containerEl);
+    const typingEl    = $('.chat-typing', containerEl);
+    const typingAvEl  = $('#' + containerEl.id + '-typing-avatar') || $('.chat-avatar', typingEl);
+    const progressEl  = $('.chat-progress', containerEl);
+    let index = 0;
+
+    // Build actor map from messages
+    const actors = {};
+    messages.forEach(msg => {
+      const sender = msg.dataset.sender;
+      const avatar = $('.chat-avatar', msg);
+      if (avatar && !actors[sender]) {
+        actors[sender] = { initial: avatar.textContent.trim(), style: avatar.style.background };
+      }
+    });
+
+    function updateProgress() {
+      if (progressEl) progressEl.textContent = index + ' / ' + messages.length + ' messages';
+    }
+
+    function showNext() {
+      if (index >= messages.length) return;
+      const msg    = messages[index];
+      const sender = msg.dataset.sender;
+
+      if (typingEl && actors[sender]) {
+        if (typingAvEl) {
+          typingAvEl.textContent       = actors[sender].initial;
+          typingAvEl.style.background  = actors[sender].style;
+        }
+        typingEl.style.display = 'flex';
+      }
+
+      setTimeout(() => {
+        if (typingEl) typingEl.style.display = 'none';
+        msg.style.display = 'flex';
+        msg.style.animation = 'fadeSlideUp 0.3s var(--ease-out)';
+        index++;
+        updateProgress();
+      }, 800);
+    }
+
+    function showAll() {
+      const iv = setInterval(() => {
+        if (index >= messages.length) { clearInterval(iv); return; }
+        showNext();
+      }, 1200);
+    }
+
+    function reset() {
+      index = 0;
+      messages.forEach(m => { m.style.display = 'none'; m.style.animation = ''; });
+      if (typingEl) typingEl.style.display = 'none';
+      updateProgress();
+    }
+
+    // Bind controls
+    const nextBtn  = $('.chat-next-btn',  containerEl);
+    const allBtn   = $('.chat-all-btn',   containerEl);
+    const resetBtn = $('.chat-reset-btn', containerEl);
+    if (nextBtn)  nextBtn.addEventListener('click',  showNext);
+    if (allBtn)   allBtn.addEventListener('click',   showAll);
+    if (resetBtn) resetBtn.addEventListener('click', reset);
+
+    updateProgress();
+  }
+
+  $$('.chat-window').forEach(el => initChat(el));
+
+  /* ── FLOW ANIMATION ENGINE ─────────────────────────────────── */
+  function initFlow(containerEl) {
+    if (!containerEl) return;
+    const stepsData  = JSON.parse(containerEl.dataset.steps || '[]');
+    const labelEl    = $('.flow-step-label', containerEl);
+    const progressEl = $('.flow-progress',   containerEl);
+    const packet     = $('.flow-packet',     containerEl);
+    let step = 0;
+
+    function updateProgress() {
+      if (progressEl) progressEl.textContent = 'Step ' + step + ' / ' + stepsData.length;
+    }
+
+    function animatePacket(fromId, toId) {
+      if (!packet) return;
+      const fromEl = $('#' + fromId);
+      const toEl   = $('#' + toId);
+      if (!fromEl || !toEl) return;
+      const fromR = fromEl.getBoundingClientRect();
+      const toR   = toEl.getBoundingClientRect();
+      const contR = containerEl.getBoundingClientRect();
+      const fx = fromR.left + fromR.width / 2  - contR.left;
+      const fy = fromR.top  + fromR.height / 2 - contR.top;
+      const tx = toR.left   + toR.width / 2    - contR.left;
+      const ty = toR.top    + toR.height / 2   - contR.top;
+      packet.style.setProperty('--packet-from-x', fx + 'px');
+      packet.style.setProperty('--packet-from-y', fy + 'px');
+      packet.style.setProperty('--packet-to-x',   tx + 'px');
+      packet.style.setProperty('--packet-to-y',   ty + 'px');
+      packet.style.display    = 'block';
+      packet.style.animation  = 'none';
+      packet.offsetHeight; // reflow
+      packet.style.animation  = 'packetMove 0.8s var(--ease-in-out) forwards';
+      setTimeout(() => { packet.style.display = 'none'; }, 850);
+    }
+
+    function next() {
+      if (step >= stepsData.length) return;
+      const s = stepsData[step];
+      $$('.flow-actor', containerEl).forEach(a => a.classList.remove('active'));
+      if (s.highlight) {
+        const hEl = $('#' + s.highlight, containerEl) || $('#flow-' + s.highlight);
+        if (hEl) hEl.classList.add('active');
+      }
+      if (s.packet && s.from && s.to) animatePacket('flow-' + s.from, 'flow-' + s.to);
+      if (labelEl) labelEl.textContent = s.label || '';
+      step++;
+      updateProgress();
+    }
+
+    function reset() {
+      step = 0;
+      $$('.flow-actor', containerEl).forEach(a => a.classList.remove('active'));
+      if (labelEl) labelEl.textContent = 'Click "Next Step" to begin';
+      if (packet)  packet.style.display = 'none';
+      updateProgress();
+    }
+
+    const nextBtn  = $('.flow-next-btn',  containerEl);
+    const resetBtn = $('.flow-reset-btn', containerEl);
+    if (nextBtn)  nextBtn.addEventListener('click',  next);
+    if (resetBtn) resetBtn.addEventListener('click', reset);
+
+    updateProgress();
+  }
+
+  $$('.flow-animation').forEach(el => initFlow(el));
+
+  /* ── ARCHITECTURE DIAGRAM ──────────────────────────────────── */
+  $$('.arch-component').forEach(comp => {
+    comp.addEventListener('click', function () {
+      const diagram = this.closest('.arch-diagram');
+      $$('.arch-component', diagram).forEach(c => c.classList.remove('active'));
+      this.classList.add('active');
+      const descEl = $('.arch-description', diagram);
+      if (descEl) descEl.textContent = this.dataset.desc || '';
+    });
+  });
+
+  /* ── BUG CHALLENGE ─────────────────────────────────────────── */
+  window.checkBugLine = function (el, isCorrect) {
+    const challenge = el.closest('.bug-challenge');
+    const feedback  = $('.bug-feedback', challenge);
+    if (isCorrect) {
+      el.classList.add('correct');
+      feedback.innerHTML  = '<strong>Found it!</strong> ' + (el.dataset.explanation || '');
+      feedback.className  = 'bug-feedback show success';
+      $$('.bug-line', challenge).forEach(l => l.style.pointerEvents = 'none');
+    } else {
+      el.classList.add('incorrect');
+      feedback.innerHTML  = (el.dataset.hint || 'Not this line — keep looking...');
+      feedback.className  = 'bug-feedback show error';
+      setTimeout(() => {
+        el.classList.remove('incorrect');
+        feedback.className = 'bug-feedback';
+      }, 1800);
+    }
+  };
+
+  /* ── LAYER TOGGLE ──────────────────────────────────────────── */
+  window.showLayer = function (layerId, btn) {
+    const demo = btn ? btn.closest('.layer-demo') : null;
+    if (!demo) return;
+    $$('.layer', demo).forEach(l => l.style.display = 'none');
+    $$('.layer-tab', demo).forEach(t => t.classList.remove('active'));
+    const layer = $('#' + layerId);
+    if (layer) layer.style.display = 'block';
+    btn.classList.add('active');
+  };
+
+})();

--- a/courses/image-generator-ui-course/modules/01-journey.html
+++ b/courses/image-generator-ui-course/modules/01-journey.html
@@ -1,0 +1,502 @@
+<section class="module" id="module-1" style="background: var(--color-bg-warm)">
+  <div class="module-content">
+
+    <header class="module-header animate-in">
+      <span class="module-number">01</span>
+      <h1 class="module-title">The Journey of One Photo</h1>
+      <p class="module-subtitle">You drop a photo onto the box and click Generate. For four seconds, nothing visible happens. Here is everything that happens in those four seconds.</p>
+    </header>
+
+    <div class="module-body">
+
+      <!-- ══════════════ SCREEN 1 ══════════════ -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">What this thing actually does</h2>
+
+        <p>Charlie &amp; Lola AI is a website with one job. You drag in a photo of yourself, or your dog, or a toy, and a few seconds later you get the same subject redrawn in the scratchy, flat-colour style of the British children's cartoon <em>Charlie and Lola</em>.</p>
+
+        <p>Then you download it, or copy a link to share it. That is the entire product.</p>
+
+        <div class="step-cards stagger-children">
+          <div class="step-card animate-in">
+            <div class="step-num">1</div>
+            <div class="step-body">
+              <strong>You drop in a photo</strong>
+              <p>A dashed box on the page accepts up to five images at once</p>
+            </div>
+          </div>
+          <div class="step-card animate-in">
+            <div class="step-num">2</div>
+            <div class="step-body">
+              <strong>You click Generate</strong>
+              <p>A spinner appears. Roughly four seconds pass.</p>
+            </div>
+          </div>
+          <div class="step-card animate-in">
+            <div class="step-num">3</div>
+            <div class="step-body">
+              <strong>A cartoon version appears</strong>
+              <p>Same subject, redrawn. Download it or copy the share link.</p>
+            </div>
+          </div>
+        </div>
+
+        <p>Everything in this course is about the machinery behind that one button — and about the visual building blocks the interface is made from.</p>
+
+        <h3 class="screen-heading">What it is built out of</h3>
+
+        <div class="icon-rows">
+          <div class="icon-row">
+            <div class="icon-circle" style="background: var(--color-actor-2)">🧱</div>
+            <div>
+              <strong>Next.js 15 + React</strong>
+              <p><span class="term" data-definition="Next.js is a framework — a big starter kit of pre-written code that handles the boring parts of building a website, like page addresses and talking to a server. You would say to an AI assistant: this is a Next.js app.">Next.js</span> is the website <span class="term" data-definition="A framework is a pre-built skeleton for an app. It already knows how to do the common jobs so you only write the parts unique to your product.">framework</span>; <span class="term" data-definition="React is the library that draws the screen. You describe what the page should look like for a given set of data, and React handles updating the actual pixels when that data changes.">React</span> draws what you see on screen.</p>
+            </div>
+          </div>
+          <div class="icon-row">
+            <div class="icon-circle" style="background: var(--color-actor-3)">🎨</div>
+            <div>
+              <strong>Tailwind CSS + Shadcn UI</strong>
+              <p><span class="term" data-definition="Tailwind CSS is a styling system where you set colours, spacing and sizes by adding short keyword labels directly onto an element, instead of writing separate style files.">Tailwind CSS</span> handles the looks; <span class="term" data-definition="Shadcn UI is a collection of ready-made interface pieces — buttons, sliders, dialogs — that you copy into your own project and then are free to edit.">Shadcn UI</span> supplies ready-made buttons, sliders and dialogs.</p>
+            </div>
+          </div>
+          <div class="icon-row">
+            <div class="icon-circle" style="background: var(--color-actor-4)">✏️</div>
+            <div>
+              <strong>Google Gemini</strong>
+              <p>The <span class="term" data-definition="A model is a trained AI system you send input to and get output back from. Gemini is Google&apos;s family of models; this app uses one that can look at a picture and draw a new one.">model</span> that does the actual drawing. It lives on Google's computers, not in this app.</p>
+            </div>
+          </div>
+        </div>
+
+        <p>This course has two halves: the <strong>generator engine</strong> (how a photo becomes a cartoon) and the <strong>interface</strong> it lives inside (how the page is assembled from reusable pieces). This module is the engine, end to end.</p>
+      </section>
+
+      <!-- ══════════════ SCREEN 2 ══════════════ -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">The seven stations</h2>
+
+        <p>Think of a one-hour photo lab. You hand your film over the counter, it disappears behind the wall into machines you never see, and twenty minutes later prints come back.</p>
+
+        <p>You have no idea what those machines do. But there <em>is</em> a fixed sequence back there, and every ruined photo has one specific station where it went wrong.</p>
+
+        <div class="callout callout-accent">
+          <div class="callout-icon">💡</div>
+          <div class="callout-content">
+            <strong class="callout-title">The key idea of this whole module</strong>
+            <p>A generation is not one magical event. It is a relay of seven hand-offs between separate pieces of software — three of which are not on your computer at all.</p>
+          </div>
+        </div>
+
+        <p>Press <strong>Next Step</strong> and walk behind the counter. Five machines, seven hand-offs.</p>
+
+        <div class="flow-animation" data-steps='[
+          {"highlight":"flow-actor-1","label":"You drop a photo onto the dashed box. The browser reads the file into one very long text string — a data URL. Nothing has left your computer yet."},
+          {"highlight":"flow-actor-2","label":"You click Generate. ImagenClient packs the photo plus your settings into a FormData parcel.","packet":true,"from":"actor-1","to":"actor-2"},
+          {"highlight":"flow-actor-3","label":"The parcel is POSTed to /api/generate-cyberpunk — the server that belongs to this app.","packet":true,"from":"actor-2","to":"actor-3"},
+          {"highlight":"flow-actor-3","label":"The server picks an unused Gemini API key from its pool, converts the photo to base64, and glues it to a written style instruction.","packet":true,"from":"actor-3","to":"actor-4"},
+          {"highlight":"flow-actor-4","label":"Gemini reads the picture and the instruction, then sends back a NEW picture — encoded as text.","packet":true,"from":"actor-4","to":"actor-3"},
+          {"highlight":"flow-actor-5","label":"The server uploads that picture to Cloudflare R2 storage and gets back a public web address.","packet":true,"from":"actor-3","to":"actor-5"},
+          {"highlight":"flow-actor-1","label":"The address travels back to the browser, lands in setGeneratedImage(...), and React repaints the right-hand panel.","packet":true,"from":"actor-3","to":"actor-1"}
+        ]'>
+          <div class="flow-actors">
+            <div class="flow-actor" id="flow-actor-1">
+              <div class="flow-actor-icon">🖱️</div>
+              <span>You<br>(the browser)</span>
+            </div>
+            <div class="flow-actor" id="flow-actor-2">
+              <div class="flow-actor-icon">📦</div>
+              <span>ImagenClient<br>(page code)</span>
+            </div>
+            <div class="flow-actor" id="flow-actor-3">
+              <div class="flow-actor-icon">⚙️</div>
+              <span>/api/generate-<br>cyberpunk</span>
+            </div>
+            <div class="flow-actor" id="flow-actor-4">
+              <div class="flow-actor-icon">✏️</div>
+              <span>Google<br>Gemini</span>
+            </div>
+            <div class="flow-actor" id="flow-actor-5">
+              <div class="flow-actor-icon">🗄️</div>
+              <span>Cloudflare R2<br>(storage)</span>
+            </div>
+          </div>
+
+          <div class="flow-packet" id="flow-packet"></div>
+
+          <div class="flow-step-label" id="flow-label">Click "Next Step" to begin</div>
+
+          <div class="flow-controls">
+            <button class="btn flow-next-btn">Next Step</button>
+            <button class="btn flow-reset-btn">Restart</button>
+            <span class="flow-progress"></span>
+          </div>
+        </div>
+
+        <p>Two of those five machines belong to other companies, reached over an <span class="term" data-definition="An API is the agreed list of requests one program is willing to accept from another — like a menu. Your server orders from Google&apos;s menu; your browser orders from your server&apos;s menu.">API</span>. Knowing the seven stations means that when something breaks, you can name the station instead of saying "the AI is broken."</p>
+
+        <div class="badge-list">
+          <div class="badge-item">
+            <code class="badge-code">the AI is broken</code>
+            <span class="badge-desc">What you get back: a shotgun of guesses from your AI coding assistant</span>
+          </div>
+          <div class="badge-item">
+            <code class="badge-code">the POST to /api/generate-cyberpunk returns fine but the preview stays empty</code>
+            <span class="badge-desc">What you get back: a fix</span>
+          </div>
+        </div>
+
+        <p>That second sentence is the actual skill this module teaches. Let us earn it, station by station.</p>
+      </section>
+
+      <!-- ══════════════ SCREEN 3 ══════════════ -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">Stations 1–2: the photo never leaves the page (yet)</h2>
+
+        <p>Here is the surprise. When you drop a photo on the box and the thumbnail appears instantly, <strong>nothing has been sent anywhere</strong>. Your film is still sitting on your side of the counter.</p>
+
+        <p>The <span class="term" data-definition="The browser is the program you are reading this in — Chrome, Safari, Firefox. It runs on your own machine and can only see what the page gives it.">browser</span> reads the file off your disk and turns it into text that the page can display immediately. That is stations 1 and 2, and they are entirely local.</p>
+
+        <div class="step-cards stagger-children">
+          <div class="step-card animate-in">
+            <div class="step-num">1</div>
+            <div class="step-body">
+              <strong>The file lands in the box</strong>
+              <p>Drag-and-drop, or the file picker — either way the browser hands over a File</p>
+            </div>
+          </div>
+          <div class="step-card animate-in">
+            <div class="step-num">2</div>
+            <div class="step-body">
+              <strong>FileReader converts it to text</strong>
+              <p>The picture becomes one enormous string of letters and numbers</p>
+            </div>
+          </div>
+          <div class="step-card animate-in">
+            <div class="step-num">3</div>
+            <div class="step-body">
+              <strong>The thumbnail appears</strong>
+              <p>That string can be pasted straight into an image tag, so the preview is instant</p>
+            </div>
+          </div>
+        </div>
+
+        <p>This is the <span class="term" data-definition="A function is a named chunk of code you can run on demand — like a recipe card. Point at it by name and it does its steps. Here, handleFileUpload runs every time a file arrives.">function</span> that does it, from the real file. Read the code on the left; the plain English on the right walks the same path.</p>
+
+        <div class="translation-block animate-in">
+          <div class="translation-code">
+            <span class="translation-label">src/components/blocks/imagen-wrapper/imagen-client.tsx</span>
+            <pre><code>  <span class="code-keyword">const</span> <span class="code-function">handleFileUpload</span> = (file: File) => {
+    <span class="code-keyword">if</span> (uploadedImages.length >= <span class="code-number">5</span>) {
+      toast.<span class="code-function">error</span>(t.upload.max_images_error);
+      <span class="code-keyword">return</span>;
+    }
+
+    <span class="code-keyword">const</span> reader = <span class="code-keyword">new</span> <span class="code-function">FileReader</span>();
+    reader.onload = (e) => {
+      <span class="code-keyword">const</span> imageData = e.target?.result <span class="code-keyword">as</span> <span class="code-keyword">string</span>;
+      <span class="code-function">setUploadedImages</span>(prev => [...prev, imageData]);
+      <span class="code-function">setGeneratedImage</span>(<span class="code-keyword">null</span>);
+    };
+    reader.<span class="code-function">readAsDataURL</span>(file);
+  };</code></pre>
+          </div>
+          <div class="translation-english">
+            <span class="translation-label">Plain English</span>
+            <div class="translation-lines">
+              <p class="tl">Whenever a file arrives, run these steps on it.</p>
+              <p class="tl">First, a bouncer check: if five pictures are already loaded, show a polite error and stop right here.</p>
+              <p class="tl">Otherwise, hire a FileReader — the browser's built-in tool for turning a file into something the page can use.</p>
+              <p class="tl">Reading takes a moment, so leave instructions for when it finishes: "when you're done, do this."</p>
+              <p class="tl">The finished result is a long text string. Grab it.</p>
+              <p class="tl">Add that string to the list of uploaded images, keeping the ones already there.</p>
+              <p class="tl">Clear any previous cartoon result, so the old output does not sit next to a new input.</p>
+              <p class="tl">And finally — the line that actually starts the work — read the file, as a data URL.</p>
+            </div>
+          </div>
+        </div>
+
+        <p>Two things in there are worth knowing by name.</p>
+
+        <div class="pattern-cards">
+          <div class="pattern-card" style="border-top: 3px solid var(--color-actor-2)">
+            <div class="pattern-icon" style="background: var(--color-actor-2)">📄</div>
+            <h4 class="pattern-title">data URL</h4>
+            <p class="pattern-desc">A <span class="term" data-definition="A data URL is a whole file — a picture, a sound — written out as one long line of text starting with data:image/png;base64,... It can be pasted anywhere a web address goes, and needs no server.">data URL</span> is the entire picture rewritten as text. It starts <code class="badge-code">data:image/png;base64,</code> and runs for thousands of characters.</p>
+          </div>
+          <div class="pattern-card" style="border-top: 3px solid var(--color-actor-3)">
+            <div class="pattern-icon" style="background: var(--color-actor-3)">🧠</div>
+            <h4 class="pattern-title">state</h4>
+            <p class="pattern-desc"><code class="badge-code">setUploadedImages</code> updates the <span class="term" data-definition="A component is one reusable chunk of interface — a button, an upload box, a whole panel — with its own code and its own memory. Pages are built by nesting components inside each other.">component</span>'s <span class="term" data-definition="State is a component&apos;s memory — the current values it is holding, like which images are loaded. Change the state and React automatically redraws the parts of the screen that depend on it.">state</span>. Change state, and React repaints the screen for you.</p>
+          </div>
+        </div>
+
+        <div class="callout callout-accent">
+          <div class="callout-icon">✨</div>
+          <div class="callout-content">
+            <strong class="callout-title">Aha: an image is just text if you squint</strong>
+            <p><span class="term" data-definition="Base64 is a way of rewriting any file using only ordinary letters, digits and a couple of symbols. Nothing is lost — it just gets about a third longer — so files can travel down pipes built for text.">Base64</span> and data URLs mean the exact same picture can travel as a string of letters through channels that only carry text. That is why an AI service can hand a picture back to you over a plain text connection.</p>
+          </div>
+        </div>
+      </section>
+
+      <!-- ══════════════ SCREEN 4 ══════════════ -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">Station 3: packing the parcel</h2>
+
+        <p>You click Generate. Now the film goes over the counter — and this is the moment the photo leaves your computer.</p>
+
+        <p>The page's code gathers the <span class="term" data-definition="An upload is the act of sending a file from your own machine to a server. Until that moment, the file is only ever on your side.">uploaded</span> images and every setting into one parcel, then hands it to the app's own <span class="term" data-definition="A server is a computer that belongs to the app, running somewhere in a data centre, that your browser sends requests to. It can hold secrets your browser never sees.">server</span>.</p>
+
+        <div class="translation-block animate-in">
+          <div class="translation-code">
+            <span class="translation-label">imagen-client.tsx · generateImage()</span>
+            <pre><code>      <span class="code-keyword">const</span> formData = <span class="code-keyword">new</span> <span class="code-function">FormData</span>();
+
+      formData.<span class="code-function">append</span>(<span class="code-string">'mode'</span>, <span class="code-string">'image2image'</span>);
+      formData.<span class="code-function">append</span>(<span class="code-string">'style'</span>, <span class="code-string">'charlie-lola'</span>); <span class="code-comment">// Fixed style for Charlie and Lola</span>
+      formData.<span class="code-function">append</span>(<span class="code-string">'aspectRatio'</span>, aspectRatio);
+      formData.<span class="code-function">append</span>(<span class="code-string">'outputFormat'</span>, outputFormat);
+      formData.<span class="code-function">append</span>(<span class="code-string">'model'</span>, <span class="code-string">'standard'</span>); <span class="code-comment">// Fixed model</span>
+
+      <span class="code-keyword">if</span> (customPrompt.<span class="code-function">trim</span>()) {
+        formData.<span class="code-function">append</span>(<span class="code-string">'customPrompt'</span>, customPrompt);
+      }
+
+      <span class="code-keyword">for</span> (<span class="code-keyword">let</span> i = <span class="code-number">0</span>; i &lt; uploadedImages.length; i++) {
+        <span class="code-keyword">const</span> response = <span class="code-keyword">await</span> <span class="code-function">fetch</span>(uploadedImages[i]);
+        <span class="code-keyword">const</span> blob = <span class="code-keyword">await</span> response.<span class="code-function">blob</span>();
+        formData.<span class="code-function">append</span>(<span class="code-string">`image_${i}`</span>, blob);
+      }
+
+      formData.<span class="code-function">append</span>(<span class="code-string">'imageCount'</span>, uploadedImages.length.<span class="code-function">toString</span>());
+
+      <span class="code-keyword">const</span> apiResponse = <span class="code-keyword">await</span> <span class="code-function">fetch</span>(<span class="code-string">'/api/generate-cyberpunk'</span>, {
+        <span class="code-property">method</span>: <span class="code-string">'POST'</span>,
+        <span class="code-property">body</span>: formData,
+      });</code></pre>
+          </div>
+          <div class="translation-english">
+            <span class="translation-label">Plain English</span>
+            <div class="translation-lines">
+              <p class="tl">Get an empty parcel. <span class="term" data-definition="FormData is a container for sending a mixed bag of things to a server in one go — text settings and real files side by side. It is the same machinery a normal web form uses when you attach a file.">FormData</span> can hold text labels and real files side by side.</p>
+              <p class="tl">Label it: we are turning an image into another image, not writing one from scratch.</p>
+              <p class="tl">Hard-code the style to charlie-lola. This app only makes one look, so this is never a choice the visitor makes.</p>
+              <p class="tl">Attach the shape you picked (square, portrait) and the file type you want back.</p>
+              <p class="tl">Hard-code the quality tier too — another decision the app makes for you.</p>
+              <p class="tl">If you typed anything into the extra-instructions box, and it is not just blank spaces, include it.</p>
+              <p class="tl">Now for the pictures. Walk through the uploaded ones, one at a time.</p>
+              <p class="tl">Remember each one is currently a long text string. Read that string back...</p>
+              <p class="tl">...and turn it into a <span class="term" data-definition="A blob is a raw lump of file data — the actual bytes of a picture — as opposed to a description of it. Servers want the bytes.">blob</span>: the real bytes of the file, rather than the text version.</p>
+              <p class="tl">Drop it into the parcel under a numbered name: image_0, image_1, and so on.</p>
+              <p class="tl">Note down how many pictures are in there, so the server does not have to guess.</p>
+              <p class="tl">Then hand the parcel over the counter — to <code class="badge-code">/api/generate-cyberpunk</code>, the app's own <span class="term" data-definition="An endpoint is one specific address on a server that does one specific job. /api/generate-cyberpunk is the address for &quot;make me a picture&quot;.">endpoint</span>.</p>
+              <p class="tl"><span class="term" data-definition="POST means &quot;here is some data, please do something with it&quot;, as opposed to GET which means &quot;please send me something&quot;. Uploads are always POST.">POST</span> means we are sending something, not just asking for something.</p>
+              <p class="tl">And the parcel itself is the body of the request.</p>
+            </div>
+          </div>
+        </div>
+
+        <p>Notice what is in the parcel: five text settings, then the images themselves. One container, two very different kinds of cargo.</p>
+
+        <div class="badge-list">
+          <div class="badge-item">
+            <code class="badge-code">mode</code>
+            <span class="badge-desc">image2image — start from a picture, do not invent one from words alone</span>
+          </div>
+          <div class="badge-item">
+            <code class="badge-code">style</code>
+            <span class="badge-desc">Always charlie-lola. Hard-coded, not a setting the visitor can change</span>
+          </div>
+          <div class="badge-item">
+            <code class="badge-code">aspectRatio</code>
+            <span class="badge-desc">The shape of the result — square, portrait, landscape</span>
+          </div>
+          <div class="badge-item">
+            <code class="badge-code">outputFormat</code>
+            <span class="badge-desc">Which kind of image file you get back</span>
+          </div>
+          <div class="badge-item">
+            <code class="badge-code">customPrompt</code>
+            <span class="badge-desc">Optional extra wording from you — only included if you actually typed something</span>
+          </div>
+          <div class="badge-item">
+            <code class="badge-code">image_0 … image_4</code>
+            <span class="badge-desc">The pictures, as real file data</span>
+          </div>
+        </div>
+
+        <div class="callout callout-info">
+          <div class="callout-icon">😅</div>
+          <div class="callout-content">
+            <strong class="callout-title">Yes, it says "cyberpunk"</strong>
+            <p>The <span class="term" data-definition="A route is a file on the server that handles requests to one address. In this app, src/app/api/generate-cyberpunk/route.ts is the file behind /api/generate-cyberpunk.">route</span> is called <code class="badge-code">/api/generate-cyberpunk</code> even though the app makes children's-book art. It is a leftover name from the template this app was built from. Module 5 takes stale naming seriously — for now, just enjoy it.</p>
+          </div>
+        </div>
+      </section>
+
+      <!-- ══════════════ SCREEN 5 ══════════════ -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">Stations 6–7: the picture comes back as text</h2>
+
+        <p>Behind the wall, Gemini has drawn something. It cannot post you a photograph down a wire, so it sends the picture the only way a text connection allows: as base64.</p>
+
+        <p>The server gives it a name and, if all else fails, wraps it straight back up as a data URL.</p>
+
+        <div class="translation-block animate-in">
+          <div class="translation-code">
+            <span class="translation-label">src/app/api/generate-cyberpunk/route.ts</span>
+            <pre><code>    <span class="code-comment">// Generate filename and store the image</span>
+    <span class="code-keyword">const</span> batch = <span class="code-function">getUuid</span>();
+    <span class="code-keyword">const</span> fileExtension = generatedImageMimeType.<span class="code-function">split</span>(<span class="code-string">'/'</span>)[<span class="code-number">1</span>];
+    <span class="code-keyword">const</span> filename = <span class="code-string">`charlie-lola-${batch}.${fileExtension}`</span>;
+
+    <span class="code-keyword">let</span> finalImageUrl = <span class="code-string">`data:${generatedImageMimeType};base64,${generatedImageData}`</span>;</code></pre>
+          </div>
+          <div class="translation-english">
+            <span class="translation-label">Plain English</span>
+            <div class="translation-lines">
+              <p class="tl">A note-to-self in the code, for whoever reads it next.</p>
+              <p class="tl">Mint a <span class="term" data-definition="A UUID is a long random ID like 3f2a-9c1b-… that is effectively guaranteed never to repeat. Handy when you need a unique filename and nobody is keeping a list.">unique ID</span> so this result gets a filename nobody else will ever collide with.</p>
+              <p class="tl">Gemini told us the picture is, say, image/png. Chop that in half and keep the second bit: png. That is the <span class="term" data-definition="A MIME type is a short label that says what kind of file something is — image/png, image/jpeg, application/json. Servers use it to know how to treat the data.">MIME type</span> becoming a file extension.</p>
+              <p class="tl">Glue them together: charlie-lola-3f2a9c1b.png.</p>
+              <p class="tl">And build a fallback address — the whole picture as a data URL — so there is always something to show, even before it reaches <span class="term" data-definition="A storage bucket is a folder in the cloud with a public web address. Cloudflare R2 is one such service — upload a file, get back a link anyone can open.">cloud storage</span>.</p>
+            </div>
+          </div>
+        </div>
+
+        <p>Whatever address wins — the storage link or the data URL — it travels back to the browser wrapped in <span class="term" data-definition="JSON is a plain-text way of writing structured data: labels and values in curly brackets. It is how a server and a browser most commonly talk.">JSON</span>. And then station 7 is four lines long.</p>
+
+        <div class="translation-block animate-in">
+          <div class="translation-code">
+            <span class="translation-label">imagen-client.tsx · back in the browser</span>
+            <pre><code>      <span class="code-keyword">const</span> result = <span class="code-keyword">await</span> apiResponse.<span class="code-function">json</span>();
+
+      <span class="code-keyword">if</span> (result.code === <span class="code-number">0</span> &amp;&amp; result.data?.imageUrl) {
+        <span class="code-function">setGeneratedImage</span>(result.data.imageUrl);
+</code></pre>
+          </div>
+          <div class="translation-english">
+            <span class="translation-label">Plain English</span>
+            <div class="translation-lines">
+              <p class="tl">Unwrap the <span class="term" data-definition="A response is what a server sends back after you ask it something: a status, plus usually some data. Getting a response does not by itself mean the answer was a good one.">response</span> from the server and read what is inside.</p>
+              <p class="tl">Two conditions, both of which must hold: the app's own status code says all-clear (zero means fine here), AND there is genuinely an image address in the reply.</p>
+              <p class="tl">Only then, put that address into state — and React repaints the right-hand panel with your cartoon.</p>
+            </div>
+          </div>
+        </div>
+
+        <p>Worth pausing on: the server can reply perfectly well and still be reporting a failure <em>inside</em> the message. "The request succeeded" and "the image appeared" are two separate claims.</p>
+
+        <h3 class="screen-heading">Name the station</h3>
+
+        <p>Three situations. In each one, work out which station is involved before you pick — that is the whole exercise.</p>
+
+        <div class="quiz-container" id="quiz-module1">
+
+          <div class="quiz-question-block"
+               data-correct="local-only"
+               data-explanation-right="Exactly. FileReader runs entirely inside the browser, on your own machine. Stations 1 and 2 never touch the internet — which is why the thumbnail is instant and works offline. The photo only crosses the counter at station 3."
+               data-explanation-wrong="Not quite — think about where the work happened. The thumbnail comes from FileReader turning the file into a data URL, and that all happens inside the browser on the visitor&apos;s own machine. No wifi needed. Nothing crosses the counter until the Generate click at station 3.">
+            <div class="scenario-block">
+              <div class="scenario-context">
+                <span class="scenario-label">Scenario</span>
+                <p>Someone tells you: "I dropped my photo in and the thumbnail appeared instantly — and my wifi was off at the time." Is that possible, and what does it tell you?</p>
+              </div>
+            </div>
+            <h3 class="quiz-question">Which stations had already run?</h3>
+            <div class="quiz-options">
+              <button class="quiz-option" data-value="local-only" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>Only 1 and 2 — reading the file into a data URL is entirely local, so it works with no connection at all</span>
+              </button>
+              <button class="quiz-option" data-value="through-server" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>1 through 3 — the thumbnail is proof the server received the upload and sent a preview back</span>
+              </button>
+              <button class="quiz-option" data-value="impossible" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>None — a thumbnail cannot appear without a connection, so they must be misremembering</span>
+              </button>
+            </div>
+            <div class="quiz-feedback"></div>
+          </div>
+
+          <div class="quiz-question-block"
+               data-correct="response-handling"
+               data-explanation-right="Right. The parcel went out and came back with an address in it, so stations 3 through 6 all did their jobs. What is left is station 7 — the check on result.code and the handing-off to setGeneratedImage. Naming that narrows the search from a whole app to a few lines."
+               data-explanation-wrong="Have another think about what the successful response proves. If the reply already contains an imageUrl, then the parcel arrived, Gemini drew something, and storage handed back an address — stations 3 to 6 are all fine. The only station left is the browser deciding what to do with that reply.">
+            <div class="scenario-block">
+              <div class="scenario-context">
+                <span class="scenario-label">Scenario</span>
+                <p>The preview panel stays stubbornly empty. But you look at the browser's <span class="term" data-definition="The network tab is a built-in browser panel that lists every request the page made and what came back. It is the single most useful place to look when something will not load.">network tab</span> and the POST to <code class="badge-code">/api/generate-cyberpunk</code> came back successfully, with an <code class="badge-code">imageUrl</code> right there in the reply.</p>
+              </div>
+            </div>
+            <h3 class="quiz-question">Where do you look first?</h3>
+            <div class="quiz-options">
+              <button class="quiz-option" data-value="gemini" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>Google Gemini — the model probably returned something malformed</span>
+              </button>
+              <button class="quiz-option" data-value="response-handling" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>Station 7 — how the browser handles the reply, starting with the <code class="badge-code">result.code === 0</code> check</span>
+              </button>
+              <button class="quiz-option" data-value="storage" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>Cloudflare R2 — the file never really made it into storage</span>
+              </button>
+            </div>
+            <div class="quiz-feedback"></div>
+          </div>
+
+          <div class="quiz-question-block"
+               data-correct="server-and-gemini"
+               data-explanation-right="Yes. The upload side already handles up to five images, and the panel already knows how to show a result. The real change is on the server: calling Gemini more than once and returning several addresses instead of one — which then makes the results panel plural."
+               data-explanation-wrong="Look at what already exists before assuming everything must change. handleFileUpload already accepts up to five images, so the drop box is not the bottleneck. The station that has to genuinely change shape is the one that talks to Gemini and decides what comes back.">
+            <div class="scenario-block">
+              <div class="scenario-context">
+                <span class="scenario-label">Scenario</span>
+                <p>You want to add a feature: "generate three variations at once." You are about to describe it to your AI coding assistant and want to point it at the right place.</p>
+              </div>
+            </div>
+            <h3 class="quiz-question">Which station's shape changes most?</h3>
+            <div class="quiz-options">
+              <button class="quiz-option" data-value="upload-ui" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>The upload box — it would need to accept multiple files for the first time</span>
+              </button>
+              <button class="quiz-option" data-value="server-and-gemini" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>The server route and its call to Gemini — it has to ask for several pictures and return several addresses</span>
+              </button>
+              <button class="quiz-option" data-value="filereader" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>FileReader — it would need to read each file three separate times</span>
+              </button>
+            </div>
+            <div class="quiz-feedback"></div>
+          </div>
+
+          <button class="quiz-check-btn" onclick="checkQuiz('quiz-module1')">Check Answers</button>
+          <button class="quiz-reset-btn" onclick="resetQuiz('quiz-module1')">Try Again</button>
+        </div>
+
+        <h3 class="screen-heading">Next: the line that station 3 crossed</h3>
+
+        <p>Look back at the seven stations. Stations 1 and 2 ran on your machine. Stations 4, 5 and 6 ran on machines owned by Google and Cloudflare.</p>
+
+        <p>Somewhere in the middle, station 3 crossed a line — and one of the things that stayed on the far side of it was the <span class="term" data-definition="An API key is a secret password that identifies your app to an outside service like Google. Anyone holding it can spend your money, which is why it must never reach a visitor&apos;s browser.">API key</span>.</p>
+
+        <div class="callout callout-info">
+          <div class="callout-icon">🚪</div>
+          <div class="callout-content">
+            <strong class="callout-title">Coming up in Module 2 — Front of House, Backstage</strong>
+            <p>Which of these stations run in the visitor's browser, which run on the company's server, and why the API key can only ever live on one side. That line is the single most important thing to understand about this app.</p>
+          </div>
+        </div>
+      </section>
+
+    </div>
+  </div>
+</section>

--- a/courses/image-generator-ui-course/modules/02-actors.html
+++ b/courses/image-generator-ui-course/modules/02-actors.html
@@ -1,0 +1,611 @@
+<section class="module" id="module-2">
+  <div class="module-content">
+
+    <header class="module-header animate-in">
+      <span class="module-number">02</span>
+      <h1 class="module-title">Front of House, Backstage</h1>
+      <p class="module-subtitle">Every file in this app runs on one of two machines. Here's the wall between them — and how to tell, at a glance, which side any file is on.</p>
+    </header>
+
+    <div class="module-body">
+
+      <!-- ══════════════ SCREEN 1 — THE HOOK ══════════════ -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">The key that pays for everything</h2>
+
+        <p>The <span class="term" data-definition="An API key is a long secret password that identifies your account to an outside service. Whoever holds it can spend your money on that service — so it is treated like a credit card number.">API key</span> that pays Google for every image this app generates is sitting in a file right now. If it ever reached a visitor's <span class="term" data-definition="The browser is the program a visitor uses to view websites — Chrome, Safari, Firefox. It runs on their computer, which means they can inspect and change anything inside it.">browser</span>, a stranger could run up the bill on somebody else's card.</p>
+
+        <p>Module 1 followed one photo from the upload box to the moment it crossed from the browser to the <span class="term" data-definition="A server is a computer the company owns and runs, sitting in a data centre somewhere. Visitors never touch it directly — they can only send it requests and read what it chooses to send back.">server</span>. This module is about that crossing itself: what it is, why it exists, and how to tell which side of it you're standing on.</p>
+
+        <div class="callout callout-warning">
+          <div class="callout-icon">⚠️</div>
+          <div class="callout-content">
+            <strong class="callout-title">This is the #1 thing AI coding assistants get wrong</strong>
+            <p>Ask an AI for a feature in a <span class="term" data-definition="Next.js is the framework this app is built on — a big pre-made toolkit for building websites with React. It is the thing that decides which of your files run on the server and which get sent to browsers.">Next.js</span> app and it will happily put browser-only code in a server file, or read a secret in a browser file. The errors that come back are famously baffling — "useState is not a function", "<span class="term" data-definition="Hydration is the moment the browser takes the finished page the server sent and wires the buttons up so they actually work. A hydration mismatch means the server and the browser disagreed about what the page should say.">hydration</span> mismatch". Spotting the side a file belongs to lets you correct it in one sentence instead of ten rounds of guessing.</p>
+          </div>
+        </div>
+      </section>
+
+      <!-- ══════════════ SCREEN 2 — THE METAPHOR ══════════════ -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">A theatre has two halves</h2>
+
+        <p>Front of house is what the audience sees: the stage, the actors, the programme in their hands. Backstage is the fly system, the lighting desk, and the safe in the manager's office with the keys in it.</p>
+
+        <p>The audience can walk right up to the edge of the stage. They can never walk into that office. That single fact is the whole architecture of this app.</p>
+
+        <div class="icon-rows stagger-children">
+          <div class="icon-row animate-in">
+            <div class="icon-circle" style="background: var(--color-actor-3)">🎭</div>
+            <div>
+              <strong>Front of house = the visitor's browser</strong>
+              <p>Buttons, drag-and-drop, spinners, previews. Everything here was shipped to a stranger's laptop, and a stranger can read every line of it.</p>
+            </div>
+          </div>
+          <div class="icon-row animate-in">
+            <div class="icon-circle" style="background: var(--color-actor-5)">🔐</div>
+            <div>
+              <strong>Backstage = the company's server</strong>
+              <p>Translation files, database lookups, the API keys. Nothing here is ever sent out — only the <em>results</em> of what happens here.</p>
+            </div>
+          </div>
+          <div class="icon-row animate-in">
+            <div class="icon-circle" style="background: var(--color-accent)">🚪</div>
+            <div>
+              <strong>The stage door = one line of text</strong>
+              <p>A file that starts with <code class="badge-code">'use client'</code> is front of house. A file without it stays backstage. That's it — that's the whole mechanism.</p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- ══════════════ SCREEN 3 — THE CAST ══════════════ -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">Meet the cast</h2>
+
+        <p>Five files do almost all the work in this feature. Click any of them to hear what they do — and notice which side of the wall each one lives on.</p>
+
+        <div class="arch-diagram">
+          <h4 class="arch-zone-label">🎭 Front of house — the visitor's browser · anyone can read this</h4>
+          <div class="arch-zone">
+            <div class="arch-component" data-desc="ImagenClient (imagen-client.tsx, 893 lines) — everything you can touch: drag-and-drop, image previews, the Generate button, spinners, toasts, and remembering your last settings. It runs on a stranger's laptop, so it gets no secrets and no direct line to Google.">
+              <div class="arch-icon">🖐️</div>
+              <span>ImagenClient</span>
+            </div>
+          </div>
+
+          <h4 class="arch-zone-label">🚪 ── the stage door: <code>'use client'</code> ──</h4>
+
+          <h4 class="arch-zone-label">🔐 Backstage — the company's server · nobody outside can look in</h4>
+          <div class="arch-zone">
+            <div class="arch-component" data-desc="The Page (page.tsx) — the homepage itself. It renders the generator at the top plus about ten marketing sections below it. It runs entirely on the server and only its finished HTML is sent out.">
+              <div class="arch-icon">📄</div>
+              <span>The Page</span>
+            </div>
+            <div class="arch-component" data-desc="ImagenWrapper (index.tsx) — looks up every piece of English or Chinese text the generator needs, bundles it into one plain object, and hands it down to ImagenClient. Nothing interactive, no buttons — just fetching words.">
+              <div class="arch-icon">🎁</div>
+              <span>ImagenWrapper</span>
+            </div>
+            <div class="arch-component" data-desc="The route (api/generate-cyberpunk/route.ts) — the only door between the two worlds. It checks who you are, spends your credits, calls Gemini, and stores the result. Every request from the browser comes through here or not at all.">
+              <div class="arch-icon">🚦</div>
+              <span>The route</span>
+            </div>
+            <div class="arch-component" data-desc="The key pool (gemini-api-pool.ts) — holds the Gemini API keys read from the server's environment. It never leaves the building, and Module 3 covers how it rotates between up to six of them.">
+              <div class="arch-icon">🗝️</div>
+              <span>The key pool</span>
+            </div>
+          </div>
+
+          <div class="arch-description">Click any actor to see what it does.</div>
+        </div>
+      </section>
+
+      <!-- ══════════════ SCREEN 4 — HERO: GROUP CHAT ══════════════ -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">The backstage group chat</h2>
+
+        <p>Here's what those five say to each other in the half-second after a visitor loads the homepage. Play it through — the last four messages are the whole point of this module.</p>
+
+        <div class="chat-window" id="chat-module2">
+          <div class="chat-messages">
+
+            <div class="chat-message" data-msg="0" data-sender="page" style="display:none">
+              <div class="chat-avatar" style="background: var(--color-actor-1)">P</div>
+              <div class="chat-bubble">
+                <span class="chat-sender" style="color: var(--color-actor-1)">The Page</span>
+                <p>Visitor incoming, <span class="term" data-definition="A locale is the code for a visitor's language and region — 'en' for English, 'zh' for Chinese. The app uses it to decide which set of words to show.">locale</span> <code>en</code>. Wrapper, you're up.</p>
+              </div>
+            </div>
+
+            <div class="chat-message" data-msg="1" data-sender="wrapper" style="display:none">
+              <div class="chat-avatar" style="background: var(--color-actor-2)">W</div>
+              <div class="chat-bubble">
+                <span class="chat-sender" style="color: var(--color-actor-2)">ImagenWrapper</span>
+                <p>On it. Pulling all 40-odd strings from the <code>imagen</code> <span class="term" data-definition="A namespace is a labelled drawer that keeps names from colliding. All the text for the image generator lives in the 'imagen' drawer, so its 'title' does not clash with the pricing page's 'title'.">namespace</span>… badge, title, upload prompts, error messages. Bundling.</p>
+              </div>
+            </div>
+
+            <div class="chat-message" data-msg="2" data-sender="client" style="display:none">
+              <div class="chat-avatar" style="background: var(--color-actor-3)">C</div>
+              <div class="chat-bubble">
+                <span class="chat-sender" style="color: var(--color-actor-3)">ImagenClient</span>
+                <p>Just send me the finished words. I can't read translation files — I run on a stranger's laptop.</p>
+              </div>
+            </div>
+
+            <div class="chat-message" data-msg="3" data-sender="wrapper" style="display:none">
+              <div class="chat-avatar" style="background: var(--color-actor-2)">W</div>
+              <div class="chat-bubble">
+                <span class="chat-sender" style="color: var(--color-actor-2)">ImagenWrapper</span>
+                <p>Here. One plain object, already in English. 📦 <code>translations</code></p>
+              </div>
+            </div>
+
+            <div class="chat-message" data-msg="4" data-sender="client" style="display:none">
+              <div class="chat-avatar" style="background: var(--color-actor-3)">C</div>
+              <div class="chat-bubble">
+                <span class="chat-sender" style="color: var(--color-actor-3)">ImagenClient</span>
+                <p>Great. I'll take it from here — drag-and-drop, previews, the button. Route, stand by.</p>
+              </div>
+            </div>
+
+            <div class="chat-message" data-msg="5" data-sender="route" style="display:none">
+              <div class="chat-avatar" style="background: var(--color-actor-4)">R</div>
+              <div class="chat-bubble">
+                <span class="chat-sender" style="color: var(--color-actor-4)">The route</span>
+                <p>Standing by. Nobody talks to Gemini except me.</p>
+              </div>
+            </div>
+
+            <div class="chat-message" data-msg="6" data-sender="client" style="display:none">
+              <div class="chat-avatar" style="background: var(--color-actor-3)">C</div>
+              <div class="chat-bubble">
+                <span class="chat-sender" style="color: var(--color-actor-3)">ImagenClient</span>
+                <p>Can I just have the API key? It'd save a round trip.</p>
+              </div>
+            </div>
+
+            <div class="chat-message" data-msg="7" data-sender="keypool" style="display:none">
+              <div class="chat-avatar" style="background: var(--color-actor-5)">K</div>
+              <div class="chat-bubble">
+                <span class="chat-sender" style="color: var(--color-actor-5)">The key pool</span>
+                <p>Absolutely not. 😊</p>
+              </div>
+            </div>
+
+            <div class="chat-message" data-msg="8" data-sender="route" style="display:none">
+              <div class="chat-avatar" style="background: var(--color-actor-4)">R</div>
+              <div class="chat-bubble">
+                <span class="chat-sender" style="color: var(--color-actor-4)">The route</span>
+                <p>It'd be in the <span class="term" data-definition="Page source is the raw text of a web page. Right-click any website and choose View Page Source to see it — everything the site sent your browser, secrets included, if anyone was careless enough to send one.">page source</span> in about four seconds. Send me the photo, I'll send you a picture.</p>
+              </div>
+            </div>
+
+          </div>
+
+          <div class="chat-typing" id="chat-module2-typing" style="display:none">
+            <div class="chat-avatar" id="chat-module2-typing-avatar">?</div>
+            <div class="chat-typing-dots">
+              <span class="typing-dot"></span>
+              <span class="typing-dot"></span>
+              <span class="typing-dot"></span>
+            </div>
+          </div>
+
+          <div class="chat-controls">
+            <button class="btn chat-next-btn">Next Message</button>
+            <button class="btn btn-primary chat-all-btn">Play All</button>
+            <button class="btn chat-reset-btn">Replay</button>
+            <span class="chat-progress"></span>
+          </div>
+        </div>
+
+        <div class="callout callout-accent">
+          <div class="callout-icon">💡</div>
+          <div class="callout-content">
+            <strong class="callout-title">Aha — the browser is a hostile environment you don't control</strong>
+            <p>Everything you send to a browser can be read, edited and replayed by whoever's holding the laptop. The client/server line isn't bureaucracy — it's the only place a secret can actually hide.</p>
+          </div>
+        </div>
+      </section>
+
+      <!-- ══════════════ SCREEN 5 — THE STAGE DOOR ══════════════ -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">The stage door is one line long</h2>
+
+        <p>This is the top of <code class="badge-code">imagen-client.tsx</code>, the 893-line file behind every button in the generator. The first line is what makes it front of house.</p>
+
+        <div class="translation-block animate-in">
+          <div class="translation-code">
+            <span class="translation-label">CODE</span>
+            <pre><code><span class="code-line"><span class="code-string">'use client'</span>;</span>
+<span class="code-line"></span>
+<span class="code-line"><span class="code-keyword">import</span> React, { useState, useRef, useEffect } <span class="code-keyword">from</span> <span class="code-string">'react'</span>;</span>
+<span class="code-line"><span class="code-keyword">import</span> { useSession } <span class="code-keyword">from</span> <span class="code-string">'next-auth/react'</span>;</span>
+<span class="code-line"><span class="code-keyword">import</span> { Card, CardContent } <span class="code-keyword">from</span> <span class="code-string">'@/components/ui/card'</span>;</span>
+<span class="code-line"><span class="code-keyword">import</span> { Button } <span class="code-keyword">from</span> <span class="code-string">'@/components/ui/button'</span>;</span>
+<span class="code-line"><span class="code-keyword">import</span> { cn } <span class="code-keyword">from</span> <span class="code-string">'@/lib/utils'</span>;</span>
+<span class="code-line"><span class="code-keyword">import</span> { useUserCredits } <span class="code-keyword">from</span> <span class="code-string">'@/hooks/useUserCredits'</span>;</span></code></pre>
+          </div>
+          <div class="translation-english">
+            <span class="translation-label">PLAIN ENGLISH</span>
+            <div class="translation-lines">
+              <p class="tl">"Ship this whole file to the visitor's browser." That one line turns everything below it into a <span class="term" data-definition="A client component is a file that gets sent to the visitor's browser and runs there. It can respond to clicks and typing — but it can never hold a secret, because the visitor can read it.">client component</span>.</p>
+              <p class="tl">A blank line — just breathing room.</p>
+              <p class="tl">Borrow the tools for <span class="term" data-definition="State is a component's short-term memory — which image you uploaded, whether the spinner is showing. Only browser code can have it, because only the browser is watching the visitor in real time.">remembering things</span> and reacting to changes. These only work front of house, which is exactly why the file needs line 1.</p>
+              <p class="tl">Borrow a way to ask "is anyone logged in right now?"</p>
+              <p class="tl">Borrow the ready-made Card box that the generator panel sits inside.</p>
+              <p class="tl">Borrow the ready-made Button, so every button in the app looks the same.</p>
+              <p class="tl">Borrow a small helper for combining styling names tidily.</p>
+              <p class="tl">Borrow a way to read how many credits the logged-in visitor has left.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="callout callout-info">
+          <div class="callout-icon">📌</div>
+          <div class="callout-content">
+            <strong class="callout-title">Useful phrase for talking to an AI</strong>
+            <p>"Put the interactive part in a <code>'use client'</code> component and keep the data fetching on the server." That one sentence resolves most of the confusion an assistant will get into in a Next.js project.</p>
+          </div>
+        </div>
+      </section>
+
+      <!-- ══════════════ SCREEN 6 — THE WRAPPER ══════════════ -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">Backstage: fetching the words</h2>
+
+        <p><code class="badge-code">ImagenWrapper</code> has no line 1, so it stays backstage — it's a <span class="term" data-definition="A server component is a file that runs only on the company's server. It can read secrets and wait for slow lookups, and only its finished output is sent to the visitor. In Next.js this is the default for every file.">server component</span>. Its entire job is looking up text in the right language and handing it over.</p>
+
+        <div class="translation-block animate-in">
+          <div class="translation-code">
+            <span class="translation-label">CODE</span>
+            <pre><code><span class="code-line"><span class="code-keyword">export default async function</span> <span class="code-function">ImagenWrapper</span>({ locale = <span class="code-string">'en'</span> }: ImagenWrapperProps = {}) {</span>
+<span class="code-line">  <span class="code-comment">// Set the request locale for server-side translations</span></span>
+<span class="code-line">  <span class="code-function">setRequestLocale</span>(locale);</span>
+<span class="code-line"></span>
+<span class="code-line">  <span class="code-comment">// Get the translations on the server side with explicit locale</span></span>
+<span class="code-line">  <span class="code-keyword">const</span> t = <span class="code-keyword">await</span> <span class="code-function">getTranslations</span>({ locale, <span class="code-property">namespace</span>: <span class="code-string">'imagen'</span> });</span>
+<span class="code-line"></span>
+<span class="code-line">  <span class="code-comment">// Pass translations as props to the client component</span></span>
+<span class="code-line">  <span class="code-keyword">const</span> translations = {</span>
+<span class="code-line">    <span class="code-property">badge</span>: { <span class="code-property">text</span>: <span class="code-function">t</span>(<span class="code-string">'badge.text'</span>) },</span>
+<span class="code-line">    <span class="code-property">title</span>: { <span class="code-property">main</span>: <span class="code-function">t</span>(<span class="code-string">'title.main'</span>), <span class="code-property">subtitle</span>: <span class="code-function">t</span>(<span class="code-string">'title.subtitle'</span>) },</span></code></pre>
+          </div>
+          <div class="translation-english">
+            <span class="translation-label">PLAIN ENGLISH</span>
+            <div class="translation-lines">
+              <p class="tl">Define the wrapper. The word <span class="term" data-definition="Async is short for asynchronous — code that is allowed to pause, go do something slow like a lookup, and carry on when the answer arrives. Server components may do this; browser components may not.">async</span> is the giveaway that this runs on the server: only a backstage file is allowed to pause. If no language is given, use English.</p>
+              <p class="tl">A note from the original author explaining the next line.</p>
+              <p class="tl">Tell the translation system which language this particular visitor gets.</p>
+              <p class="tl">Blank line.</p>
+              <p class="tl">Another author's note.</p>
+              <p class="tl">Go and load the <span class="term" data-definition="Internationalisation, usually shortened to i18n, is the practice of keeping every visible sentence in separate language files so the same app can be shown in English, Chinese, or anything else without rewriting it.">translation</span> file, and <span class="term" data-definition="Await means pause here until the answer comes back, then continue. It is only legal in code that is allowed to wait — which browser components are not.">wait</span> for it. Then call the result <code>t</code> — a lookup tool for words in the <code>imagen</code> drawer.</p>
+              <p class="tl">Blank line.</p>
+              <p class="tl">The author telling us exactly what happens next.</p>
+              <p class="tl">Start building one plain package of finished text.</p>
+              <p class="tl">Look up the badge wording and put it in the package.</p>
+              <p class="tl">Look up the headline and subheadline too. About forty more lookups follow this one.</p>
+            </div>
+          </div>
+        </div>
+
+        <p>Seventy lines later, the package is complete and the hand-off happens on a single line:</p>
+
+        <div class="translation-block animate-in">
+          <div class="translation-code">
+            <span class="translation-label">CODE</span>
+            <pre><code><span class="code-line">  <span class="code-keyword">return</span> &lt;<span class="code-tag">ImagenClient</span> <span class="code-attr">translations</span>={translations} /&gt;;</span></code></pre>
+          </div>
+          <div class="translation-english">
+            <span class="translation-label">PLAIN ENGLISH</span>
+            <div class="translation-lines">
+              <p class="tl">Hand the finished package of words to ImagenClient as a <span class="term" data-definition="A prop is a value one component passes down to another, like handing over a labelled box. The receiving component can read it but not change it.">prop</span>, and let the front of house take over. Passing one bundled object rather than forty separate ones keeps this from turning into <span class="term" data-definition="Prop drilling is when a value has to be passed down through layer after layer of components to reach the one that needs it — tedious, and easy to break. Bundling everything into a single object is one common way to avoid it.">prop drilling</span>. This is the whole crossing: words go out, the translation files stay in.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="callout callout-info">
+          <div class="callout-icon">🎬</div>
+          <div class="callout-content">
+            <strong class="callout-title">Why not let ImagenClient fetch its own text?</strong>
+            <p>Because doing it backstage means the correct words are already in the page before any JavaScript runs — the visitor sees real text instantly, and search engines see real text too. Fetching it front of house would mean a flash of emptiness first.</p>
+          </div>
+        </div>
+      </section>
+
+      <!-- ══════════════ SCREEN 7 — SECRETS ══════════════ -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">What only backstage can see</h2>
+
+        <p>This is the key pool reading Google's API keys out of the server's <span class="term" data-definition="Environment variables are settings stored on the machine running the app rather than written into the code — the standard hiding place for passwords and keys, so they never end up in a shared code repository.">environment variables</span>. It has no <code>'use client'</code>, so no visitor will ever see it.</p>
+
+        <div class="translation-block animate-in">
+          <div class="translation-code">
+            <span class="translation-label">CODE</span>
+            <pre><code><span class="code-line">    <span class="code-comment">// Get all Gemini API keys from environment variables</span></span>
+<span class="code-line">    <span class="code-keyword">const</span> geminiKeys = [</span>
+<span class="code-line">      process.env.GEMINI_API_KEY,</span>
+<span class="code-line">      process.env.GEMINI_API_KEY_1,</span>
+<span class="code-line">      process.env.GEMINI_API_KEY_2, </span>
+<span class="code-line">      process.env.GEMINI_API_KEY_3,</span>
+<span class="code-line">      process.env.GEMINI_API_KEY_4,</span>
+<span class="code-line">      process.env.GEMINI_API_KEY_5,</span>
+<span class="code-line">    ].<span class="code-function">filter</span>(key =&gt; key &amp;&amp; key.<span class="code-function">trim</span>() !== <span class="code-string">''</span>);</span></code></pre>
+          </div>
+          <div class="translation-english">
+            <span class="translation-label">PLAIN ENGLISH</span>
+            <div class="translation-lines">
+              <p class="tl">The author's note: we're about to collect the keys.</p>
+              <p class="tl">Make a list to hold them.</p>
+              <p class="tl">Reach into <span class="term" data-definition="process.env is how code asks the machine it is running on for its settings. On the server it returns real values; anything read this way is invisible to visitors unless its name says otherwise.">the machine's settings</span> for the main key.</p>
+              <p class="tl">And the first spare.</p>
+              <p class="tl">And the second.</p>
+              <p class="tl">And the third.</p>
+              <p class="tl">And the fourth.</p>
+              <p class="tl">And the fifth — six slots in total, though most may be empty.</p>
+              <p class="tl">Throw away any slot that's missing or blank, so only real keys survive. Module 3 is entirely about what happens next.</p>
+            </div>
+          </div>
+        </div>
+
+        <h3 class="screen-heading">The one exception, and it's spelled out in the name</h3>
+
+        <p>Deep inside the browser file, there <em>is</em> a setting being read. It's allowed out only because of how it's named.</p>
+
+        <div class="translation-block animate-in">
+          <div class="translation-code">
+            <span class="translation-label">CODE</span>
+            <pre><code><span class="code-line">                    {t.buttons.generate}</span>
+<span class="code-line">                    &lt;<span class="code-tag">span</span> <span class="code-attr">className</span>=<span class="code-value">"text-cl-blue font-medium"</span>&gt;</span>
+<span class="code-line">                      {process.env.NEXT_PUBLIC_FREE_MODE_ENABLED === <span class="code-string">'true'</span> </span>
+<span class="code-line">                        ? <span class="code-string">`(${t.buttons.limited_free})`</span></span>
+<span class="code-line">                        : <span class="code-string">`(${modelOptions.<span class="code-function">find</span>(m =&gt; m.value === selectedModel)?.credits || <span class="code-number">10</span>} credits)`</span></span>
+<span class="code-line">                      }</span>
+<span class="code-line">                    &lt;/<span class="code-tag">span</span>&gt;</span></code></pre>
+          </div>
+          <div class="translation-english">
+            <span class="translation-label">PLAIN ENGLISH</span>
+            <div class="translation-lines">
+              <p class="tl">Print the button's label — "Generate", in whichever language the wrapper sent.</p>
+              <p class="tl">Open a small styled piece of text right next to it.</p>
+              <p class="tl">Check a setting: is the app currently in free mode? The <code>NEXT_PUBLIC_</code> prefix is why this one is readable here at all.</p>
+              <p class="tl">If yes, show the "limited free" wording in brackets.</p>
+              <p class="tl">If no, look up how many credits the chosen model costs and show that instead — falling back to 10 if it can't tell.</p>
+              <p class="tl">Done choosing.</p>
+              <p class="tl">Close the styled text.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="badge-list">
+          <div class="badge-item">
+            <code class="badge-code">GEMINI_API_KEY</code>
+            <span class="badge-desc">No prefix → stripped out of anything sent to browsers. Server only. This is the default and the safe one.</span>
+          </div>
+          <div class="badge-item">
+            <code class="badge-code">NEXT_PUBLIC_FREE_MODE_ENABLED</code>
+            <span class="badge-desc">Prefixed → baked into the <span class="term" data-definition="A bundle is the single big file of JavaScript — the code that makes a page interactive — that gets packed up and downloaded by every visitor. Anything inside it is readable by anyone who cares to look.">bundle</span> every visitor downloads. A promise you're making: "it is fine for strangers to read this."</span>
+          </div>
+        </div>
+
+        <div class="callout callout-warning">
+          <div class="callout-icon">✍️</div>
+          <div class="callout-content">
+            <strong class="callout-title">Naming is the entire security mechanism</strong>
+            <p>There's no vault and no permission list — the framework decides purely by reading the name. Which means adding six characters to the front of a key's name is a real, published leak.</p>
+          </div>
+        </div>
+      </section>
+
+      <!-- ══════════════ SCREEN 8 — HOW TO TELL ══════════════ -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">Three ways to tell which side you're on</h2>
+
+        <div class="pattern-cards">
+          <div class="pattern-card" style="border-top: 3px solid var(--color-actor-3)">
+            <div class="pattern-icon" style="background: var(--color-actor-3)">1️⃣</div>
+            <h4 class="pattern-title">Read the top line</h4>
+            <p class="pattern-desc"><code>'use client'</code> on line 1 means front of house. No line 1 means backstage — that's the default in this app.</p>
+          </div>
+          <div class="pattern-card" style="border-top: 3px solid var(--color-actor-4)">
+            <div class="pattern-icon" style="background: var(--color-actor-4)">2️⃣</div>
+            <h4 class="pattern-title">Look at what it touches</h4>
+            <p class="pattern-desc">Clicks, typing, remembering, spinners → must be front of house. Waiting on a lookup, reading secrets → must be backstage.</p>
+          </div>
+          <div class="pattern-card" style="border-top: 3px solid var(--color-actor-5)">
+            <div class="pattern-icon" style="background: var(--color-actor-5)">3️⃣</div>
+            <h4 class="pattern-title">Ask who's allowed to see it</h4>
+            <p class="pattern-desc">If a stranger reading this file would be a problem, it cannot be front of house. No exceptions, no clever workarounds.</p>
+          </div>
+        </div>
+
+        <div class="file-tree">
+          <div class="ft-folder open">
+            <span class="ft-name">src/</span>
+            <span class="ft-desc">All the app's own code</span>
+            <div class="ft-children">
+              <div class="ft-folder open">
+                <span class="ft-name">app/</span>
+                <span class="ft-desc">Pages visitors land on, and the doors they knock at</span>
+                <div class="ft-children">
+                  <div class="ft-file">
+                    <span class="ft-name">[locale]/(default)/page.tsx</span>
+                    <span class="ft-desc">🔐 backstage — the homepage</span>
+                  </div>
+                  <div class="ft-file">
+                    <span class="ft-name">api/generate-cyberpunk/route.ts</span>
+                    <span class="ft-desc">🔐 backstage — the only door between the two worlds</span>
+                  </div>
+                </div>
+              </div>
+              <div class="ft-folder open">
+                <span class="ft-name">components/blocks/imagen-wrapper/</span>
+                <span class="ft-desc">The generator panel, in two halves</span>
+                <div class="ft-children">
+                  <div class="ft-file">
+                    <span class="ft-name">index.tsx</span>
+                    <span class="ft-desc">🔐 backstage — fetches the words, hands them down</span>
+                  </div>
+                  <div class="ft-file">
+                    <span class="ft-name">imagen-client.tsx</span>
+                    <span class="ft-desc">🎭 front of house — 893 lines of everything you can touch</span>
+                  </div>
+                </div>
+              </div>
+              <div class="ft-folder open">
+                <span class="ft-name">lib/</span>
+                <span class="ft-desc">Shared helpers</span>
+                <div class="ft-children">
+                  <div class="ft-file">
+                    <span class="ft-name">gemini-api-pool.ts</span>
+                    <span class="ft-desc">🔐 backstage — the drawer with the keys in it</span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <p>One honest observation: 893 lines in a single front-of-house file is a lot. It works, and it shipped — but every visitor downloads all of it, and every change risks the whole panel.</p>
+      </section>
+
+      <!-- ══════════════ SCREEN 9 — QUIZ ══════════════ -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">Try it on real situations</h2>
+
+        <p>No score, no pass mark. Each of these is a thing that genuinely happens when you're building with an AI assistant.</p>
+
+        <div class="quiz-container" id="quiz-module2">
+
+          <div class="quiz-question-block"
+               data-correct="opt-b"
+               data-explanation-right="Exactly. Remembering a choice is state, and state only exists front of house. The one-line correction is: 'Put that dropdown in imagen-client.tsx instead — it needs state, so it has to be a client component.' You have just saved yourself six rounds of confusing error messages."
+               data-explanation-wrong="Not quite — think about what 'remembers' means. Remembering the last pick is state, and state only works in a file that ships to the browser. index.tsx is backstage, so it cannot hold any. The fix is a one-liner to the AI: put the dropdown in imagen-client.tsx, or make a new component with 'use client' at the top.">
+            <div class="scenario-block">
+              <div class="scenario-context">
+                <span class="scenario-label">Scenario</span>
+                <p>You ask an AI to "add a dropdown that remembers the last style the user picked." It writes the code into <code>index.tsx</code> — the wrapper. What happens, and what do you say back?</p>
+              </div>
+            </div>
+            <div class="quiz-options">
+              <button class="quiz-option" data-value="opt-a" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>It works, but the dropdown will be slow because the server has to re-render it every time.</span>
+              </button>
+              <button class="quiz-option" data-value="opt-b" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>It breaks — remembering means state, and state only exists front of house. Tell it to put the dropdown in <code>imagen-client.tsx</code> instead.</span>
+              </button>
+              <button class="quiz-option" data-value="opt-c" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>It works fine — the wrapper already handles the translations, so it can handle the dropdown too.</span>
+              </button>
+            </div>
+            <div class="quiz-feedback"></div>
+          </div>
+
+          <div class="quiz-question-block"
+               data-correct="opt-c"
+               data-explanation-right="Right on both counts. Without the prefix the value is stripped out and arrives as nothing, so the call to Google just fails. And the tempting 'fix' — renaming it to NEXT_PUBLIC_GEMINI_API_KEY — would publish the key to every single visitor. The honest fix is to leave the key backstage and let the route make the call."
+               data-explanation-wrong="Close, but there are two failures stacked here. First, without the NEXT_PUBLIC_ prefix the value never reaches the browser at all, so the code gets nothing and the call fails. Second, and worse, the obvious way to 'fix' that is to rename it with the prefix — which would publish the key to every visitor who loads the page.">
+            <div class="scenario-block">
+              <div class="scenario-context">
+                <span class="scenario-label">Scenario</span>
+                <p>A teammate adds <code>process.env.GEMINI_API_KEY</code> to <code>imagen-client.tsx</code> to "skip the round trip and speed things up." What actually happens?</p>
+              </div>
+            </div>
+            <div class="quiz-options">
+              <button class="quiz-option" data-value="opt-a" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>It works and is genuinely faster — one less hop through the server.</span>
+              </button>
+              <button class="quiz-option" data-value="opt-b" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>Next.js refuses to build the app and prints a security error.</span>
+              </button>
+              <button class="quiz-option" data-value="opt-c" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>It arrives empty because the name has no <code>NEXT_PUBLIC_</code> prefix — and "fixing" that by adding the prefix would publish the key to every visitor.</span>
+              </button>
+            </div>
+            <div class="quiz-feedback"></div>
+          </div>
+
+          <div class="quiz-question-block"
+               data-correct="opt-a"
+               data-explanation-right="Exactly. The right words are chosen per visitor, per language, backstage — so they are already sitting in the page before a single line of JavaScript runs. The visitor sees real text instantly, and search engines see real text too, not an empty box waiting to be filled."
+               data-explanation-wrong="Think about timing rather than tidiness. If ImagenClient fetched its own text, the visitor would get an empty panel first and the words a moment later. Doing the lookup backstage means the finished words are baked into the page before it is even sent — instant for the visitor, and readable by search engines.">
+            <div class="scenario-block">
+              <div class="scenario-context">
+                <span class="scenario-label">Scenario</span>
+                <p>Someone proposes deleting <code>ImagenWrapper</code> entirely and letting <code>ImagenClient</code> fetch its own text. Why does the wrapper exist?</p>
+              </div>
+            </div>
+            <div class="quiz-options">
+              <button class="quiz-option" data-value="opt-a" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>So the right words are already in the page before any JavaScript runs — instant for the visitor, and visible to search engines.</span>
+              </button>
+              <button class="quiz-option" data-value="opt-b" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>Because translation files contain secrets that visitors must never see.</span>
+              </button>
+              <button class="quiz-option" data-value="opt-c" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>Purely as a style choice — the team likes small files, and it makes no practical difference.</span>
+              </button>
+            </div>
+            <div class="quiz-feedback"></div>
+          </div>
+
+          <div class="quiz-question-block"
+               data-correct="opt-b"
+               data-explanation-right="That is the honest answer. It works, it shipped, and it is the file you would split first. Every visitor downloads all 893 lines whether they generate an image or not, and a small change to the download button sits in the same file as the upload logic."
+               data-explanation-wrong="It is tempting to call it a bug, but it is not — the app works. The real cost is quieter: everything in a front-of-house file ships to every visitor, so the whole 893 lines get downloaded by someone who only came to read the marketing copy. And with upload, preview, prompt editing, download and share all in one place, any change risks the entire panel.">
+            <div class="scenario-block">
+              <div class="scenario-context">
+                <span class="scenario-label">Scenario</span>
+                <p><code>imagen-client.tsx</code> is 893 lines holding upload, preview, prompt editing, download and share. What's the practical cost of that?</p>
+              </div>
+            </div>
+            <div class="quiz-options">
+              <button class="quiz-option" data-value="opt-a" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>None — file length is purely a matter of taste and has no effect on anything.</span>
+              </button>
+              <button class="quiz-option" data-value="opt-b" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>All of it ships to every visitor, and any change risks the whole panel. It works, but it's the file you'd split first.</span>
+              </button>
+              <button class="quiz-option" data-value="opt-c" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>The API keys inside it become easier for visitors to find.</span>
+              </button>
+            </div>
+            <div class="quiz-feedback"></div>
+          </div>
+
+          <button class="quiz-check-btn" onclick="checkQuiz('quiz-module2')">Check Answers</button>
+          <button class="quiz-reset-btn" onclick="resetQuiz('quiz-module2')">Try Again</button>
+        </div>
+      </section>
+
+      <!-- ══════════════ SCREEN 10 — HANDOFF ══════════════ -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">Next: through the stage door</h2>
+
+        <p>You can now look at any file in a Next.js project and say which machine it runs on — which is most of what you need to steer an AI assistant through one.</p>
+
+        <div class="callout callout-accent">
+          <div class="callout-icon">🗝️</div>
+          <div class="callout-content">
+            <strong class="callout-title">Module 3 — Commissioning the Artist</strong>
+            <p>Backstage, there's a drawer with up to six keys in it. Only one gets used per request, and the drawer remembers which ones are burnt.</p>
+          </div>
+        </div>
+      </section>
+
+    </div>
+  </div>
+</section>

--- a/courses/image-generator-ui-course/modules/03-gemini.html
+++ b/courses/image-generator-ui-course/modules/03-gemini.html
@@ -1,0 +1,655 @@
+<section class="module" id="module-3" style="background: var(--color-bg-warm)">
+  <div class="module-content">
+
+    <header class="module-header animate-in">
+      <span class="module-number">03</span>
+      <h1 class="module-title">Commissioning the Artist</h1>
+      <p class="module-subtitle">The whole "Charlie &amp; Lola style" is one paragraph of English. Here is how it gets sent, and what the app does around it.</p>
+    </header>
+
+    <div class="module-body">
+
+      <!-- ============ SCREEN 1: THE HOOK ============ -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">There is no "Charlie &amp; Lola" button</h2>
+
+        <p>Open the generator and look at the prompt box on the right. You can read the entire product in there — and you are allowed to edit it.</p>
+
+        <p>Nobody trained a Charlie-and-Lola machine. Someone wrote a paragraph describing exactly how the drawing should look, and the app sends that paragraph plus your photo to a general-purpose artist, every single time you press the button.</p>
+
+        <div class="callout callout-accent">
+          <div class="callout-icon">🖍️</div>
+          <div class="callout-content">
+            <strong class="callout-title">The metaphor for this module: commissioning an illustrator</strong>
+            <p>You are not applying a filter. You are handing a freelance illustrator a written brief and a reference photo, and waiting for what comes back. The "style" you picked in the interface <em>is</em> the brief.</p>
+          </div>
+        </div>
+
+        <h2 class="screen-heading" style="margin-top: var(--space-12)">The intelligence is rented. These five jobs are the app.</h2>
+
+        <p>The drawing talent belongs to Google. Everything the app itself contributes fits on five cards — and every one of them is a place things break.</p>
+
+        <div class="pattern-cards stagger-children">
+          <div class="pattern-card animate-in" style="border-top: 3px solid var(--color-actor-2)">
+            <div class="pattern-icon" style="background: var(--color-actor-2)">🔑</div>
+            <h4 class="pattern-title">Choose a key</h4>
+            <p class="pattern-desc">Pick one of six <span class="term" data-definition="An API key is a long secret password that proves to an outside service that a request is coming from a paying, registered account. Whoever holds it can spend that account&apos;s money — which is why it never leaves the server.">API keys</span> that still has budget left for today.</p>
+          </div>
+          <div class="pattern-card animate-in" style="border-top: 3px solid var(--color-actor-1)">
+            <div class="pattern-icon" style="background: var(--color-actor-1)">✍️</div>
+            <h4 class="pattern-title">Write the brief</h4>
+            <p class="pattern-desc">One long paragraph of English describing the look, what to keep, and what to avoid.</p>
+          </div>
+          <div class="pattern-card animate-in" style="border-top: 3px solid var(--color-actor-3)">
+            <div class="pattern-icon" style="background: var(--color-actor-3)">📎</div>
+            <h4 class="pattern-title">Attach the photo</h4>
+            <p class="pattern-desc">Re-shape your upload into the exact parcel the artist expects to receive.</p>
+          </div>
+          <div class="pattern-card animate-in" style="border-top: 3px solid var(--color-actor-4)">
+            <div class="pattern-icon" style="background: var(--color-actor-4)">🔍</div>
+            <h4 class="pattern-title">Dig out the reply</h4>
+            <p class="pattern-desc">The answer is a mixed bag of parts. Find the one part that is actually a picture.</p>
+          </div>
+          <div class="pattern-card animate-in" style="border-top: 3px solid var(--color-actor-5)">
+            <div class="pattern-icon" style="background: var(--color-actor-5)">🗄️</div>
+            <h4 class="pattern-title">Store it somewhere</h4>
+            <p class="pattern-desc">Put the finished drawing at a permanent web address so it can be shown and shared.</p>
+          </div>
+        </div>
+      </section>
+
+      <!-- ============ SCREEN 2: HERO FLOW ANIMATION ============ -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">One commission, start to finish</h2>
+
+        <p>Module 2 left us at the door of the <span class="term" data-definition="A route is a single web address on the server that accepts requests and sends back an answer — like one specific desk in an office, with its own job and its own queue.">route</span> that lives on the server. Step through it. Click <strong>Next Step</strong> — the last two steps show the ending where things go wrong.</p>
+
+        <div class="flow-animation" data-steps='[
+          {"highlight":"flow-actor-1","label":"Your photo and the chosen style arrive at the server route. First question the route asks: does ANY key still have life left today?"},
+          {"highlight":"flow-actor-2","label":"The pool hands over key #3 — the next one in the circle — and immediately moves its pointer to #4, so the next visitor gets a different key.","packet":true,"from":"actor-1","to":"actor-2"},
+          {"highlight":"flow-actor-3","label":"The photo and the written style brief travel to Gemini together, as one sealed parcel.","packet":true,"from":"actor-2","to":"actor-3"},
+          {"highlight":"flow-actor-3","label":"Gemini answers with candidates: a list of parts. Some parts are text, one part holds the new picture."},
+          {"highlight":"flow-actor-3","label":"The route walks the list, grabs the first part that carries inlineData, and throws the rest away."},
+          {"highlight":"flow-actor-4","label":"The picture is uploaded to R2 storage, where it stops being data-in-transit and becomes a normal web address.","packet":true,"from":"actor-3","to":"actor-4"},
+          {"highlight":"flow-actor-5","label":"That address travels back to the browser, and the finished drawing appears on your screen.","packet":true,"from":"actor-4","to":"actor-5"},
+          {"highlight":"flow-actor-3","label":"ALTERNATE ENDING. Instead of a picture, Gemini answers 429 Too Many Requests. That key is out of budget for the day.","packet":true,"from":"actor-2","to":"actor-3"},
+          {"highlight":"flow-actor-2","label":"Key #3 is marked burnt out and skipped by every future request. You see the message: Too many users online!","packet":true,"from":"actor-3","to":"actor-2"}
+        ]'>
+          <div class="flow-actors">
+            <div class="flow-actor" id="flow-actor-1">
+              <div class="flow-actor-icon">📨</div>
+              <span>Request</span>
+            </div>
+            <div class="flow-actor" id="flow-actor-2">
+              <div class="flow-actor-icon">🔑</div>
+              <span>Key Pool<br>(6 slots)</span>
+            </div>
+            <div class="flow-actor" id="flow-actor-3">
+              <div class="flow-actor-icon">🎨</div>
+              <span>Gemini</span>
+            </div>
+            <div class="flow-actor" id="flow-actor-4">
+              <div class="flow-actor-icon">🗄️</div>
+              <span>R2 Storage</span>
+            </div>
+            <div class="flow-actor" id="flow-actor-5">
+              <div class="flow-actor-icon">🖼️</div>
+              <span>Response</span>
+            </div>
+          </div>
+
+          <div class="flow-packet" id="flow-packet"></div>
+
+          <div class="flow-step-label" id="flow-label">Click "Next Step" to send a commission</div>
+
+          <div class="flow-controls">
+            <button class="btn flow-next-btn">Next Step</button>
+            <button class="btn flow-reset-btn">Restart</button>
+            <span class="flow-progress"></span>
+          </div>
+        </div>
+
+        <div class="badge-list">
+          <div class="badge-item">
+            <code class="badge-code">Key Pool</code>
+            <span class="badge-desc">Six keys taking turns, so one account never carries the whole crowd</span>
+          </div>
+          <div class="badge-item">
+            <code class="badge-code">Gemini</code>
+            <span class="badge-desc">Google&apos;s image <span class="term" data-definition="A model is the trained AI system itself — the thing that actually generates the picture. You rent access to it by the request; you do not own it or keep a copy.">model</span>, rented by the request — the actual artist</span>
+          </div>
+          <div class="badge-item">
+            <code class="badge-code">R2 Storage</code>
+            <span class="badge-desc">Cloudflare&apos;s file warehouse — where finished images get a permanent web address</span>
+          </div>
+        </div>
+      </section>
+
+      <!-- ============ SCREEN 3: THE BRIEF ============ -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">The brief you are allowed to rewrite</h2>
+
+        <p>This is the actual <span class="term" data-definition="A prompt is the written instruction you give an AI model — plain English, no code. Changing the prompt is the single cheapest way to change what an AI feature produces.">prompt</span> the app sends, sitting in the source as one very long line. Read it as what it is: instructions to a freelancer.</p>
+
+        <div class="callout callout-info">
+          <div class="callout-icon">📜</div>
+          <div class="callout-content">
+            <strong class="callout-title">From the brief itself</strong>
+            <p>"…thin sketchy outlines, flat colors, childlike proportions, playful hand-drawn charm…"</p>
+            <p>"Retain the subject&apos;s original clothing, hairstyle, facial features, accessories, skin tone, pose, and expression…"</p>
+            <p>"Negative Prompt: No realistic shading, no detailed rendering, no anime or manga style, no 3D modeling, no photographic textures!"</p>
+          </div>
+        </div>
+
+        <p>Every good image brief has the same three-part shape. This structure transfers to any image model you will ever use.</p>
+
+        <div class="pattern-cards stagger-children">
+          <div class="pattern-card animate-in" style="border-top: 3px solid var(--color-actor-1)">
+            <div class="pattern-icon" style="background: var(--color-actor-1)">🎯</div>
+            <h4 class="pattern-title">What to make</h4>
+            <p class="pattern-desc">The look you want, in concrete visual words: sketchy outlines, flat colours, childlike proportions.</p>
+          </div>
+          <div class="pattern-card animate-in" style="border-top: 3px solid var(--color-actor-5)">
+            <div class="pattern-icon" style="background: var(--color-actor-5)">🔒</div>
+            <h4 class="pattern-title">What to preserve</h4>
+            <p class="pattern-desc">The things from the photo that must survive: clothing, hairstyle, skin tone, pose, expression.</p>
+          </div>
+          <div class="pattern-card animate-in" style="border-top: 3px solid var(--color-error)">
+            <div class="pattern-icon" style="background: var(--color-error)">🚫</div>
+            <h4 class="pattern-title">What to forbid</h4>
+            <p class="pattern-desc">The <span class="term" data-definition="A negative prompt is the list of things you explicitly do NOT want in the output. Image models drift toward glossy realism by default, so naming what to avoid is often more powerful than naming what you want.">negative prompt</span> — the list of default habits the model must resist.</p>
+          </div>
+        </div>
+
+        <p>Notice what this means for you: if the output keeps losing people&apos;s glasses, the fix is a few words added to the "retain" list. No new logic, no new <span class="term" data-definition="Deploying means pushing a new version of the app out to the live servers so real users get it. It is the moment a change stops being on your laptop and starts affecting everyone.">deploy</span> of clever code — just better writing.</p>
+      </section>
+
+      <!-- ============ SCREEN 4: SEALING THE PARCEL ============ -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">Sealing the parcel</h2>
+
+        <p>The brief and the photo have to travel together, in one shape the artist recognises. Here is that parcel being built.</p>
+
+        <div class="translation-block animate-in">
+          <div class="translation-code">
+            <span class="translation-label">CODE</span>
+            <pre><code><span class="code-line">    <span class="code-keyword">const</span> imageEditPrompt = [</span>
+<span class="code-line">      { <span class="code-property">text</span>: charlieLolaPrompt },</span>
+<span class="code-line">      {</span>
+<span class="code-line">        <span class="code-property">inlineData</span>: {</span>
+<span class="code-line">          <span class="code-property">mimeType</span>: mimeType,</span>
+<span class="code-line">          <span class="code-property">data</span>: base64Image,</span>
+<span class="code-line">        },</span>
+<span class="code-line">      },</span>
+<span class="code-line">    ];</span></code></pre>
+          </div>
+          <div class="translation-english">
+            <span class="translation-label">PLAIN ENGLISH</span>
+            <div class="translation-lines">
+              <p class="tl">Make the parcel we are about to hand the illustrator. It is a list with exactly two things in it.</p>
+              <p class="tl">Thing one: the written brief — that long Charlie &amp; Lola paragraph.</p>
+              <p class="tl">Thing two starts here: the reference photo.</p>
+              <p class="tl"><span class="term" data-definition="inlineData means the file travels inside the message itself, rather than as a link pointing somewhere else. Like stapling the photo to the letter instead of writing down where the photo can be found.">inlineData</span> = the photo rides inside the message, not as a link to fetch later.</p>
+              <p class="tl">Tell the artist what kind of file it is — the <span class="term" data-definition="A MIME type is a short label that says what kind of file something is, like image/png or image/jpeg. Without it, the receiving program has to guess, and guessing goes badly.">MIME type</span>, e.g. image/png.</p>
+              <p class="tl">And here is the photo itself, re-typed as one gigantic string of letters and numbers (<span class="term" data-definition="base64 is a way of rewriting a picture or any file as plain text characters, so it can travel inside a normal text message. It is about a third bigger than the original file — the price of being sendable as text.">base64</span>).</p>
+              <p class="tl">Close the photo item.</p>
+              <p class="tl">Close the list. Parcel sealed, ready to send.</p>
+            </div>
+          </div>
+        </div>
+
+        <h2 class="screen-heading" style="margin-top: var(--space-12)">The actual AI call is four lines</h2>
+
+        <p>All that hype, all that money, all that capability — and from the app&apos;s side it is one polite request with a name on it.</p>
+
+        <div class="translation-block animate-in">
+          <div class="translation-code">
+            <span class="translation-label">CODE</span>
+            <pre><code><span class="code-line">      response = <span class="code-keyword">await</span> ai.models.<span class="code-function">generateContent</span>({</span>
+<span class="code-line">        <span class="code-property">model</span>: <span class="code-string">"gemini-2.5-flash-image-preview"</span>,</span>
+<span class="code-line">        <span class="code-property">contents</span>: imageEditPrompt,</span>
+<span class="code-line">      });</span></code></pre>
+          </div>
+          <div class="translation-english">
+            <span class="translation-label">PLAIN ENGLISH</span>
+            <div class="translation-lines">
+              <p class="tl">Send the commission and wait for the reply. <code>await</code> means: stop here, do nothing else, until the artist answers.</p>
+              <p class="tl">Which artist? This exact one, by name. Swapping models is one word on this line.</p>
+              <p class="tl">And here is what we are sending: the parcel we just sealed.</p>
+              <p class="tl">End of the request. Everything after this is dealing with whatever comes back.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="badge-list">
+          <div class="badge-item">
+            <code class="badge-code">ai.models</code>
+            <span class="badge-desc">Comes from Google&apos;s <span class="term" data-definition="An SDK (Software Development Kit) is a ready-made bundle of code a company publishes so other people can use their service without writing the plumbing themselves. It is the difference between buying a kettle and building one.">SDK</span> — the ready-made toolkit Google publishes so nobody has to hand-write the plumbing</span>
+          </div>
+          <div class="badge-item">
+            <code class="badge-code">-flash-</code>
+            <span class="badge-desc">Google&apos;s name for the fast, cheap tier of the model family — a deliberate cost choice</span>
+          </div>
+          <div class="badge-item">
+            <code class="badge-code">-preview</code>
+            <span class="badge-desc">Not final. Google can change or retire it, and this line stops working the day they do</span>
+          </div>
+        </div>
+      </section>
+
+      <!-- ============ SCREEN 5: DIGGING OUT THE REPLY ============ -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">Opening the envelope</h2>
+
+        <p>Gemini does not reply with a picture. It replies with <span class="term" data-definition="Candidates are the alternative answers a model returns — usually just one. Each candidate is made of parts: some parts are text, some are files. You have to look through them to find what you wanted.">candidates</span>: a bag of parts, some text, hopefully one image. The route rummages until it finds the picture.</p>
+
+        <div class="translation-block animate-in">
+          <div class="translation-code">
+            <span class="translation-label">CODE</span>
+            <pre><code><span class="code-line">    <span class="code-keyword">for</span> (<span class="code-keyword">const</span> part <span class="code-keyword">of</span> response.candidates[<span class="code-number">0</span>].content.parts) {</span>
+<span class="code-line">      <span class="code-keyword">if</span> (part.inlineData) {</span>
+<span class="code-line">        generatedImageData = part.inlineData.data;</span>
+<span class="code-line">        generatedImageMimeType = part.inlineData.mimeType;</span>
+<span class="code-line">        <span class="code-keyword">break</span>;</span>
+<span class="code-line">      }</span>
+<span class="code-line">    }</span></code></pre>
+          </div>
+          <div class="translation-english">
+            <span class="translation-label">PLAIN ENGLISH</span>
+            <div class="translation-lines">
+              <p class="tl">Take the first answer Gemini sent, and go through its parts one at a time.</p>
+              <p class="tl">Is this part a file rather than words? (Text parts have no <code>inlineData</code>.)</p>
+              <p class="tl">Yes — so keep the picture data.</p>
+              <p class="tl">And keep the note saying what kind of image file it is.</p>
+              <p class="tl"><code>break</code> = stop looking. We found what we came for; ignore the rest.</p>
+              <p class="tl">Close the "if it is a file" check.</p>
+              <p class="tl">Close the loop. If we got all the way here without finding one, there is no image — and the app says so.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="icon-rows">
+          <div class="icon-row">
+            <div class="icon-circle" style="background: var(--color-actor-4)">🧭</div>
+            <div>
+              <strong>Worth remembering when you debug</strong>
+              <p>If a user ever sees "No image data found in Gemini API response", this loop ran and found nothing. The call worked, the key worked — the artist just replied with words instead of a drawing, usually a polite refusal.</p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- ============ SCREEN 6: THE KEY POOL ============ -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">Six keys, taking turns</h2>
+
+        <p>Google puts a daily ceiling on each account. So this app holds six keys and rotates through them — a pattern called <span class="term" data-definition="Round-robin means taking strict turns in a fixed circle: first, second, third, back to first. No favourites, no cleverness — just the next one along.">round-robin</span>, the same way a deck of chores rotates through a house of flatmates.</p>
+
+        <div class="translation-block animate-in">
+          <div class="translation-code">
+            <span class="translation-label">CODE</span>
+            <pre><code><span class="code-line">    <span class="code-comment">// Try each key starting from current index</span></span>
+<span class="code-line">    <span class="code-keyword">for</span> (<span class="code-keyword">let</span> i = <span class="code-number">0</span>; i &lt; <span class="code-keyword">this</span>.apiKeys.length; i++) {</span>
+<span class="code-line">      <span class="code-keyword">const</span> index = (<span class="code-keyword">this</span>.currentIndex + i) % <span class="code-keyword">this</span>.apiKeys.length;</span>
+<span class="code-line">      <span class="code-keyword">const</span> keyStatus = <span class="code-keyword">this</span>.apiKeys[index];</span>
+<span class="code-line"></span>
+<span class="code-line">      <span class="code-keyword">if</span> (keyStatus.isAvailable &amp;&amp; keyStatus.requestCount &lt; keyStatus.dailyLimit) {</span>
+<span class="code-line">        <span class="code-keyword">this</span>.currentIndex = (index + <span class="code-number">1</span>) % <span class="code-keyword">this</span>.apiKeys.length;</span>
+<span class="code-line">        keyStatus.lastUsed = <span class="code-keyword">new</span> <span class="code-function">Date</span>();</span>
+<span class="code-line">        keyStatus.requestCount++;</span>
+<span class="code-line">        <span class="code-keyword">return</span> keyStatus.key;</span>
+<span class="code-line">      }</span>
+<span class="code-line">    }</span></code></pre>
+          </div>
+          <div class="translation-english">
+            <span class="translation-label">PLAIN ENGLISH</span>
+            <div class="translation-lines">
+              <p class="tl">A note left by whoever wrote this, for whoever reads it next.</p>
+              <p class="tl">Walk around the circle of keys once — at most six tries, then give up.</p>
+              <p class="tl">Start from wherever we stopped last time. The <code>%</code> (<span class="term" data-definition="Modulo, written %, gives the remainder after dividing. Think of a clock face: 3 hours after 11 is 2, not 14. Run past the last key and you wrap around to the first.">modulo</span>) is a clock face — run past the last key and you wrap around to the first.</p>
+              <p class="tl">Pick up that key and its record card: is it healthy, how much has it spent today.</p>
+              <p class="tl">&nbsp;</p>
+              <p class="tl">Two conditions, both required: this key is not marked burnt out, AND it is still under its daily allowance.</p>
+              <p class="tl">Good one. Move the pointer to the NEXT key straight away, so the following visitor gets a different one.</p>
+              <p class="tl">Stamp the time it was last used.</p>
+              <p class="tl">Add one to its tally for today.</p>
+              <p class="tl">Hand the key over. Done — nobody looks at the remaining keys.</p>
+              <p class="tl">Close the check.</p>
+              <p class="tl">Close the circle. If we get past here, all six were unusable.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="callout callout-accent">
+          <div class="callout-icon">💡</div>
+          <div class="callout-content">
+            <strong class="callout-title">Aha: a rate limit is a nightclub capacity, not a fine</strong>
+            <p>A <span class="term" data-definition="A rate limit is a cap on how many requests you may make in a period of time. Go over it and the service simply refuses you until the window resets — it does not bill you extra.">rate limit</span> does not charge you more when you go over. It stops letting you in. That is why apps pool keys: six doors instead of one, same club.</p>
+          </div>
+        </div>
+
+        <div class="callout callout-warning">
+          <div class="callout-icon">⚠️</div>
+          <div class="callout-content">
+            <strong class="callout-title">The pool lives in memory, not in a database</strong>
+            <p>The counters are <span class="term" data-definition="In-memory means the information is held in the server&apos;s short-term working memory, not written to disk or a database. It is fast — and it vanishes completely the moment that server restarts.">in-memory</span>, held by a single copy of the pool object (a <span class="term" data-definition="A singleton is a thing the program deliberately creates only one of, so everybody shares the same copy. Handy for shared state — until you run several servers, and each one quietly gets its own singleton.">singleton</span>). Run three server copies and each has its own private pool with its own idea of which keys are burnt out. Restart, and the app forgets everything.</p>
+          </div>
+        </div>
+
+        <p>Those six keys are <span class="term" data-definition="An environment variable is a setting stored outside the code — on the server, in a config panel — so secrets never sit in the source files and can differ between test and live.">environment variables</span>, set on the server and never shipped to your browser.</p>
+
+        <div class="badge-list">
+          <div class="badge-item">
+            <code class="badge-code">GEMINI_API_KEY</code>
+            <span class="badge-desc">The first key. If only this one is set, the pool is a pool of one</span>
+          </div>
+          <div class="badge-item">
+            <code class="badge-code">GEMINI_API_KEY_2 … _5</code>
+            <span class="badge-desc">The extra doors — optional, and each one multiplies daily capacity</span>
+          </div>
+          <div class="badge-item">
+            <code class="badge-code">STORAGE_ENDPOINT</code>
+            <span class="badge-desc">Where finished pictures get uploaded — the address of the file warehouse</span>
+          </div>
+          <div class="badge-item">
+            <code class="badge-code">STORAGE_ACCESS_KEY</code>
+            <span class="badge-desc">The username half of the warehouse credentials</span>
+          </div>
+          <div class="badge-item">
+            <code class="badge-code">STORAGE_SECRET_KEY</code>
+            <span class="badge-desc">The password half. Server-side only, always</span>
+          </div>
+          <div class="badge-item">
+            <code class="badge-code">STORAGE_BUCKET</code>
+            <span class="badge-desc">Which shelf inside the warehouse these images belong on</span>
+          </div>
+        </div>
+      </section>
+
+      <!-- ============ SCREEN 7: WHEN THINGS GO WRONG ============ -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">When a key burns out</h2>
+
+        <p>Sooner or later a key hits its <span class="term" data-definition="A quota is the total allowance an account gets in a period — say 500 images a day. Spend it and you are done until the clock resets, no matter how much you are willing to pay.">quota</span> and Gemini refuses. Here is the app catching that and turning it into something a human can read.</p>
+
+        <div class="translation-block animate-in">
+          <div class="translation-code">
+            <span class="translation-label">CODE</span>
+            <pre><code><span class="code-line">      <span class="code-comment">// Check if it's a quota/limit error</span></span>
+<span class="code-line">      <span class="code-keyword">if</span> (error.message?.<span class="code-function">includes</span>(<span class="code-string">'quota'</span>) || error.message?.<span class="code-function">includes</span>(<span class="code-string">'limit'</span>) || error.status === <span class="code-number">429</span>) {</span>
+<span class="code-line">        geminiApiPool.<span class="code-function">markKeyAsUnavailable</span>(geminiApiKey, <span class="code-string">'Quota exceeded'</span>);</span>
+<span class="code-line">        <span class="code-keyword">return</span> <span class="code-function">respErr</span>(<span class="code-string">"Too many users online! VIP users get priority access. You're in queue, please wait a moment or upgrade to VIP for instant access."</span>, <span class="code-string">'QUEUE_REQUIRED'</span>);</span>
+<span class="code-line">      }</span></code></pre>
+          </div>
+          <div class="translation-english">
+            <span class="translation-label">PLAIN ENGLISH</span>
+            <div class="translation-lines">
+              <p class="tl">A note explaining the check below.</p>
+              <p class="tl">Three ways to recognise "you are out of budget": the word quota in the error, the word limit, or the code <span class="term" data-definition="HTTP 429 is the standard internet reply meaning Too Many Requests. It is the bouncer&apos;s hand on your chest — come back later, nothing personal.">429</span>. Any one of them counts.</p>
+              <p class="tl">Mark that key burnt out in the pool, so no future request wastes time on it.</p>
+              <p class="tl">Send the user a friendly message instead of a scary error — and a tag, <code>QUEUE_REQUIRED</code>, so the interface knows to show the queue and upgrade prompt.</p>
+              <p class="tl">Close the check. Any other kind of error falls through to the general handler below.</p>
+            </div>
+          </div>
+        </div>
+
+        <p>Note what that message really means: "too many users online" is one honest reading, and "we ran out of allowance on all six accounts" is another. Same code, different story.</p>
+
+        <h2 class="screen-heading" style="margin-top: var(--space-12)">Bending instead of breaking</h2>
+
+        <p>Storage is optional. If the warehouse is not set up, the app does not crash — it just carries the picture home in its pockets.</p>
+
+        <div class="translation-block animate-in">
+          <div class="translation-code">
+            <span class="translation-label">CODE</span>
+            <pre><code><span class="code-line">    <span class="code-keyword">const</span> hasStorageConfig = process.env.STORAGE_ENDPOINT &amp;&amp; </span>
+<span class="code-line">                            process.env.STORAGE_ACCESS_KEY &amp;&amp; </span>
+<span class="code-line">                            process.env.STORAGE_SECRET_KEY &amp;&amp; </span>
+<span class="code-line">                            process.env.STORAGE_BUCKET;</span></code></pre>
+          </div>
+          <div class="translation-english">
+            <span class="translation-label">PLAIN ENGLISH</span>
+            <div class="translation-lines">
+              <p class="tl">Before uploading anything, ask: do we actually have a warehouse address?</p>
+              <p class="tl">And a username for it?</p>
+              <p class="tl">And a password?</p>
+              <p class="tl">And a shelf to put things on? All four, or we skip uploading entirely.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="callout callout-info">
+          <div class="callout-icon">🪂</div>
+          <div class="callout-content">
+            <strong class="callout-title">A feature that degrades instead of dying</strong>
+            <p>With no storage configured, the image URL stays as a giant <code>data:image/png;base64,...</code> string and the app still works — the picture just travels inside the response instead of living at a web address. That is a <span class="term" data-definition="A fallback is the lesser-but-still-working path a program takes when the ideal one is unavailable — the stairs when the lift is out. Good software has them; brittle software just stops.">fallback</span>, and it is why a fresh developer can run this app with no cloud account at all.</p>
+          </div>
+        </div>
+      </section>
+
+      <!-- ============ SCREEN 8: THE DOCUMENTATION TRAP ============ -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">The documentation trap</h2>
+
+        <p>This project&apos;s own instructions file, <code>CLAUDE.md</code>, says in bold that the generator <em>requires a valid OpenAI API key to function</em>, and lists <code>OPENAI_API_KEY</code> as REQUIRED.</p>
+
+        <p>It does not. Nothing in the generator calls OpenAI. Everything you have just read calls Google Gemini.</p>
+
+        <div class="icon-rows">
+          <div class="icon-row">
+            <div class="icon-circle" style="background: var(--color-error)">📄</div>
+            <div>
+              <strong>What the docs say</strong>
+              <p>OPENAI_API_KEY is required. The feature is a "cyberpunk image generator".</p>
+            </div>
+          </div>
+          <div class="icon-row">
+            <div class="icon-circle" style="background: var(--color-success)">⚙️</div>
+            <div>
+              <strong>What the code does</strong>
+              <p>Reads GEMINI_API_KEY through the key pool and calls gemini-2.5-flash-image-preview.</p>
+            </div>
+          </div>
+          <div class="icon-row">
+            <div class="icon-circle" style="background: var(--color-actor-4)">🏷️</div>
+            <div>
+              <strong>Other honest leftovers</strong>
+              <p>The <span class="term" data-definition="An endpoint is one specific web address on the server that does one job — like a single phone extension in a company. Renaming one means updating every place that dials it.">endpoint</span> is still called generate-cyberpunk, and a whole unused video toolkit sits in the codebase with only a demo page importing it.</p>
+            </div>
+          </div>
+        </div>
+
+        <p>This is completely normal residue. A product got rebuilt — cyberpunk became Charlie &amp; Lola, OpenAI became Gemini — and the documentation stayed where it was, as documentation always does.</p>
+
+        <div class="callout callout-warning">
+          <div class="callout-icon">🤖</div>
+          <div class="callout-content">
+            <strong class="callout-title">Why this matters more for you than for a developer</strong>
+            <p>An AI coding assistant reads <code>CLAUDE.md</code> and README files as gospel. Ask one to "fix the image generation" and it may cheerfully add OpenAI code to a Gemini app — and be very confident about it.</p>
+          </div>
+        </div>
+
+        <p>So here is the habit worth building. Before you trust a doc, ask what the code actually calls — you can literally say this to your AI assistant:</p>
+
+        <div class="step-cards">
+          <div class="step-card">
+            <div class="step-num">1</div>
+            <div class="step-body">
+              <strong>"Search the codebase for which AI provider this feature actually imports."</strong>
+              <p>Searching for a word across every file is called <span class="term" data-definition="To grep is to search every file in a project for a word or pattern. It is the fastest way to find out what a codebase really does, as opposed to what its README claims.">grepping</span>, and it takes seconds.</p>
+            </div>
+          </div>
+          <div class="step-card">
+            <div class="step-num">2</div>
+            <div class="step-body">
+              <strong>"Show me the file the docs describe, and tell me where they disagree."</strong>
+              <p>Force the mismatch into the open before any code gets written.</p>
+            </div>
+          </div>
+          <div class="step-card">
+            <div class="step-num">3</div>
+            <div class="step-body">
+              <strong>"Update CLAUDE.md to match reality first, then make the change."</strong>
+              <p>Fixing the doc is a two-minute job that stops the next five confident mistakes.</p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- ============ SCREEN 9: QUIZ ============ -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">Think it through</h2>
+
+        <p>Four situations. None of them have appeared word-for-word above — that is the point.</p>
+
+        <div class="quiz-container" id="quiz-module3">
+
+          <div class="quiz-question-block"
+               data-correct="opt-memory"
+               data-explanation-right="Exactly. markKeyAsUnavailable writes to memory, and while markKeyAsAvailable and resetDailyLimits exist in the pool, nothing calls them on a schedule. Once a key is marked burnt, it stays burnt until the server restarts — which is why restarting the app is the accidental cure, and why this belongs in a database or on a timer, not in one server&apos;s head."
+               data-explanation-wrong="Not quite — and the clue is that Google says you have quota left. That means the refusal is not coming from Google at all any more; it is coming from the pool&apos;s own memory of a refusal it saw earlier. Nothing in the code ever un-marks a burnt key on a schedule.">
+            <h3 class="quiz-question">Every user suddenly sees "Too many users online!" — but your Google dashboard shows plenty of quota left on all six keys. What is the most likely cause?</h3>
+            <div class="quiz-options">
+              <button class="quiz-option" data-value="opt-google" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>Google is throttling the account behind the scenes and the dashboard is lagging</span>
+              </button>
+              <button class="quiz-option" data-value="opt-memory" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>The keys got marked unavailable in the pool&apos;s memory earlier, and nothing ever un-marks them</span>
+              </button>
+              <button class="quiz-option" data-value="opt-prompt" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>The prompt got too long, so requests are being rejected before they reach the model</span>
+              </button>
+              <button class="quiz-option" data-value="opt-storage" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>Storage is misconfigured, so finished images have nowhere to go</span>
+              </button>
+            </div>
+            <div class="quiz-feedback"></div>
+          </div>
+
+          <div class="quiz-question-block"
+               data-correct="opt-brief"
+               data-explanation-right="Exactly. Glasses are an accessory, and the brief already has a retain list. Adding a few words there costs one line of English, no new logic, no model change — and it is the single biggest quality lever in almost any AI feature."
+               data-explanation-wrong="Think about where the instructions actually live. The model is a rented generalist that does whatever the written brief asks — so the cheapest lever is almost always the wording, not the machinery around it.">
+            <h3 class="quiz-question">Users complain the output keeps dropping people&apos;s glasses. What is the cheapest place to fix it?</h3>
+            <div class="quiz-options">
+              <button class="quiz-option" data-value="opt-model" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>Switch to a more expensive, more capable Gemini model</span>
+              </button>
+              <button class="quiz-option" data-value="opt-brief" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>Add glasses to the "retain the subject&apos;s original…" list in the prompt paragraph</span>
+              </button>
+              <button class="quiz-option" data-value="opt-detect" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>Add code that detects glasses in the upload and pastes them back onto the result</span>
+              </button>
+              <button class="quiz-option" data-value="opt-retry" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>Call the model three times and pick whichever result kept the glasses</span>
+              </button>
+            </div>
+            <div class="quiz-feedback"></div>
+          </div>
+
+          <div class="quiz-question-block"
+               data-correct="opt-correct-premise"
+               data-explanation-right="Exactly. The request contains a false premise picked up from a stale doc. Correcting it first — and pointing at the route and the key pool — is the difference between a clean change and an assistant confidently bolting OpenAI onto a Gemini app."
+               data-explanation-wrong="Careful — the phrase &quot;matching how we do it today&quot; is doing a lot of damage here, because today the app uses Gemini, not OpenAI. Sorting out the premise before any code gets written is what saves the afternoon.">
+            <h3 class="quiz-question">You tell an AI assistant: "add support for the new OpenAI image model, matching how we do image generation today." What should you say first, before anything else?</h3>
+            <div class="quiz-options">
+              <button class="quiz-option" data-value="opt-tests" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>Ask it to write tests first, so the change is safe</span>
+              </button>
+              <button class="quiz-option" data-value="opt-correct-premise" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>Correct the premise: the app uses Gemini today, CLAUDE.md is out of date — read route.ts and the key pool</span>
+              </button>
+              <button class="quiz-option" data-value="opt-branch" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>Ask it to work on a separate branch so nothing breaks</span>
+              </button>
+              <button class="quiz-option" data-value="opt-docs" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>Paste in the OpenAI documentation so it has the latest reference</span>
+              </button>
+            </div>
+            <div class="quiz-feedback"></div>
+          </div>
+
+          <div class="quiz-question-block"
+               data-correct="opt-replied-text"
+               data-explanation-right="Exactly. A key was handed out, the call went through, and Gemini answered — the loop simply walked the parts and found no inlineData anywhere. The reply was words, most often a safety refusal. Look at the prompt and the uploaded photo, not at keys or networking."
+               data-explanation-wrong="Read the message literally: something came back, and code ran over it looking for a picture. That rules out the key and the network — the failure is at the far end of the journey, in what the model chose to reply with.">
+            <h3 class="quiz-question">A request comes back successfully, but the app reports "No image data found in Gemini API response." What does that tell you about where the failure happened?</h3>
+            <div class="quiz-options">
+              <button class="quiz-option" data-value="opt-key" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>The key pool handed out a burnt-out key</span>
+              </button>
+              <button class="quiz-option" data-value="opt-network" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>The connection to Google dropped partway through</span>
+              </button>
+              <button class="quiz-option" data-value="opt-replied-text" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>The call worked and the model replied — with text rather than a picture, most likely a refusal</span>
+              </button>
+              <button class="quiz-option" data-value="opt-upload" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>The upload to R2 storage failed, so the image URL is missing</span>
+              </button>
+            </div>
+            <div class="quiz-feedback"></div>
+          </div>
+
+          <button class="quiz-check-btn" onclick="checkQuiz('quiz-module3')">Check Answers</button>
+          <button class="quiz-reset-btn" onclick="resetQuiz('quiz-module3')">Try Again</button>
+        </div>
+      </section>
+
+      <!-- ============ SCREEN 10: WRAP + TEASE ============ -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">What you can do with this now</h2>
+
+        <div class="icon-rows">
+          <div class="icon-row">
+            <div class="icon-circle" style="background: var(--color-actor-1)">✍️</div>
+            <div>
+              <strong>Change the output without changing code</strong>
+              <p>The biggest quality lever in an AI feature is the wording of the brief: make / preserve / forbid.</p>
+            </div>
+          </div>
+          <div class="icon-row">
+            <div class="icon-circle" style="background: var(--color-actor-2)">🚪</div>
+            <div>
+              <strong>Reason about capacity before you build</strong>
+              <p>Rate limits are doors, not fines. Pooling keys buys more doors; it does not make the club bigger.</p>
+            </div>
+          </div>
+          <div class="icon-row">
+            <div class="icon-circle" style="background: var(--color-actor-3)">🔎</div>
+            <div>
+              <strong>Trust the code over the docs</strong>
+              <p>Ask what a feature actually imports before you accept what any README tells you it does.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="callout callout-info">
+          <div class="callout-icon">🧱</div>
+          <div class="callout-content">
+            <strong class="callout-title">Next: The LEGO Box</strong>
+            <p>The engine is rented. The interface around it is entirely the app&apos;s own — colour tokens, Tailwind, and about thirty reusable bricks that every panel in the generator is built from.</p>
+          </div>
+        </div>
+      </section>
+
+    </div>
+  </div>
+</section>

--- a/courses/image-generator-ui-course/modules/04-ui.html
+++ b/courses/image-generator-ui-course/modules/04-ui.html
@@ -1,0 +1,707 @@
+<section class="module" id="module-4" style="background: var(--color-bg)">
+  <div class="module-content">
+
+    <header class="module-header animate-in">
+      <span class="module-number">04</span>
+      <h1 class="module-title">The LEGO Box</h1>
+      <p class="module-subtitle">Nobody wrote the colour yellow anywhere near the upload box. Here is how the glow gets there — through four layers of indirection, every one of them earning its keep.</p>
+    </header>
+
+    <div class="module-body">
+
+      <!-- ============ SCREEN 1: THE HOOK ============ -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">Drag a photo over the box. It glows yellow.</h2>
+
+        <p>Last module we watched the app hand a written brief to a rented artist. Now turn around and look at the dashboard the app built <em>around</em> that engine — the panel, the buttons, the glow.</p>
+
+        <p>Open the generator, pick up a photo, hold it over the upload area. The dashed outline goes solid lemon yellow and the inside washes faintly warm. Search the generator&apos;s file for the word "yellow" as a colour value and you will not find it.</p>
+
+        <div class="callout callout-accent">
+          <div class="callout-icon">🧱</div>
+          <div class="callout-content">
+            <strong class="callout-title">The metaphor for this module: a LEGO box with a paint chart taped inside the lid</strong>
+            <p>The tray of loose bricks is <code>src/components/ui/</code> — Button, Card, Input, about thirty of them. The finished models are <code>src/components/blocks/</code> — the hero section, the pricing table, the generator panel. And taped inside the lid is one paint chart: change a swatch there and every brick in every model repaints at once, because no brick names a colour directly.</p>
+          </div>
+        </div>
+
+        <h2 class="screen-heading" style="margin-top: var(--space-12)">The one idea, before the details</h2>
+
+        <p>Nothing in this interface names a colour, a corner radius or a shadow directly. Everything names a <em>role</em> — <code>primary</code>, <code>card</code>, <code>border</code>, <code>muted-foreground</code> — and the roles get their values in one file, twice: once for light mode, once for dark.</p>
+
+        <div class="icon-rows">
+          <div class="icon-row">
+            <div class="icon-circle" style="background: var(--color-actor-1)">🚫</div>
+            <div>
+              <strong>What the app never says</strong>
+              <p>"Paint this button <code>#F5D547</code>." A <span class="term" data-definition="A hex colour is a colour written as a # followed by six characters, like #F5D547. It is exact, and it is completely anonymous — nothing about it says what the colour is for.">hex colour</span> typed straight onto an element is a dead end: it looks right today and wrong after the next theme tweak.</p>
+            </div>
+          </div>
+          <div class="icon-row">
+            <div class="icon-circle" style="background: var(--color-actor-2)">✅</div>
+            <div>
+              <strong>What it says instead</strong>
+              <p>"Paint this button with whatever <code>primary</code> currently means." One sentence in one file decides what that is, for the whole app, in both light and dark.</p>
+            </div>
+          </div>
+          <div class="icon-row">
+            <div class="icon-circle" style="background: var(--color-actor-5)">🌗</div>
+            <div>
+              <strong>Which is why dark mode is free</strong>
+              <p>The whole app can flip to <span class="term" data-definition="Dark mode is the light-text-on-dark-background version of an interface. In a well-built app it is not a second design — it is the same design with a different set of colour values swapped in.">dark mode</span> without a single button, card or input knowing dark mode exists.</p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- ============ SCREEN 2: HERO — THE FOUR LAYERS ============ -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">Follow one yellow, all the way to the button</h2>
+
+        <p>Here is the actual journey of the app&apos;s lemon yellow, from the paint chart to the pixel under your cursor. Five hops, four of them are files you could open right now.</p>
+
+        <div class="flow-steps">
+          <div class="flow-step">
+            <div class="flow-step-num">1</div>
+            <p><code>oklch(0.9&nbsp;0.15&nbsp;85)</code></p>
+          </div>
+          <div class="flow-arrow">→</div>
+          <div class="flow-step">
+            <div class="flow-step-num">2</div>
+            <p><code>--primary</code></p>
+          </div>
+          <div class="flow-arrow">→</div>
+          <div class="flow-step">
+            <div class="flow-step-num">3</div>
+            <p><code>--color-primary</code></p>
+          </div>
+          <div class="flow-arrow">→</div>
+          <div class="flow-step">
+            <div class="flow-step-num">4</div>
+            <p><code>bg-primary</code></p>
+          </div>
+          <div class="flow-arrow">→</div>
+          <div class="flow-step">
+            <div class="flow-step-num">5</div>
+            <p>the Generate button</p>
+          </div>
+        </div>
+
+        <p>Four layers make that journey possible. Click through them — each tab is a real file in this project.</p>
+
+        <div class="layer-demo">
+          <div class="layer-tabs">
+            <button class="layer-tab active" onclick="showLayer('m4-layer-paint', this)">1 · Paint chart</button>
+            <button class="layer-tab" onclick="showLayer('m4-layer-bridge', this)">2 · Bridge</button>
+            <button class="layer-tab" onclick="showLayer('m4-layer-utility', this)">3 · Utility classes</button>
+            <button class="layer-tab" onclick="showLayer('m4-layer-bricks', this)">4 · Bricks</button>
+          </div>
+
+          <!-- LAYER 1 -->
+          <div class="layer" id="m4-layer-paint" style="display:block">
+            <p><strong>The paint chart —</strong> <code>src/app/theme.css</code>. Inside the <span class="term" data-definition="&#58;root is CSS shorthand for the very top of the page — the outermost element everything else lives inside. Values set there are visible to every element on the page, which makes it the natural home for app-wide settings.">:root</span> block, raw colour values get given role names. A second block further down, <code>.dark</code>, redefines the same names with different values.</p>
+
+            <div class="translation-block">
+              <div class="translation-code">
+                <span class="translation-label">CODE</span>
+                <pre><code><span class="code-line">  <span class="code-property">--primary</span>: <span class="code-function">oklch</span>(<span class="code-number">0.9 0.15 85</span>);            <span class="code-comment">/* Lemon Yellow */</span></span>
+<span class="code-line">  <span class="code-property">--primary-foreground</span>: <span class="code-function">oklch</span>(<span class="code-number">0.17 0 0</span>);</span>
+<span class="code-line">  <span class="code-property">--secondary</span>: <span class="code-function">oklch</span>(<span class="code-number">0.8 0.08 200</span>);         <span class="code-comment">/* Sky Blue */</span></span>
+<span class="code-line">  <span class="code-property">--secondary-foreground</span>: <span class="code-function">oklch</span>(<span class="code-number">0.17 0 0</span>);</span>
+<span class="code-line">  <span class="code-property">--muted</span>: <span class="code-function">oklch</span>(<span class="code-number">0.95 0.02 90</span>);            <span class="code-comment">/* Lighter gray */</span></span>
+<span class="code-line">  <span class="code-property">--muted-foreground</span>: <span class="code-function">oklch</span>(<span class="code-number">0.4 0.02 50</span>);</span>
+<span class="code-line">  <span class="code-property">--accent</span>: <span class="code-function">oklch</span>(<span class="code-number">0.8 0.15 60</span>);             <span class="code-comment">/* Coral Orange */</span></span>
+<span class="code-line">  <span class="code-property">--accent-foreground</span>: <span class="code-function">oklch</span>(<span class="code-number">0.17 0 0</span>);</span>
+<span class="code-line">  <span class="code-property">--destructive</span>: <span class="code-function">oklch</span>(<span class="code-number">0.7 0.2 25</span>);           <span class="code-comment">/* Tomato Red */</span></span></code></pre>
+              </div>
+              <div class="translation-english">
+                <span class="translation-label">PLAIN ENGLISH</span>
+                <div class="translation-lines">
+                  <p class="tl">Each of these is a <span class="term" data-definition="A CSS variable (properly: a custom property) is a named value you set once and reuse everywhere, written with two dashes in front — like --primary. Change it in one place and every element reading it updates.">CSS variable</span> — a named value. This one is not called "yellow", it is called "the main colour", and today the main colour happens to be lemon.</p>
+                  <p class="tl">Every background role gets a matching <em>foreground</em> — the ink that goes on top. Near-black here, so text on yellow stays readable.</p>
+                  <p class="tl">The app&apos;s second voice: sky blue, with its own matching ink. This is what the <code>secondary</code> buttons use.</p>
+                  <p class="tl">The quiet pair: a pale background and a soft grey text colour, for captions, hints and placeholder text.</p>
+                  <p class="tl">Coral orange for highlights and hover states — plus, again, the ink that belongs on it.</p>
+                  <p class="tl">And the "are you sure?" red. Every delete button in the app reads this one name.</p>
+                  <p class="tl"><span class="term" data-definition="oklch(lightness chroma hue) is a newer way of writing colours. The first number is how light it is, the second how vivid, the third which hue on the colour wheel. Its advantage over hex: nudging the lightness of two different hues by the same amount actually looks like the same amount.">oklch</span> is just a way of spelling a colour: how light, how vivid, which hue.</p>
+                </div>
+              </div>
+            </div>
+
+            <p class="layer-description">Nine role names, nine values. Swap the values, and every screen in the app is wearing a new outfit.</p>
+          </div>
+
+          <!-- LAYER 2 -->
+          <div class="layer" id="m4-layer-bridge" style="display:none">
+            <p><strong>The bridge —</strong> further down the same file. This block is what turns a role name into something you can actually type on an element.</p>
+
+            <div class="translation-block">
+              <div class="translation-code">
+                <span class="translation-label">CODE</span>
+                <pre><code><span class="code-line"><span class="code-keyword">@theme</span> inline {</span>
+<span class="code-line">  <span class="code-property">--color-background</span>: <span class="code-function">var</span>(--background);</span>
+<span class="code-line">  <span class="code-property">--color-foreground</span>: <span class="code-function">var</span>(--foreground);</span>
+<span class="code-line">  <span class="code-property">--color-card</span>: <span class="code-function">var</span>(--card);</span>
+<span class="code-line">  <span class="code-property">--color-card-foreground</span>: <span class="code-function">var</span>(--card-foreground);</span>
+<span class="code-line">  <span class="code-property">--color-popover</span>: <span class="code-function">var</span>(--popover);</span>
+<span class="code-line">  <span class="code-property">--color-popover-foreground</span>: <span class="code-function">var</span>(--popover-foreground);</span>
+<span class="code-line">  <span class="code-property">--color-primary</span>: <span class="code-function">var</span>(--primary);</span>
+<span class="code-line">  <span class="code-property">--color-primary-foreground</span>: <span class="code-function">var</span>(--primary-foreground);</span></code></pre>
+              </div>
+              <div class="translation-english">
+                <span class="translation-label">PLAIN ENGLISH</span>
+                <div class="translation-lines">
+                  <p class="tl">"Here is my palette, Tailwind — register every one of these as a colour you know about."</p>
+                  <p class="tl">The page background and the main text colour get registered first.</p>
+                  <p class="tl">Then the card surface and the ink that sits on cards.</p>
+                  <p class="tl">Then popovers — the little floating panels that appear over the page.</p>
+                  <p class="tl"><code>var(--primary)</code> means "go and read whatever <code>--primary</code> currently is". It does not copy the yellow, it points at it.</p>
+                  <p class="tl">That pointing is the whole trick: registered once here, the value can still change underneath — which is exactly what the <code>.dark</code> block does.</p>
+                  <p class="tl">The payoff of this one line: the class name <code>bg-primary</code> now exists and works.</p>
+                </div>
+              </div>
+            </div>
+
+            <p class="layer-description">Layer 1 decides <em>what</em> the colour is. Layer 2 decides <em>that you can type it</em>.</p>
+          </div>
+
+          <!-- LAYER 3 -->
+          <div class="layer" id="m4-layer-utility" style="display:none">
+            <p><strong>The utility classes —</strong> <span class="term" data-definition="Tailwind is a styling toolkit. Instead of writing a separate stylesheet, you attach lots of tiny single-purpose class names directly to the element — one for padding, one for colour, one for rounded corners.">Tailwind</span>. Honestly: it looks noisy. In exchange you never have to invent a name like <code>.upload-box-inner-wrapper</code> again.</p>
+
+            <p>Traditional <span class="term" data-definition="CSS is the language that decides how a web page looks — colours, spacing, sizes, fonts. Historically it lives in its own file, separate from the page structure.">CSS</span> means writing the look in one file and the <span class="term" data-definition="A class is a label you attach to an element so styling rules can find it — like putting a coloured sticker on a box so you can say &quot;paint every box with a red sticker&quot;.">class</span> names in another, then keeping the two in sync forever. Tailwind puts tiny single-purpose classes directly on the element instead.</p>
+
+            <div class="badge-list">
+              <div class="badge-item">
+                <code class="badge-code">bg-primary</code>
+                <span class="badge-desc">Background = the <code>primary</code> role. This is hop 4 of the yellow&apos;s journey.</span>
+              </div>
+              <div class="badge-item">
+                <code class="badge-code">text-muted-foreground</code>
+                <span class="badge-desc">Text = the quiet grey. Used on every hint and caption in the generator.</span>
+              </div>
+              <div class="badge-item">
+                <code class="badge-code">border-2 border-dashed</code>
+                <span class="badge-desc">A 2-pixel dashed outline — the resting state of the upload box.</span>
+              </div>
+              <div class="badge-item">
+                <code class="badge-code">rounded-xl</code>
+                <span class="badge-desc">Extra-large rounded corners, sized from the app&apos;s single <code>--radius</code> setting.</span>
+              </div>
+              <div class="badge-item">
+                <code class="badge-code">grid lg:grid-cols-2</code>
+                <span class="badge-desc">One column normally; two side-by-side once the screen is wide. <code>lg:</code> is a <span class="term" data-definition="A responsive breakpoint is a screen width at which the layout is allowed to change. In Tailwind you write it as a prefix — lg&#58; means &quot;from large screens upward&quot;.">responsive breakpoint</span>.</span>
+              </div>
+              <div class="badge-item">
+                <code class="badge-code">hover:bg-primary/90</code>
+                <span class="badge-desc">On hover, the same yellow at 90% strength. Prefixes stack conditions onto a class.</span>
+              </div>
+            </div>
+
+            <p class="layer-description">Every one of these is real, copied from the generator panel and the button file you are about to see.</p>
+          </div>
+
+          <!-- LAYER 4 -->
+          <div class="layer" id="m4-layer-bricks" style="display:none">
+            <p><strong>The bricks —</strong> <span class="term" data-definition="Shadcn UI is a collection of ready-made interface pieces — buttons, cards, dialogs. Unlike a normal library, you do not install it and import from it: you copy the pieces into your own project as ordinary files you own and can edit.">Shadcn UI</span>. The crucial, easily-missed part: it is <em>not</em> a library you install and import from. Its components are copied into your own repository as ordinary files you own.</p>
+
+            <p>That is why <code>src/components/ui/button.tsx</code> is only 59 lines and sitting right there in the project. Here is a whole brick, in full.</p>
+
+            <div class="translation-block">
+              <div class="translation-code">
+                <span class="translation-label">CODE</span>
+                <pre><code><span class="code-line"><span class="code-keyword">function</span> <span class="code-function">Card</span>({ className, ...props }: React.ComponentProps&lt;<span class="code-string">"div"</span>&gt;) {</span>
+<span class="code-line">  <span class="code-keyword">return</span> (</span>
+<span class="code-line">    &lt;<span class="code-tag">div</span></span>
+<span class="code-line">      <span class="code-attr">data-slot</span>=<span class="code-value">"card"</span></span>
+<span class="code-line">      <span class="code-attr">className</span>={<span class="code-function">cn</span>(</span>
+<span class="code-line">        <span class="code-string">"bg-card text-card-foreground flex flex-col gap-6 rounded-xl border py-6 shadow-sm"</span>,</span>
+<span class="code-line">        className</span>
+<span class="code-line">      )}</span>
+<span class="code-line">      {...props}</span>
+<span class="code-line">    /&gt;</span>
+<span class="code-line">  )</span>
+<span class="code-line">}</span></code></pre>
+              </div>
+              <div class="translation-english">
+                <span class="translation-label">PLAIN ENGLISH</span>
+                <div class="translation-lines">
+                  <p class="tl">Define a <span class="term" data-definition="A component is one reusable piece of interface — a button, a card, a search box — defined once and used in many places. Think of it as a LEGO brick: same shape every time, whatever you build with it.">component</span> called <code>Card</code>. It accepts a <code>className</code> (extra classes the caller wants to add) plus anything else passed to it.</p>
+                  <p class="tl">Here is what it puts on the screen…</p>
+                  <p class="tl">…a plain <code>div</code>. That is all a Card really is: a box.</p>
+                  <p class="tl">Stamp it with a <span class="term" data-definition="A data- attribute is a custom label you can attach to any element on a page — invisible to the user, but findable by styling rules, tests and scripts. Here it says &quot;this thing is a card&quot;.">data- attribute</span> that says "this is a card". Remember this line — it becomes a back door in a moment.</p>
+                  <p class="tl">Now build the class list with <code>cn()</code>, the next screen&apos;s star.</p>
+                  <p class="tl">Card&apos;s own opinions: card background, matching ink, children stacked with a gap, rounded corners, a border, vertical padding, small shadow.</p>
+                  <p class="tl">…followed by whatever the caller passed in, which is allowed to override the opinions above.</p>
+                  <p class="tl">Close the class list.</p>
+                  <p class="tl">Pass everything else straight through — the click handler, the id, the contents, all of it.</p>
+                </div>
+              </div>
+            </div>
+
+            <p class="layer-description">Notice: not one colour, size or shadow value in that file. Only role names.</p>
+          </div>
+        </div>
+      </section>
+
+      <!-- ============ SCREEN 3: cn() ============ -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">The six-line file that shows up everywhere</h2>
+
+        <p>You just saw <code>cn()</code> inside Card. It is in essentially every component in this project. Here is the entire thing.</p>
+
+        <div class="translation-block animate-in">
+          <div class="translation-code">
+            <span class="translation-label">CODE</span>
+            <pre><code><span class="code-line"><span class="code-keyword">import</span> { clsx, <span class="code-keyword">type</span> ClassValue } <span class="code-keyword">from</span> <span class="code-string">"clsx"</span>;</span>
+<span class="code-line"><span class="code-keyword">import</span> { twMerge } <span class="code-keyword">from</span> <span class="code-string">"tailwind-merge"</span>;</span>
+<span class="code-line"></span>
+<span class="code-line"><span class="code-keyword">export function</span> <span class="code-function">cn</span>(...inputs: ClassValue[]) {</span>
+<span class="code-line">  <span class="code-keyword">return</span> <span class="code-function">twMerge</span>(<span class="code-function">clsx</span>(inputs));</span>
+<span class="code-line">}</span></code></pre>
+          </div>
+          <div class="translation-english">
+            <span class="translation-label">PLAIN ENGLISH</span>
+            <div class="translation-lines">
+              <p class="tl">Borrow <span class="term" data-definition="clsx is a tiny helper that glues a list of class names into one string and quietly drops any entry that turned out to be false or empty. It saves you from writing &quot;undefined&quot; into your HTML.">clsx</span> — it glues class names together and drops any that are false.</p>
+              <p class="tl">Borrow <code>twMerge</code> — the referee that settles fights between conflicting classes.</p>
+              <p class="tl">(Blank line. The imports are done.)</p>
+              <p class="tl">Make a <span class="term" data-definition="A function is a named piece of behaviour you can run whenever you like, usually giving it some input and getting something back. Here: give it class names, get back one tidy class name string.">function</span> called <code>cn</code> that accepts any number of class-name bits — strings, or conditions that may produce nothing.</p>
+              <p class="tl">Glue them all together, then hand the result to the referee and return the verdict.</p>
+              <p class="tl">Done. Six lines, used thousands of times.</p>
+            </div>
+          </div>
+        </div>
+
+        <h2 class="screen-heading" style="margin-top: var(--space-12)">Why the referee matters</h2>
+
+        <p>If a component bakes in <code>px-4</code> and you pass <code>px-8</code>, plain gluing would put both in the page and leave the browser to decide by an obscure rulebook.</p>
+
+        <div class="step-cards">
+          <div class="step-card">
+            <div class="step-num">✕</div>
+            <div class="step-body">
+              <strong>Without twMerge</strong>
+              <p><code>"px-4 px-8"</code> — both survive. Which one wins depends on <span class="term" data-definition="Specificity is the browser&apos;s tie-breaking rulebook for deciding which style wins when two rules apply to the same element. It is famously fiddly, and relying on it is how interfaces get mysterious.">specificity</span> and stylesheet order. Fun to debug at 11pm.</p>
+            </div>
+          </div>
+          <div class="step-card">
+            <div class="step-num">✓</div>
+            <div class="step-body">
+              <strong>With twMerge</strong>
+              <p><code>"px-8"</code> — the referee notices the two are arguing about the same thing, deletes the earlier one, keeps the later one. Every time, predictably.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="callout callout-info">
+          <div class="callout-icon">🎛️</div>
+          <div class="callout-content">
+            <strong class="callout-title">This is the rule that makes bricks reusable</strong>
+            <p>A component can hold strong opinions about how it looks <em>and</em> still let any caller override them, because the caller&apos;s classes always go last into <code>cn()</code>. Opinionated by default, overridable on request.</p>
+          </div>
+        </div>
+      </section>
+
+      <!-- ============ SCREEN 4: CVA ============ -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">One button component, six different looks</h2>
+
+        <p>The app does not have six button files. It has one, plus a lookup table that turns a word like <code>outline</code> into a string of classes.</p>
+
+        <p>The table lives in <code>src/components/ui/button.tsx</code> and is built with <span class="term" data-definition="cva stands for &quot;class variance authority&quot; — a small tool for mapping option names to sets of classes. In plain terms: a menu that says &quot;if someone asks for the outline look, here are the classes that make it&quot;.">cva</span>.</p>
+
+        <div class="translation-block animate-in">
+          <div class="translation-code">
+            <span class="translation-label">CODE</span>
+            <pre><code><span class="code-line">    <span class="code-property">variants</span>: {</span>
+<span class="code-line">      <span class="code-property">variant</span>: {</span>
+<span class="code-line">        <span class="code-property">default</span>:</span>
+<span class="code-line">          <span class="code-string">"bg-primary text-primary-foreground shadow-xs hover:bg-primary/90"</span>,</span>
+<span class="code-line">        <span class="code-property">destructive</span>:</span>
+<span class="code-line">          <span class="code-string">"bg-destructive text-white shadow-xs hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60"</span>,</span>
+<span class="code-line">        <span class="code-property">outline</span>:</span>
+<span class="code-line">          <span class="code-string">"border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50"</span>,</span>
+<span class="code-line">        <span class="code-property">secondary</span>:</span>
+<span class="code-line">          <span class="code-string">"bg-secondary text-secondary-foreground shadow-xs hover:bg-secondary/80"</span>,</span>
+<span class="code-line">        <span class="code-property">ghost</span>:</span>
+<span class="code-line">          <span class="code-string">"hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50"</span>,</span>
+<span class="code-line">        <span class="code-property">link</span>: <span class="code-string">"text-primary underline-offset-4 hover:underline"</span>,</span>
+<span class="code-line">      },</span></code></pre>
+          </div>
+          <div class="translation-english">
+            <span class="translation-label">PLAIN ENGLISH</span>
+            <div class="translation-lines">
+              <p class="tl">"Here are the ways this button is allowed to differ."</p>
+              <p class="tl">The first way is called <span class="term" data-definition="A variant is one named version of a component — the outline button, the small button, the danger button. Same component, different look, chosen by name.">variant</span> — the word you type as <code>variant="…"</code> when you use the button.</p>
+              <p class="tl"><strong>default</strong> — the yellow one. Background = <code>primary</code>, ink = the matching foreground, tiny shadow, and on hover the same yellow at 90% strength. This is the Generate button.</p>
+              <p class="tl"><strong>destructive</strong> — the red one, with a red focus ring, and slightly different values when the page is in dark mode (that is what the <code>dark:</code> prefix means).</p>
+              <p class="tl"><strong>outline</strong> — a border and the page background, going coral on hover. Quiet until you touch it.</p>
+              <p class="tl"><strong>secondary</strong> — identical shape, sky blue instead of lemon. One token swapped.</p>
+              <p class="tl"><strong>ghost</strong> — nothing at all until hover. Used for icon buttons that should not shout.</p>
+              <p class="tl"><strong>link</strong> — not a box at all; it looks like a text link and underlines on hover.</p>
+              <p class="tl">End of the look menu. Six entries, one component, zero duplicate files.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="callout callout-accent">
+          <div class="callout-icon">💡</div>
+          <div class="callout-content">
+            <strong class="callout-title">Aha! Indirection is a superpower you can ask for</strong>
+            <p>"Use the <code>secondary</code> token, not a hex value" and "add a <code>variant</code> to the existing <code>buttonVariants</code>, don&apos;t write a new component" are two of the highest-value sentences you can say to an AI coding assistant. They are the difference between a change that lands in one place and a change that lands in forty.</p>
+          </div>
+        </div>
+      </section>
+
+      <!-- ============ SCREEN 5: THE GLOW ============ -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">Back to the glow</h2>
+
+        <p>Now the opening hook decodes. This is the real upload box from <code>imagen-client.tsx</code> — one true-or-false value swapping one set of class names for another.</p>
+
+        <div class="translation-block animate-in">
+          <div class="translation-code">
+            <span class="translation-label">CODE</span>
+            <pre><code><span class="code-line">                    <span class="code-attr">className</span>={<span class="code-function">cn</span>(</span>
+<span class="code-line">                      <span class="code-string">"relative min-h-[400px] rounded-xl border-2 border-dashed transition-all duration-300 cursor-pointer"</span>,</span>
+<span class="code-line">                      uploadedImages.length &gt; <span class="code-number">0</span> ? <span class="code-string">"flex"</span> : <span class="code-string">"flex items-center justify-center"</span>,</span>
+<span class="code-line">                      dragActive </span>
+<span class="code-line">                        ? <span class="code-string">"border-cl-yellow bg-cl-yellow/10"</span> </span>
+<span class="code-line">                        : <span class="code-string">"border-muted hover:border-cl-yellow hover:bg-cl-yellow/5"</span></span>
+<span class="code-line">                    )}</span></code></pre>
+          </div>
+          <div class="translation-english">
+            <span class="translation-label">PLAIN ENGLISH</span>
+            <div class="translation-lines">
+              <p class="tl">Work out this box&apos;s classes fresh, every time the screen redraws.</p>
+              <p class="tl">Always true: at least 400 pixels tall, extra-rounded corners, a 2-pixel dashed outline, animate any change over 300 milliseconds, show a pointer cursor.</p>
+              <p class="tl">Are there already photos in the box? Then just lay them out. If it is empty, centre the "drop a photo here" message instead.</p>
+              <p class="tl"><code>dragActive</code> is a <span class="term" data-definition="A boolean is a value that can only be true or false — a light switch, not a dial. Most on/off behaviour in an interface is one boolean somewhere.">boolean</span>: is a file being dragged over the box <em>right now</em>?</p>
+              <p class="tl">Yes → solid yellow outline plus a 10%-strength yellow wash. <strong>That is the glow.</strong></p>
+              <p class="tl">No → muted grey outline, turning yellow only when the mouse hovers, with an even fainter 5% wash.</p>
+              <p class="tl">Hand the finished class list to the box.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="icon-rows">
+          <div class="icon-row">
+            <div class="icon-circle" style="background: var(--color-actor-4)">🔀</div>
+            <div>
+              <strong>State goes in, classes come out</strong>
+              <p><code>dragActive</code> is flipped true by <code>onDragOver</code> and false by <code>onDragLeave</code>. Everything else follows automatically.</p>
+            </div>
+          </div>
+          <div class="icon-row">
+            <div class="icon-circle" style="background: var(--color-actor-3)">🚫</div>
+            <div>
+              <strong>No animation library. No manual page editing.</strong>
+              <p>Nothing here reaches into the page and repaints a pixel. The app describes what the box should look like; the browser does the rest.</p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- ============ SCREEN 6: BRICKS VS MODELS ============ -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">The tray of bricks and the finished models</h2>
+
+        <p>Two folders, two completely different jobs. Getting this distinction right is most of what "keeping a codebase tidy" means in practice.</p>
+
+        <div class="file-tree">
+          <div class="ft-folder open">
+            <span class="ft-name">components/</span>
+            <span class="ft-desc">everything the user looks at</span>
+            <div class="ft-children">
+              <div class="ft-folder open">
+                <span class="ft-name">ui/</span>
+                <span class="ft-desc">the loose bricks — generic, reusable, know nothing about this app</span>
+                <div class="ft-children">
+                  <div class="ft-file"><span class="ft-name">button.tsx</span><span class="ft-desc">59 lines, six variants</span></div>
+                  <div class="ft-file"><span class="ft-name">card.tsx</span><span class="ft-desc">a box with a border and a gap</span></div>
+                  <div class="ft-file"><span class="ft-name">input.tsx</span><span class="ft-desc">a text field, styled</span></div>
+                </div>
+              </div>
+              <div class="ft-folder open">
+                <span class="ft-name">blocks/</span>
+                <span class="ft-desc">the finished models — built from bricks, and they know this app</span>
+                <div class="ft-children">
+                  <div class="ft-file"><span class="ft-name">imagen-wrapper/</span><span class="ft-desc">the whole generator panel</span></div>
+                  <div class="ft-file"><span class="ft-name">form/</span><span class="ft-desc">the feedback and settings forms</span></div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="pattern-cards stagger-children">
+          <div class="pattern-card animate-in" style="border-top: 3px solid var(--color-actor-2)">
+            <div class="pattern-icon" style="background: var(--color-actor-2)">🧱</div>
+            <h4 class="pattern-title">Bricks (<code>ui/</code>)</h4>
+            <p class="pattern-desc">No business logic, no app text, no data. You could lift <code>button.tsx</code> into a completely different project tomorrow. Safe to reuse anywhere.</p>
+          </div>
+          <div class="pattern-card animate-in" style="border-top: 3px solid var(--color-actor-1)">
+            <div class="pattern-icon" style="background: var(--color-actor-1)">🏰</div>
+            <h4 class="pattern-title">Models (<code>blocks/</code>)</h4>
+            <p class="pattern-desc">These know about <em>this</em> app — its wording, its uploads, its Generate button. Reusing one somewhere else would drag the whole app along with it.</p>
+          </div>
+          <div class="pattern-card animate-in" style="border-top: 3px solid var(--color-actor-5)">
+            <div class="pattern-icon" style="background: var(--color-actor-5)">🗣️</div>
+            <h4 class="pattern-title">How to say it</h4>
+            <p class="pattern-desc">"Build this out of the existing <code>ui/</code> components and put the new panel in <code>blocks/</code>" is a one-sentence architecture instruction an AI will follow happily.</p>
+          </div>
+        </div>
+
+        <h2 class="screen-heading" style="margin-top: var(--space-12)">The back door: restyling every brick without touching it</h2>
+
+        <p>Remember <code>data-slot="card"</code> stamped on the Card component? Shadcn stamps one on every component it ships. This project uses those stamps as a back door.</p>
+
+        <div class="translation-block animate-in">
+          <div class="translation-code">
+            <span class="translation-label">CODE</span>
+            <pre><code><span class="code-line">[<span class="code-attr">data-slot</span>=<span class="code-value">"card"</span>] {</span>
+<span class="code-line">  <span class="code-property">background</span>: <span class="code-function">var</span>(--card);</span>
+<span class="code-line">  <span class="code-property">border</span>: <span class="code-number">2px</span> solid <span class="code-function">var</span>(--border);</span>
+<span class="code-line">  <span class="code-property">border-radius</span>: <span class="code-function">var</span>(--radius);</span>
+<span class="code-line">  <span class="code-property">box-shadow</span>: none;</span>
+<span class="code-line">}</span></code></pre>
+          </div>
+          <div class="translation-english">
+            <span class="translation-label">PLAIN ENGLISH</span>
+            <div class="translation-lines">
+              <p class="tl">"Find every element in the entire app carrying the card stamp."</p>
+              <p class="tl">Give it whatever <code>--card</code> currently means as its background.</p>
+              <p class="tl">Give it a chunky 2-pixel outline instead of the default hairline — this app wants a drawn-on-paper look.</p>
+              <p class="tl">Corner roundness comes from the one <code>--radius</code> knob, so it stays in step with everything else.</p>
+              <p class="tl">And kill the soft drop shadow entirely. Flat, not floaty.</p>
+              <p class="tl">Result: every card in the app restyled, and <code>card.tsx</code> was never opened.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="callout callout-warning">
+          <div class="callout-icon">🔨</div>
+          <div class="callout-content">
+            <strong class="callout-title">A lovely trick with a sharp edge</strong>
+            <p>This works because the rule and the stamp agree with each other. When they quietly stop agreeing, nothing errors — the styling just never happens. Module 5 has the version of this that fails in exactly that way.</p>
+          </div>
+        </div>
+      </section>
+
+      <!-- ============ SCREEN 7: THE TWO TOGGLES ============ -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">The two switches in the header</h2>
+
+        <p>Both toggles look like magic and are, in fact, one small change repeated at scale. Neither one asks any component to cooperate.</p>
+
+        <div class="step-cards">
+          <div class="step-card">
+            <div class="step-num">1</div>
+            <div class="step-body">
+              <strong>🌗 Dark mode — one class on the page root</strong>
+              <p><code>ThemeProvider</code> in <code>src/contexts/theme-context.tsx</code> adds the class <code>dark</code> to the outermost element of the page. The <code>.dark</code> block in <code>theme.css</code> then takes over every role name at once. One class, whole app repainted, and <code>button.tsx</code> never hears about it.</p>
+            </div>
+          </div>
+          <div class="step-card">
+            <div class="step-num">2</div>
+            <div class="step-body">
+              <strong>🌍 Language — one segment of the URL</strong>
+              <p><code>LocaleSwitcher</code> in <code>src/components/ui/locale-switcher.tsx</code> rewrites the language prefix in the web address (<code>/zh/showcase</code>). Next.js re-renders the page on the server in that language and sends it back. The language is not hidden in the app&apos;s memory — it is in the link, so it can be shared.</p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- ============ SCREEN 8: TWO WAYS TO BUILD A FORM ============ -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">Two ways to build a form, both correct</h2>
+
+        <p>The generator panel is hand-rolled: a plain text box, a plain state value per control, no <span class="term" data-definition="Validation is checking that what someone typed is acceptable before doing anything with it — not empty, actually an email address, at least eight characters. Doing it badly is how forms become infuriating.">validation</span> tool. The app&apos;s <em>other</em> forms take the opposite route.</p>
+
+        <div class="translation-block animate-in">
+          <div class="translation-code">
+            <span class="translation-label">CODE</span>
+            <pre><code><span class="code-line"><span class="code-keyword">function</span> <span class="code-function">buildFieldSchema</span>(field: FormFieldType) {</span>
+<span class="code-line">  <span class="code-keyword">let</span> schema = z.<span class="code-function">string</span>();</span>
+<span class="code-line"></span>
+<span class="code-line">  <span class="code-keyword">if</span> (field.validation?.required) {</span>
+<span class="code-line">    schema = schema.<span class="code-function">min</span>(<span class="code-number">1</span>, {</span>
+<span class="code-line">      <span class="code-property">message</span>: field.validation.message || <span class="code-string">`${field.title} is required`</span>,</span>
+<span class="code-line">    });</span>
+<span class="code-line">  }</span></code></pre>
+          </div>
+          <div class="translation-english">
+            <span class="translation-label">PLAIN ENGLISH</span>
+            <div class="translation-lines">
+              <p class="tl">Take one field&apos;s description and turn it into a <span class="term" data-definition="A schema is a written-down description of what acceptable data looks like — which fields exist, what type each one is, what counts as valid. Declare it once and the app can check itself against it.">schema</span> — a rule-sheet the form can check itself against.</p>
+              <p class="tl">Start from the loosest possible rule: "this answer is some text". <code>z</code> is <span class="term" data-definition="Zod is a tool for describing what valid data looks like, in code. You write the rules once — required, minimum length, must be an email — and it does the checking and produces the error messages.">Zod</span>, the rule-writing tool.</p>
+              <p class="tl">(Blank line, just for breathing room.)</p>
+              <p class="tl">Did whoever defined this field mark it as required? The <code>?.</code> means "look, but do not crash if there are no validation settings at all".</p>
+              <p class="tl">Then tighten the rule: the answer must be at least 1 character long.</p>
+              <p class="tl">And if it is not, show this message — the custom one if someone wrote it, otherwise fall back to "<em>Field name</em> is required".</p>
+              <p class="tl">Done with this field. The red outline, the error text and the blocked submit button all follow from that one rule, automatically.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="pattern-cards stagger-children">
+          <div class="pattern-card animate-in" style="border-top: 3px solid var(--color-actor-4)">
+            <div class="pattern-icon" style="background: var(--color-actor-4)">✋</div>
+            <h4 class="pattern-title">Hand-rolled (the generator)</h4>
+            <p class="pattern-desc">A prompt box, a style picker, an upload area. You hold each value yourself and check nothing. Perfectly fine for three controls you fully own.</p>
+          </div>
+          <div class="pattern-card animate-in" style="border-top: 3px solid var(--color-actor-5)">
+            <div class="pattern-icon" style="background: var(--color-actor-5)">📋</div>
+            <h4 class="pattern-title">Declared (feedback, API keys)</h4>
+            <p class="pattern-desc"><span class="term" data-definition="React Hook Form is a tool that keeps track of everything a form needs — what has been typed, what has been touched, what is invalid, whether submitting is allowed — so you do not write that plumbing by hand.">React Hook Form</span> plus Zod. State the rules out loud once; errors, outlines and blocked submits come free.</p>
+          </div>
+          <div class="pattern-card animate-in" style="border-top: 3px solid var(--color-actor-2)">
+            <div class="pattern-icon" style="background: var(--color-actor-2)">⚖️</div>
+            <h4 class="pattern-title">The deciding factor</h4>
+            <p class="pattern-desc">Not the size of the form — the complexity of its rules. The moment a rule is worth stating out loud, declaring it beats hand-checking it.</p>
+          </div>
+        </div>
+      </section>
+
+      <!-- ============ SCREEN 9: QUIZ ============ -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">Four decisions</h2>
+
+        <p>Not a memory test. Each one is a request you could plausibly get on a Tuesday — decide what you would ask an AI assistant to do.</p>
+
+        <div class="quiz-container" id="quiz-module4">
+
+          <div class="quiz-question-block"
+               data-correct="radius-token"
+               data-explanation-right="Exactly. --radius is the one knob, and --radius-sm / md / lg / xl are all calculated from it, so every rounded-* class in the app moves together. This is the whole point of the paint chart: one swatch, every model repainted."
+               data-explanation-wrong="Not quite — think about where roundness is actually decided. Nothing in card.tsx or button.tsx names a pixel value; they say rounded-xl, which is derived from a single --radius setting in theme.css. Change the source, not the forty places that read it.">
+            <h3 class="quiz-question">A designer wants every card in the app to have corners twice as round. Where is the one-line change?</h3>
+            <div class="quiz-options">
+              <button class="quiz-option" data-value="find-replace" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>Search the project for <code>rounded-xl</code> and replace each one with <code>rounded-3xl</code></span>
+              </button>
+              <button class="quiz-option" data-value="radius-token" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>Change <code>--radius</code> in <code>theme.css</code> — every <code>rounded-*</code> size is calculated from it</span>
+              </button>
+              <button class="quiz-option" data-value="inline-style" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>Add a border-radius style directly onto each card where it is used</span>
+              </button>
+            </div>
+            <div class="quiz-feedback"></div>
+          </div>
+
+          <div class="quiz-question-block"
+               data-correct="add-variant"
+               data-explanation-right="Yes — and notice both halves matter. &quot;Add a variant to buttonVariants&quot; stops the AI inventing a second button component, and &quot;use a token&quot; stops it hardcoding a green that will not survive dark mode."
+               data-explanation-wrong="Not the best option. A whole new component means a second thing to maintain that will drift out of sync; a hardcoded green means a colour that nobody else can reuse and that dark mode knows nothing about. The button already has a menu of looks — add an entry to it.">
+            <h3 class="quiz-question">You need a button that looks like all the others but is green, for "Export". What is the best instruction to give an AI assistant?</h3>
+            <div class="quiz-options">
+              <button class="quiz-option" data-value="new-component" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>"Create a new <code>GreenButton</code> component styled like the existing button"</span>
+              </button>
+              <button class="quiz-option" data-value="inline-hex" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>"Add <code>className="bg-[#2D8B55]"</code> to that button where it is used"</span>
+              </button>
+              <button class="quiz-option" data-value="add-variant" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>"Add a <code>success</code> variant to the existing <code>buttonVariants</code>, using a colour token rather than a hex value"</span>
+              </button>
+            </div>
+            <div class="quiz-feedback"></div>
+          </div>
+
+          <div class="quiz-question-block"
+               data-correct="px8"
+               data-explanation-right="Right. twMerge spots that px-4 and px-8 are arguing about the same property, deletes the earlier one and keeps yours. That predictability is the entire reason cn() exists — without it you would be at the mercy of stylesheet order."
+               data-explanation-wrong="Have another look at cn(). The component&apos;s own classes go in first and yours go in last, then twMerge deletes the loser of any conflict. So px-8 wins — reliably, not by luck. Nothing ends up in the page for the browser to guess about.">
+            <h3 class="quiz-question">A component has <code>px-4</code> baked into its own class list. You pass it <code>className="px-8"</code>. What actually renders — and why is it not a coin flip?</h3>
+            <div class="quiz-options">
+              <button class="quiz-option" data-value="px4" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span><code>px-4</code> — the component&apos;s own styling always wins over anything passed in</span>
+              </button>
+              <button class="quiz-option" data-value="px8" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span><code>px-8</code> — <code>twMerge</code> deletes the conflicting earlier class, and the caller&apos;s classes go in last</span>
+              </button>
+              <button class="quiz-option" data-value="both" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>Both land in the page and the browser picks whichever rule it happens to read last</span>
+              </button>
+            </div>
+            <div class="quiz-feedback"></div>
+          </div>
+
+          <div class="quiz-question-block"
+               data-correct="rules"
+               data-explanation-right="Exactly. It is the complexity of the rules, not the number of fields. A ten-field form with no rules is easy by hand; a two-field form with a valid-email rule and a matching-passwords rule is not."
+               data-explanation-wrong="Close, but size is the wrong yardstick. The generator&apos;s prompt box has no rule worth stating — any text is fine — so hand-rolling costs nothing. The moment you can say a rule out loud (&quot;must be a real email&quot;, &quot;at least 8 characters&quot;), declaring it once beats hand-checking it in three places.">
+            <h3 class="quiz-question">The generator&apos;s prompt box is a plain text area with a plain state value. The feedback form uses Zod. What actually decides which approach a new form should use?</h3>
+            <div class="quiz-options">
+              <button class="quiz-option" data-value="count" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>How many fields it has — anything over five should use Zod</span>
+              </button>
+              <button class="quiz-option" data-value="rules" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>Whether it has rules worth stating out loud — required, valid email, minimum length</span>
+              </button>
+              <button class="quiz-option" data-value="visibility" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>Whether the form is on a public page or behind a login</span>
+              </button>
+            </div>
+            <div class="quiz-feedback"></div>
+          </div>
+
+          <button class="quiz-check-btn" onclick="checkQuiz('quiz-module4')">Check Answers</button>
+          <button class="quiz-reset-btn" onclick="resetQuiz('quiz-module4')">Try Again</button>
+        </div>
+      </section>
+
+      <!-- ============ SCREEN 10: WRAP + TEASE ============ -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">What you can do with this now</h2>
+
+        <div class="icon-rows">
+          <div class="icon-row">
+            <div class="icon-circle" style="background: var(--color-actor-1)">🎨</div>
+            <div>
+              <strong>Ask for tokens, never for hex</strong>
+              <p>"Use the <code>muted-foreground</code> token" gets you a change that survives the next theme tweak and works in dark mode for free.</p>
+            </div>
+          </div>
+          <div class="icon-row">
+            <div class="icon-circle" style="background: var(--color-actor-2)">🧱</div>
+            <div>
+              <strong>Ask for a variant, not a new component</strong>
+              <p>Extending an existing brick keeps forty buttons in agreement. Cloning one is how an interface drifts into forty shades of almost-yellow.</p>
+            </div>
+          </div>
+          <div class="icon-row">
+            <div class="icon-circle" style="background: var(--color-actor-3)">📍</div>
+            <div>
+              <strong>Say where new work should live</strong>
+              <p>Generic and reusable goes in <code>ui/</code>. Knows-about-this-app goes in <code>blocks/</code>. One sentence, and the codebase stays navigable.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="callout callout-info">
+          <div class="callout-icon">🔨</div>
+          <div class="callout-content">
+            <strong class="callout-title">Next: Tapping the Walls</strong>
+            <p>You have now seen how this interface is supposed to work. Next: five places where it doesn&apos;t — including a <code>data-slot</code> rule exactly like the card one above that never fires, and nobody gets an error. And how you would have caught each one.</p>
+          </div>
+        </div>
+      </section>
+
+    </div>
+  </div>
+</section>

--- a/courses/image-generator-ui-course/modules/05-breaks.html
+++ b/courses/image-generator-ui-course/modules/05-breaks.html
@@ -1,0 +1,733 @@
+<section class="module" id="module-5" style="background: var(--color-bg-warm)">
+  <div class="module-content">
+
+    <header class="module-header animate-in">
+      <span class="module-number">05</span>
+      <h1 class="module-title">Tapping the Walls</h1>
+      <p class="module-subtitle">Five real faults in this app. Not one of them crashes anything — which is exactly why they are all still here.</p>
+    </header>
+
+    <div class="module-body">
+
+      <!-- ============ SCREEN 1: THE INSPECTION ============ -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">Nothing here is on fire</h2>
+
+        <p>Every one of the five faults on this page is real, is in the app right now, and none of them crash anything. The bugs that crash are the easy ones — they announce themselves.</p>
+
+        <div class="callout callout-accent">
+          <div class="callout-icon">🔦</div>
+          <div class="callout-content">
+            <strong class="callout-title">The metaphor for this module: a home inspection</strong>
+            <p>An inspector does not wait for the ceiling to come down. They walk the house tapping walls, listening for the hollow spot, checking whether the switch by the door is wired to anything at all. Most of what they find is not dangerous — it is <em>disconnected</em>.</p>
+          </div>
+        </div>
+
+        <p>Wires that go nowhere. A light switch left over from a renovation that nobody removed. That is what is in this house — and in yours, and in every shipped product ever looked at under a torch.</p>
+
+        <div class="pattern-cards stagger-children">
+          <div class="pattern-card animate-in" style="border-top: 3px solid var(--color-actor-1)">
+            <div class="pattern-icon" style="background: var(--color-actor-1)">📬</div>
+            <h4 class="pattern-title">1. The reply nobody reads</h4>
+            <p class="pattern-desc">The server writes <code>message</code>. The browser asks for <code>msg</code>. One word apart, so one whole branch never runs.</p>
+          </div>
+          <div class="pattern-card animate-in" style="border-top: 3px solid var(--color-actor-2)">
+            <div class="pattern-icon" style="background: var(--color-actor-2)">🔌</div>
+            <h4 class="pattern-title">2. Three switches, no wires</h4>
+            <p class="pattern-desc">Aspect ratio, file format and model tier can never change from the values they were born with.</p>
+          </div>
+          <div class="pattern-card animate-in" style="border-top: 3px solid var(--color-actor-3)">
+            <div class="pattern-icon" style="background: var(--color-actor-3)">🎨</div>
+            <h4 class="pattern-title">3. A style rule waiting by the phone</h4>
+            <p class="pattern-desc">Hand-written chunky shadows for the buttons that have never once appeared on screen.</p>
+          </div>
+          <div class="pattern-card animate-in" style="border-top: 3px solid var(--color-actor-4)">
+            <div class="pattern-icon" style="background: var(--color-actor-4)">🔒</div>
+            <h4 class="pattern-title">4. A label that tells a fib</h4>
+            <p class="pattern-desc">The button says you must sign in. Then it generates your picture anyway.</p>
+          </div>
+          <div class="pattern-card animate-in" style="border-top: 3px solid var(--color-actor-5)">
+            <div class="pattern-icon" style="background: var(--color-actor-5)">🈳</div>
+            <h4 class="pattern-title">5. A word that was never delivered</h4>
+            <p class="pattern-desc">Written in English, translated into Chinese, and never carried the last few metres to the button.</p>
+          </div>
+        </div>
+
+        <p>One pattern accounts for all five: <strong>two halves that were each written correctly and never introduced to each other.</strong></p>
+      </section>
+
+      <!-- ============ SCREEN 2: FAULT 1 — HERO ============ -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">Fault 1 — the reply nobody reads</h2>
+
+        <p>When something goes wrong on the server, the app writes back a small note. Every failure note in the whole codebase is built by these fifteen lines.</p>
+
+        <div class="translation-block animate-in">
+          <div class="translation-code">
+            <span class="translation-label">CODE · src/lib/resp.ts</span>
+            <pre><code><span class="code-line"><span class="code-keyword">export</span> <span class="code-keyword">function</span> <span class="code-function">respErr</span>(message: <span class="code-keyword">string</span>, data?: <span class="code-keyword">any</span>) {</span>
+<span class="code-line">  <span class="code-keyword">return</span> <span class="code-function">respJson</span>(<span class="code-number">-1</span>, message, data);</span>
+<span class="code-line">}</span>
+<span class="code-line"></span>
+<span class="code-line"><span class="code-keyword">export</span> <span class="code-keyword">function</span> <span class="code-function">respJson</span>(code: <span class="code-keyword">number</span>, message: <span class="code-keyword">string</span>, data?: <span class="code-keyword">any</span>) {</span>
+<span class="code-line">  <span class="code-keyword">let</span> json: { code: <span class="code-keyword">number</span>; message: <span class="code-keyword">string</span>; data?: <span class="code-keyword">any</span> } = {</span>
+<span class="code-line">    <span class="code-property">code</span>: code,</span>
+<span class="code-line">    <span class="code-property">message</span>: message,</span>
+<span class="code-line">  };</span>
+<span class="code-line">  <span class="code-keyword">if</span> (data) {</span>
+<span class="code-line">    json.data = data;</span>
+<span class="code-line">  }</span>
+<span class="code-line"></span>
+<span class="code-line">  <span class="code-keyword">return</span> Response.<span class="code-function">json</span>(json);</span>
+<span class="code-line">}</span></code></pre>
+          </div>
+          <div class="translation-english">
+            <span class="translation-label">PLAIN ENGLISH</span>
+            <div class="translation-lines">
+              <p class="tl">Every error in the app leaves through this little door. It takes one thing: a sentence meant for a human.</p>
+              <p class="tl">It passes that sentence on, always stamped with the number <code>-1</code>. Hold on to that <code>-1</code> — it is the <em>only</em> failure number this app ever sends.</p>
+              <p class="tl">End of the door.</p>
+              <p class="tl">&nbsp;</p>
+              <p class="tl">The thing that actually writes the note. Three things go in: a number, a sentence, and optionally some extra data.</p>
+              <p class="tl">Here is the note spelled out in advance — this is <span class="term" data-definition="TypeScript is JavaScript with labels attached: you write down what shape your data is supposed to be, and the editor warns you before you run anything if you break your own rules.">TypeScript</span> describing the exact shape of what is about to be sent.</p>
+              <p class="tl">Slot one: the number.</p>
+              <p class="tl">Slot two: the sentence — and the label on this slot is the word <strong>message</strong>. That word is the whole fault.</p>
+              <p class="tl">Close the note.</p>
+              <p class="tl">Was there extra data to include?</p>
+              <p class="tl">Then tuck it in under the label <code>data</code>.</p>
+              <p class="tl">Close that check.</p>
+              <p class="tl">&nbsp;</p>
+              <p class="tl">Send it back to the browser as <span class="term" data-definition="JSON is a plain-text way of writing labelled data — names and values in curly brackets. It is how a server and a browser usually talk to each other.">JSON</span>: labelled text the browser can unpack.</p>
+              <p class="tl">Done. Every failure in this app arrives in the browser in exactly this shape.</p>
+            </div>
+          </div>
+        </div>
+
+        <p>So: every reply carries a field called <code>message</code>, and every failure carries the code <code>-1</code>. Now here is the browser side, reading that reply.</p>
+
+        <div class="bug-challenge">
+          <h3>One of these lines can never run — no matter how busy the service gets. Click it.</h3>
+          <div class="bug-code">
+            <div class="bug-line" data-line="369" data-hint="This one runs all the time — requiresRegistration really is a field the server really sends. Keep looking for a line whose condition can never be true." onclick="checkBugLine(this, false)">
+              <span class="line-num">369</span>
+              <code>        if (result.data.requiresRegistration &amp;&amp; !session) {</code>
+            </div>
+            <div class="bug-line" data-line="370" data-hint="That is only the wording of a message. Look for a condition — a line that decides whether something happens at all." onclick="checkBugLine(this, false)">
+              <span class="line-num">370</span>
+              <code>          toast.success("Image generated! Sign in to download full resolution image.");</code>
+            </div>
+            <div class="bug-line bug-target" data-line="371" data-explanation="The server never sends a field called <code>msg</code>. Look back at <code>resp.ts</code> — it is called <code>message</code>. So <code>result.msg</code> is always empty, empty is never equal to QUEUE_REQUIRED, and this warning has never appeared on anyone&apos;s screen. When all six Gemini keys are exhausted, users get the generic failure toast instead of the queue message and the upgrade offer. And nothing complains: the reply arrives from the network as untyped data, so as far as TypeScript is concerned, asking for <code>result.msg</code> is a perfectly reasonable thing to want." onclick="checkBugLine(this, true)">
+              <span class="line-num">371</span>
+              <code>        } else if (result.msg === 'QUEUE_REQUIRED') {</code>
+            </div>
+            <div class="bug-line" data-line="372" data-hint="Warm — this is the message nobody has ever seen. But it is not the reason. Look one line up, at the condition guarding it." onclick="checkBugLine(this, false)">
+              <span class="line-num">372</span>
+              <code>          toast.warning("🚧 Service is busy. You're in the queue. Upgrade to premium to skip the queue!");</code>
+            </div>
+            <div class="bug-line" data-line="373" data-hint="This is the ordinary happy path, and it runs constantly — in fact it runs in cases where it should not. Look above it." onclick="checkBugLine(this, false)">
+              <span class="line-num">373</span>
+              <code>        } else {</code>
+            </div>
+            <div class="bug-line" data-line="374" data-hint="This is the normal success message, and it works. The broken line is a condition, not an action." onclick="checkBugLine(this, false)">
+              <span class="line-num">374</span>
+              <code>          toast.success(t.messages.success.generated);</code>
+            </div>
+            <div class="bug-line" data-line="375" data-hint="This one is fine — session is a real thing the browser genuinely knows about. Look for a field that only exists on one side of the wall." onclick="checkBugLine(this, false)">
+              <span class="line-num">375</span>
+              <code>          if (session) {</code>
+            </div>
+            <div class="bug-line" data-line="376" data-hint="This runs whenever a signed-in person generates something — it is what makes the credit counter tick down on screen." onclick="checkBugLine(this, false)">
+              <span class="line-num">376</span>
+              <code>            refreshCredits();</code>
+            </div>
+            <div class="bug-line" data-line="377" data-hint="A closing bracket cannot be the bug. Look at the lines that ask questions." onclick="checkBugLine(this, false)">
+              <span class="line-num">377</span>
+              <code>          }</code>
+            </div>
+            <div class="bug-line" data-line="378" data-hint="A closing bracket cannot be the bug. Look at the lines that ask questions." onclick="checkBugLine(this, false)">
+              <span class="line-num">378</span>
+              <code>        }</code>
+            </div>
+          </div>
+          <div class="bug-feedback"></div>
+        </div>
+
+        <p>The word for a branch like that is <span class="term" data-definition="An unreachable branch is an if/else path whose condition can never be true, so the code inside it never runs. It is not broken code — it is code nobody ever calls on.">unreachable branch</span>, and the reason it survives is that it produces a <span class="term" data-definition="A silent failure is something going wrong with no error message anywhere — no red text, no crash, no log line. The feature simply does not happen, and everyone assumes it did.">silent failure</span>: nothing errors, nothing logs, the feature just quietly is not there.</p>
+
+        <div class="callout callout-warning">
+          <div class="callout-icon">🔐</div>
+          <div class="callout-content">
+            <strong class="callout-title">There is a second lock on the same door</strong>
+            <p>Elsewhere in the same function sits a branch guarded by <code>result.code === 1</code>. But <code>respErr</code> only ever sends <code>-1</code>, and successes carry their own number — so <code>1</code> is a value this app never produces. Two independent reasons, one dead branch.</p>
+          </div>
+        </div>
+
+        <h3 class="screen-heading" style="margin-top: var(--space-12)">Twenty lines later, the same person got it right</h3>
+
+        <p>This is the cruel part, and the reason nobody caught it. In the very same function, the insufficient-credits branch reads exactly the fields the server actually sends.</p>
+
+        <div class="translation-block animate-in">
+          <div class="translation-code">
+            <span class="translation-label">CODE · imagen-client.tsx</span>
+            <pre><code><span class="code-line">      } <span class="code-keyword">else</span> <span class="code-keyword">if</span> (result.code === <span class="code-number">-1</span>) {</span>
+<span class="code-line">        <span class="code-comment">// Handle error responses (including insufficient credits)</span></span>
+<span class="code-line">        <span class="code-keyword">if</span> (result.data === <span class="code-string">'INSUFFICIENT_CREDITS'</span> || result.message?.<span class="code-function">includes</span>(<span class="code-string">'Insufficient credits'</span>)) {</span>
+<span class="code-line">          toast.<span class="code-function">error</span>(result.message || <span class="code-string">'Insufficient credits to generate image'</span>);</span>
+<span class="code-line">          <span class="code-keyword">return</span>;</span>
+<span class="code-line">        }</span>
+<span class="code-line">        <span class="code-keyword">throw</span> <span class="code-keyword">new</span> <span class="code-function">Error</span>(result.message || <span class="code-string">'Generation failed'</span>);</span></code></pre>
+          </div>
+          <div class="translation-english">
+            <span class="translation-label">PLAIN ENGLISH</span>
+            <div class="translation-lines">
+              <p class="tl">Did the note come back stamped <code>-1</code>? That is the number <code>respErr</code> really sends — so this branch really runs.</p>
+              <p class="tl">A note left by whoever wrote it.</p>
+              <p class="tl">Two ways to recognise a credits problem: the tag in <code>data</code>, or the words inside <code>message</code>. Both of those field names exist. Both work.</p>
+              <p class="tl">Show the person the server&apos;s own sentence as a <span class="term" data-definition="A toast is the small message that slides into a corner of the screen and fades away by itself — Saved, Copied, Something went wrong. Named after bread popping out of a toaster.">toast</span>, or a sensible stand-in if it is missing.</p>
+              <p class="tl">Stop here. Nothing else in this function should run.</p>
+              <p class="tl">Close the credits check.</p>
+              <p class="tl">Any other failure: raise it properly so the catch block below can show the generic error.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="icon-rows">
+          <div class="icon-row">
+            <div class="icon-circle" style="background: var(--color-success)">✅</div>
+            <div>
+              <strong><code>result.message</code> and <code>result.data</code></strong>
+              <p>Both spelled the way the server spells them. This branch has worked from the day it was written.</p>
+            </div>
+          </div>
+          <div class="icon-row">
+            <div class="icon-circle" style="background: var(--color-error)">🚫</div>
+            <div>
+              <strong><code>result.msg</code></strong>
+              <p>Twenty lines earlier, in the same file, in the same function. Never fires. Nothing warns anybody.</p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- ============ SCREEN 3: FAULT 2 ============ -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">Fault 2 — three switches with the wires cut</h2>
+
+        <p>The generator carries three settings around with it: a shape for the picture, a file format, and which tier of model to use.</p>
+
+        <div class="translation-block animate-in">
+          <div class="translation-code">
+            <span class="translation-label">CODE · imagen-client.tsx</span>
+            <pre><code><span class="code-line">  <span class="code-keyword">const</span> [aspectRatio, setAspectRatio] = <span class="code-function">useState</span>(<span class="code-string">'16:9'</span>);</span>
+<span class="code-line">  <span class="code-keyword">const</span> [outputFormat, setOutputFormat] = <span class="code-function">useState</span>(<span class="code-string">'jpeg'</span>);</span>
+<span class="code-line">  <span class="code-keyword">const</span> [selectedModel, setSelectedModel] = <span class="code-function">useState</span>(<span class="code-string">'pro'</span>);</span></code></pre>
+          </div>
+          <div class="translation-english">
+            <span class="translation-label">PLAIN ENGLISH</span>
+            <div class="translation-lines">
+              <p class="tl">Two things come out of every one of these: the current value, and a <span class="term" data-definition="A state setter is the one function allowed to change a piece of a screen&apos;s memory. If nothing ever calls it, that value is frozen at whatever it started as, forever.">state setter</span> — the only hand allowed to change it. Shape starts at 16:9, and <code>setAspectRatio</code> is the only way it will ever move.</p>
+              <p class="tl">Same again for the file format: starts at jpeg, and only <code>setOutputFormat</code> can change it.</p>
+              <p class="tl">And the model tier: starts at pro, movable only by <code>setSelectedModel</code>. The Generate button reads this one to print (10 credits) beside itself.</p>
+            </div>
+          </div>
+        </div>
+
+        <p>Search the whole file for those three setter names and you find one mention each — the line that created them. Nothing else ever calls them, so nothing can ever move those values.</p>
+
+        <p>Now follow one of them all the way through the house. Click <strong>Next Step</strong>.</p>
+
+        <div class="flow-animation" data-steps='[
+          {"highlight":"flow-actor-m5-1","label":"There is no picker on the screen. Nothing anywhere calls setAspectRatio, so the value is welded to 16:9 for every visitor, forever."},
+          {"highlight":"flow-actor-m5-2","label":"The value sits in the page memory, exactly as it was born. This half is not broken — it is simply never touched.","packet":true,"from":"actor-m5-1","to":"actor-m5-2"},
+          {"highlight":"flow-actor-m5-3","label":"The browser really does send aspectRatio along with the photo. This wire is connected and working.","packet":true,"from":"actor-m5-2","to":"actor-m5-3"},
+          {"highlight":"flow-actor-m5-3","label":"The server checks it carefully against a list of allowed shapes and rejects anything unexpected. Careful, deliberate, correct work."},
+          {"highlight":"flow-actor-m5-4","label":"The parcel goes to Gemini: the written brief plus the photo. The aspect ratio is not in that parcel. Gemini is never told.","packet":true,"from":"actor-m5-3","to":"actor-m5-4"},
+          {"highlight":"flow-actor-m5-5","label":"The reply politely echoes aspectRatio back. The answer says 16:9. The picture was drawn without ever hearing about it.","packet":true,"from":"actor-m5-4","to":"actor-m5-5"}
+        ]'>
+          <div class="flow-actors">
+            <div class="flow-actor" id="flow-actor-m5-1">
+              <div class="flow-actor-icon">🎛️</div>
+              <span>Picker<br>(missing)</span>
+            </div>
+            <div class="flow-actor" id="flow-actor-m5-2">
+              <div class="flow-actor-icon">📌</div>
+              <span>Page memory<br>16:9</span>
+            </div>
+            <div class="flow-actor" id="flow-actor-m5-3">
+              <div class="flow-actor-icon">🛃</div>
+              <span>Server<br>validates</span>
+            </div>
+            <div class="flow-actor" id="flow-actor-m5-4">
+              <div class="flow-actor-icon">🎨</div>
+              <span>Gemini</span>
+            </div>
+            <div class="flow-actor" id="flow-actor-m5-5">
+              <div class="flow-actor-icon">📤</div>
+              <span>Reply</span>
+            </div>
+          </div>
+
+          <div class="flow-packet"></div>
+
+          <div class="flow-step-label">Click "Next Step" to follow the aspect ratio</div>
+
+          <div class="flow-controls">
+            <button class="btn flow-next-btn">Next Step</button>
+            <button class="btn flow-reset-btn">Restart</button>
+            <span class="flow-progress"></span>
+          </div>
+        </div>
+
+        <div class="callout callout-info">
+          <div class="callout-icon">🧰</div>
+          <div class="callout-content">
+            <strong class="callout-title">Nobody was being lazy here</strong>
+            <p>Writing that validation list on the server is real, careful work — someone was clearly planning the picker. The chain is missing two pieces at opposite ends: a control at the front, and one line at the back that hands the value to Gemini.</p>
+          </div>
+        </div>
+      </section>
+
+      <!-- ============ SCREEN 4: FAULT 3 ============ -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">Fault 3 — a style rule waiting by the phone</h2>
+
+        <p>Module 4 showed the trick: every Shadcn brick stamps a small label on itself, and <code>theme.css</code> grabs everything wearing that label and restyles it in one go. <code>[data-slot="card"]</code> does this beautifully. Here is the same trick, one step further.</p>
+
+        <div class="translation-block animate-in">
+          <div class="translation-code">
+            <span class="translation-label">CODE · src/app/theme.css</span>
+            <pre><code><span class="code-line">[<span class="code-attr">data-slot</span>=<span class="code-value">"button"</span>][<span class="code-attr">data-variant</span>=<span class="code-value">"default"</span>] {</span>
+<span class="code-line">  <span class="code-property">background</span>: <span class="code-function">var</span>(--primary);</span>
+<span class="code-line">  <span class="code-property">color</span>: <span class="code-function">var</span>(--primary-foreground);</span>
+<span class="code-line">  <span class="code-property">border</span>: <span class="code-number">2px</span> solid <span class="code-function">var</span>(--foreground);</span>
+<span class="code-line">  <span class="code-property">border-radius</span>: <span class="code-function">var</span>(--radius);</span>
+<span class="code-line">  <span class="code-property">box-shadow</span>: <span class="code-number">4px</span> <span class="code-number">4px</span> <span class="code-number">0px</span> <span class="code-function">var</span>(--foreground);</span>
+<span class="code-line">  <span class="code-property">transition</span>: all <span class="code-number">0.2s</span> ease;</span>
+<span class="code-line">}</span></code></pre>
+          </div>
+          <div class="translation-english">
+            <span class="translation-label">PLAIN ENGLISH</span>
+            <div class="translation-lines">
+              <p class="tl">This first line is the <span class="term" data-definition="A CSS selector is the sentence at the top of a style rule that says which things on the page it applies to. If it describes nothing on the page, the rule below it is simply skipped — no error, no warning.">CSS selector</span>: find every element wearing <em>both</em> of these labels. Two <span class="term" data-definition="An attribute is a small labelled note written onto an element in the page, like id=&quot;submit&quot; or disabled. Style rules and scripts use them to find things.">attributes</span>, not one — and both are required.</p>
+              <p class="tl">Paint it with the primary colour role, not a hard-coded yellow.</p>
+              <p class="tl">Text in the matching foreground role, so it stays readable if the palette changes.</p>
+              <p class="tl">A fat two-pixel outline in the ink colour — that Charlie-and-Lola storybook edge.</p>
+              <p class="tl">Corners from the shared radius token, so every corner in the app moves together.</p>
+              <p class="tl">And the signature: a hard shadow offset down and right, like a sticker peeled off the page.</p>
+              <p class="tl">Animate any change over a fifth of a second.</p>
+              <p class="tl">End of a rule that has never once been applied to anything.</p>
+            </div>
+          </div>
+        </div>
+
+        <p>Here is why. This is the entire output of the Button component — everything it ever stamps onto the page.</p>
+
+        <div class="translation-block animate-in">
+          <div class="translation-code">
+            <span class="translation-label">CODE · src/components/ui/button.tsx</span>
+            <pre><code><span class="code-line">  <span class="code-keyword">return</span> (</span>
+<span class="code-line">    &lt;<span class="code-tag">Comp</span></span>
+<span class="code-line">      <span class="code-attr">data-slot</span>=<span class="code-value">"button"</span></span>
+<span class="code-line">      <span class="code-attr">className</span>={<span class="code-function">cn</span>(<span class="code-function">buttonVariants</span>({ variant, size, className }))}</span>
+<span class="code-line">      {...props}</span>
+<span class="code-line">    /&gt;</span>
+<span class="code-line">  )</span></code></pre>
+          </div>
+          <div class="translation-english">
+            <span class="translation-label">PLAIN ENGLISH</span>
+            <div class="translation-lines">
+              <p class="tl">Hand back the thing to be drawn on the page.</p>
+              <p class="tl">Usually a real <code>&lt;button&gt;</code>, sometimes a link wearing a button costume.</p>
+              <p class="tl">Stamp on the label <span class="term" data-definition="A data- attribute is a custom label you invent and attach to an element — data-slot, data-state, data-variant. The browser ignores them, but your style rules and scripts can use them as handles.">data-slot</span> = button. This is the <em>only</em> label it ever writes. There is no <code>data-variant</code> here, and never has been.</p>
+              <p class="tl">Work out the Tailwind classes for the chosen look and size, and let anything passed in override them.</p>
+              <p class="tl">Pass through everything else the caller gave us — the click handler, the disabled flag, and so on.</p>
+              <p class="tl">Close the element.</p>
+              <p class="tl">Done. One label out, two labels required by the style rule.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="icon-rows">
+          <div class="icon-row">
+            <div class="icon-circle" style="background: var(--color-success)">🎯</div>
+            <div>
+              <strong><code>[data-slot="card"]</code> → matches every card</strong>
+              <p><code>card.tsx</code> really does stamp <code>data-slot="card"</code>. One label asked for, one label stamped. This is the rule from module 4 that works.</p>
+            </div>
+          </div>
+          <div class="icon-row">
+            <div class="icon-circle" style="background: var(--color-error)">👻</div>
+            <div>
+              <strong><code>[data-slot="button"][data-variant="default"]</code> → matches nothing</strong>
+              <p>Two labels asked for, one stamped. Zero elements on the page qualify, so those chunky shadows and the nudge-on-hover have never rendered — not once, on anybody&apos;s screen.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="callout callout-info">
+          <div class="callout-icon">🖼️</div>
+          <div class="callout-content">
+            <strong class="callout-title">The buttons still look fine, by the way</strong>
+            <p>Their colour comes from the <code>cva</code> table inside <code>button.tsx</code> — <code>bg-primary text-primary-foreground shadow-xs</code>. What never arrived is the hand-written storybook shadow described above. Nobody misses a thing they have never seen.</p>
+          </div>
+        </div>
+      </section>
+
+      <!-- ============ SCREEN 5: FAULT 4 ============ -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">Fault 4 — the button that asks you to sign in, then does it anyway</h2>
+
+        <p>Signed out, the Generate button shows a padlock and the words <em>login required</em>. Then you click it, and it generates your picture.</p>
+
+        <div class="badge-list">
+          <div class="badge-item">
+            <code class="badge-code">disabled={uploadedImages.length === 0 || isGenerating}</code>
+            <span class="badge-desc">The complete list of reasons the button ever refuses: no photo yet, or one is already being drawn. Being signed out is not on it.</span>
+          </div>
+        </div>
+
+        <div class="icon-rows">
+          <div class="icon-row">
+            <div class="icon-circle" style="background: var(--color-error)">🔒</div>
+            <div>
+              <strong>What the label promises</strong>
+              <p>Padlock icon, the words "login required". A clear statement that nothing will happen until you sign in.</p>
+            </div>
+          </div>
+          <div class="icon-row">
+            <div class="icon-circle" style="background: var(--color-actor-2)">▶️</div>
+            <div>
+              <strong>What the button does</strong>
+              <p>Runs <code>generateImage()</code>, which never checks for a <span class="term" data-definition="A session is the app&apos;s memory that you are signed in and who you are — the wristband you get at the door. No session means the app treats you as a guest.">session</span> at all. The picture gets made.</p>
+            </div>
+          </div>
+          <div class="icon-row">
+            <div class="icon-circle" style="background: var(--color-success)">🎟️</div>
+            <div>
+              <strong>What the server does</strong>
+              <p>Treats guests deliberately: sends back <code>requiresRegistration: true</code> and charges no credits. The behaviour was designed. Only the wording is out of date.</p>
+            </div>
+          </div>
+        </div>
+
+        <p>You have already met the branch that handles this properly — it was line 369 in the spot-the-bug exhibit, the one that offers a full-resolution download in exchange for signing in. That branch works. The label beside it is a leftover from when guests really were turned away.</p>
+
+        <div class="callout callout-warning">
+          <div class="callout-icon">🏷️</div>
+          <div class="callout-content">
+            <strong class="callout-title">A stale label is a real fault, not a cosmetic one</strong>
+            <p>Some people read "login required", decide they cannot be bothered, and leave — never discovering that the free try was one click away. Nothing in the code is wrong. The product still loses.</p>
+          </div>
+        </div>
+      </section>
+
+      <!-- ============ SCREEN 6: FAULT 5 ============ -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">Fault 5 — the word that was never delivered</h2>
+
+        <p>Switch free mode on and the Generate button reads <code>(undefined)</code>. The phrase exists. Someone wrote it, someone translated it — it just never travelled the last few metres.</p>
+
+        <div class="step-cards">
+          <div class="step-card">
+            <div class="step-num">1</div>
+            <div class="step-body">
+              <strong>The translation files — present ✅</strong>
+              <p><code>"limited_free": "Limited Free"</code> in English, <code>"限免"</code> in Chinese. Both written, both correct, both sitting there.</p>
+            </div>
+          </div>
+          <div class="step-card">
+            <div class="step-num">2</div>
+            <div class="step-body">
+              <strong>The <code>Translations</code> <span class="term" data-definition="An interface is a written list of exactly which pieces of information a component expects to be handed, and what type each one is. It is a contract — and like any contract, it only covers what somebody remembered to write into it.">interface</span> — missing ❌</strong>
+              <p>The list at the top of <code>imagen-client.tsx</code> declaring every string the component expects. <code>limited_free</code> is not on the list.</p>
+            </div>
+          </div>
+          <div class="step-card">
+            <div class="step-num">3</div>
+            <div class="step-body">
+              <strong>The mapping in <code>index.tsx</code> — missing ❌</strong>
+              <p>The wrapper from module 2 that hand-copies each string into one object before handing it to the browser. This one never gets copied.</p>
+            </div>
+          </div>
+        </div>
+
+        <p>So the button asks for <code>t.buttons.limited_free</code>, is handed nothing at all, and prints the word JavaScript uses for nothing at all: <code>undefined</code>. No error. No warning. Just a strange word on a button.</p>
+
+        <div class="callout callout-warning">
+          <div class="callout-icon">📮</div>
+          <div class="callout-content">
+            <strong class="callout-title">This is the bill for the hand-written wrapper</strong>
+            <p>Module 2 showed the wrapper copying translations across the client/server wall by hand. The cost: every new piece of text has to be added in <strong>three</strong> places — the JSON file, the interface, the mapping. Forget one and it fails without a sound.</p>
+          </div>
+        </div>
+      </section>
+
+      <!-- ============ SCREEN 7: THE CLIPBOARD ============ -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">What the five have in common</h2>
+
+        <div class="callout callout-accent">
+          <div class="callout-icon">💡</div>
+          <div class="callout-content">
+            <strong class="callout-title">Aha: silence is a symptom</strong>
+            <p>A branch that never runs, a rule that matches nothing and a setter that is never called all produce exactly zero errors. Working code and disconnected code look identical from the outside — which is why "it does not crash" is not evidence that it works.</p>
+          </div>
+        </div>
+
+        <p>An inspector does not need to know how a house was built to tap the walls. Here is the clipboard — five questions you can ask about your own project this afternoon.</p>
+
+        <div class="pattern-cards stagger-children">
+          <div class="pattern-card animate-in" style="border-top: 3px solid var(--color-actor-1)">
+            <div class="pattern-icon" style="background: var(--color-actor-1)">🔌</div>
+            <h4 class="pattern-title">Is this setter ever called?</h4>
+            <p class="pattern-desc">"Search the file for every place <code>setAspectRatio</code> is used." If the only hit is where it was created, the control is decorative.</p>
+          </div>
+          <div class="pattern-card animate-in" style="border-top: 3px solid var(--color-actor-2)">
+            <div class="pattern-icon" style="background: var(--color-actor-2)">🔤</div>
+            <h4 class="pattern-title">Do both sides spell it the same?</h4>
+            <p class="pattern-desc">"List the exact field names the server sends and the ones the client reads." Data crossing a network is never spell-checked by anybody.</p>
+          </div>
+          <div class="pattern-card animate-in" style="border-top: 3px solid var(--color-actor-3)">
+            <div class="pattern-icon" style="background: var(--color-actor-3)">🎯</div>
+            <h4 class="pattern-title">Does this selector match anything?</h4>
+            <p class="pattern-desc">"Show me an element that has both of these attributes." A style rule for a thing that does not exist is silent, tidy and useless.</p>
+          </div>
+          <div class="pattern-card animate-in" style="border-top: 3px solid var(--color-actor-4)">
+            <div class="pattern-icon" style="background: var(--color-actor-4)">🏷️</div>
+            <h4 class="pattern-title">Does the label match the behaviour?</h4>
+            <p class="pattern-desc">Read the button out loud, then read what it actually does. Words go stale faster than logic, and nothing checks them.</p>
+          </div>
+          <div class="pattern-card animate-in" style="border-top: 3px solid var(--color-actor-5)">
+            <div class="pattern-icon" style="background: var(--color-actor-5)">🔗</div>
+            <h4 class="pattern-title">Is it wired all the way through?</h4>
+            <p class="pattern-desc">Anything hand-copied from place to place has as many failure points as it has hops. Count the hops before you add the sixth one.</p>
+          </div>
+        </div>
+
+        <div class="callout callout-info">
+          <div class="callout-icon">🤖</div>
+          <div class="callout-content">
+            <strong class="callout-title">For steering AI: the three sentences that end a bug loop</strong>
+            <p>"Why is this broken?" gets you guesses, and the next twenty minutes get you more guesses. Say these three things instead, in this order.</p>
+          </div>
+        </div>
+
+        <div class="step-cards">
+          <div class="step-card">
+            <div class="step-num">1</div>
+            <div class="step-body">
+              <strong>Name the station</strong>
+              <p>"This is the client-side handling of the response, in <code>imagen-client.tsx</code>." You learned the seven stations in module 1 for exactly this sentence.</p>
+            </div>
+          </div>
+          <div class="step-card">
+            <div class="step-num">2</div>
+            <div class="step-body">
+              <strong>Name the mismatch</strong>
+              <p>"The server sends a field called <code>message</code>. The client reads <code>result.msg</code>." A fact, not a symptom. Nothing left to diagnose.</p>
+            </div>
+          </div>
+          <div class="step-card">
+            <div class="step-num">3</div>
+            <div class="step-body">
+              <strong>Name the fix you want</strong>
+              <p>"Change the client to read <code>result.message</code>. Do not touch <code>resp.ts</code> — everything else in the app depends on it." Otherwise a helpful assistant may fix it from the wrong end and cause a <span class="term" data-definition="A regression is something that used to work and stopped working because of a change made somewhere else. The classic way to create one is to fix a bug at the wrong end of the chain.">regression</span> in ten other places.</p>
+            </div>
+          </div>
+        </div>
+
+        <p>Guesses in, guesses out. Specifics in, patches out.</p>
+      </section>
+
+      <!-- ============ SCREEN 8: QUIZ ============ -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">Four calls from the field</h2>
+
+        <p>Each of these is a message you might actually receive. Name the station before you pick.</p>
+
+        <div class="quiz-container" id="quiz-module5">
+
+          <div class="quiz-question-block"
+               data-correct="opt-client-msg"
+               data-explanation-right="Exactly — and notice you worked it out without reproducing the traffic spike. The server does its job: it marks the burnt key and sends the QUEUE_REQUIRED tag inside a field called message. The one word that does not line up is on the browser side, which makes this a one-line change in one file."
+               data-explanation-wrong="Have another look at what the symptom proves. A generic failure toast means the reply arrived and the client read it — it just did not recognise what it was holding. Anything further upstream would fail in a different, louder way.">
+            <h3 class="quiz-question">Traffic spikes and users report the site "just says generation failed". You know the queue-and-upgrade message exists — you can read it in the server code. Where do you look first?</h3>
+            <div class="quiz-options">
+              <button class="quiz-option" data-value="opt-pool" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>The Gemini key pool — all six keys must be burning out at once</span>
+              </button>
+              <button class="quiz-option" data-value="opt-client-msg" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>The client&apos;s response handling — it reads <code>result.msg</code>, and the server sends <code>message</code></span>
+              </button>
+              <button class="quiz-option" data-value="opt-server-text" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>The server route — <code>respErr</code> must be sending the wrong wording</span>
+              </button>
+              <button class="quiz-option" data-value="opt-toast" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>The toast library — warning-style messages are probably being suppressed</span>
+              </button>
+            </div>
+            <div class="quiz-feedback"></div>
+          </div>
+
+          <div class="quiz-question-block"
+               data-correct="opt-never-rendered"
+               data-explanation-right="Exactly. The rule asks for two labels; the Button component stamps one. Saying this out loud matters, because it changes the job from find what broke it to stamp the attribute or rewrite the selector — and it stops anyone hunting through the history for a change that was never made."
+               data-explanation-wrong="Be careful with the word removed — it quietly assumes the shadow once worked. Before searching the history, compare the style rule against the component: the rule wants data-slot AND data-variant, and only one of those is ever written onto the element.">
+            <h3 class="quiz-question">A designer is certain the Generate button used to have a chunky offset shadow and that "someone removed it in a refactor". You look and find the shadow rule sitting in <code>theme.css</code>, untouched. What actually happened?</h3>
+            <div class="quiz-options">
+              <button class="quiz-option" data-value="opt-twmerge" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>A Tailwind class overrode it — <code>twMerge</code> kept the wrong one of the two</span>
+              </button>
+              <button class="quiz-option" data-value="opt-never-rendered" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>Nobody removed it. The rule needs a <code>data-variant</code> attribute the component never stamps, so it has never matched anything</span>
+              </button>
+              <button class="quiz-option" data-value="opt-dark" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>It only applies in dark mode, and the designer was looking at light mode</span>
+              </button>
+              <button class="quiz-option" data-value="opt-notloaded" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span><code>theme.css</code> is not loaded on that particular page</span>
+              </button>
+            </div>
+            <div class="quiz-feedback"></div>
+          </div>
+
+          <div class="quiz-question-block"
+               data-correct="opt-three-places"
+               data-explanation-right="Exactly. Two ends of the chain are missing and one middle section already works. If you only ask for the control, you get a beautiful dropdown that changes nothing — and then a long confusing conversation about why. Tracing end to end before you ask is the whole skill."
+               data-explanation-wrong="Follow the value the whole way. A control that sets the value is not enough on its own: the browser already sends it, the server already validates it — and then the server never mentions it to Gemini. Leave that last piece out and the picker will look perfect and do nothing.">
+            <h3 class="quiz-question">You ask an AI assistant to "make the aspect-ratio picker work". What do you need to tell it so it does not stop halfway?</h3>
+            <div class="quiz-options">
+              <button class="quiz-option" data-value="opt-just-ask" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>Nothing more — it can read the code and work out the rest</span>
+              </button>
+              <button class="quiz-option" data-value="opt-dropdown-only" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>Add the dropdown and wire <code>setAspectRatio</code> — the rest of the chain already works</span>
+              </button>
+              <button class="quiz-option" data-value="opt-three-places" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>Add the dropdown and wire <code>setAspectRatio</code>; the value is already sent and validated; but the server must actually pass it to Gemini instead of just echoing it back</span>
+              </button>
+              <button class="quiz-option" data-value="opt-db" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>Add the dropdown and save the choice to the database so it is remembered next visit</span>
+              </button>
+            </div>
+            <div class="quiz-feedback"></div>
+          </div>
+
+          <div class="quiz-question-block"
+               data-correct="opt-wrapper"
+               data-explanation-right="Exactly — and the giveaway is that only this one word is missing. The JSON has it in both languages; the interface and the hand-written mapping in index.tsx do not. That is the standing cost of the wrapper from module 2: three places per string, and forgetting one is completely silent."
+               data-explanation-wrong="Look at the scope of the damage before you pick. If the files or the language switch were broken, every label on the page would be blank — not one word on one button. Something is wrong with this string specifically, somewhere on its way across.">
+            <h3 class="quiz-question">Free mode is switched on and the Generate button reads <code>(undefined)</code>. Every other label on the page is fine, and you have confirmed the phrase exists in both translation files. What happened?</h3>
+            <div class="quiz-options">
+              <button class="quiz-option" data-value="opt-files" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>The translation files failed to load for this visitor</span>
+              </button>
+              <button class="quiz-option" data-value="opt-locale" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>The language switch broke and fell back to a language with no text in it</span>
+              </button>
+              <button class="quiz-option" data-value="opt-wrapper" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>It was never carried across: it is missing from the <code>Translations</code> interface and from the hand-written mapping in <code>index.tsx</code></span>
+              </button>
+              <button class="quiz-option" data-value="opt-typo" onclick="selectOption(this)">
+                <div class="quiz-option-radio"></div>
+                <span>Gemini returned a malformed response and the button is showing part of it</span>
+              </button>
+            </div>
+            <div class="quiz-feedback"></div>
+          </div>
+
+          <button class="quiz-check-btn" onclick="checkQuiz('quiz-module5')">Check Answers</button>
+          <button class="quiz-reset-btn" onclick="resetQuiz('quiz-module5')">Try Again</button>
+        </div>
+      </section>
+
+      <!-- ============ SCREEN 9: CLOSING THE COURSE ============ -->
+      <section class="screen animate-in">
+        <h2 class="screen-heading">Five modules ago, this was a box you dropped a photo into</h2>
+
+        <p>You have not learned to write this app. You were never trying to. Here is what you can actually do now.</p>
+
+        <div class="icon-rows">
+          <div class="icon-row">
+            <div class="icon-circle" style="background: var(--color-actor-1)">🧭</div>
+            <div>
+              <strong>Trace one generation end to end</strong>
+              <p>Seven stations, from the file landing on the page to the finished drawing coming back as a web address. When something breaks, you can name the station.</p>
+            </div>
+          </div>
+          <div class="icon-row">
+            <div class="icon-circle" style="background: var(--color-actor-2)">🎭</div>
+            <div>
+              <strong>Tell the browser half from the server half</strong>
+              <p>And say why the API key can only ever live on one side of that wall — the single most useful line you can draw through any web app.</p>
+            </div>
+          </div>
+          <div class="icon-row">
+            <div class="icon-circle" style="background: var(--color-actor-3)">✍️</div>
+            <div>
+              <strong>Recognise a rented model behind a written brief</strong>
+              <p>The whole Charlie &amp; Lola look is one paragraph of English sent to a general-purpose artist. Change the paragraph, change the product.</p>
+            </div>
+          </div>
+          <div class="icon-row">
+            <div class="icon-circle" style="background: var(--color-actor-4)">🎨</div>
+            <div>
+              <strong>Name a design token instead of a hex code</strong>
+              <p>"Use the <code>secondary</code> token" and "add a variant to <code>buttonVariants</code>" are two sentences that keep an interface from drifting into forty shades of almost-yellow.</p>
+            </div>
+          </div>
+          <div class="icon-row">
+            <div class="icon-circle" style="background: var(--color-actor-5)">🔦</div>
+            <div>
+              <strong>Spot a silent disconnection</strong>
+              <p>Two halves, each written correctly, never introduced. No crash, no error, no clue — until you tap the wall.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="callout callout-accent">
+          <div class="callout-icon">📋</div>
+          <div class="callout-content">
+            <strong class="callout-title">The one habit worth keeping</strong>
+            <p>When something looks wrong, name the station before you propose the fix. That single reordering is what separates a five-minute exchange with an AI assistant from a two-hour loop of confident, plausible, wrong suggestions.</p>
+          </div>
+        </div>
+
+        <p>The app in this course is real and running, and the files are sitting on the same disk as this page. These three are the ones worth opening first.</p>
+
+        <div class="badge-list">
+          <div class="badge-item">
+            <code class="badge-code">src/app/api/generate-cyberpunk/route.ts</code>
+            <span class="badge-desc">The server side of the whole feature: the key pool, the written brief, the call to Gemini, the upload. Still named after a product that no longer exists.</span>
+          </div>
+          <div class="badge-item">
+            <code class="badge-code">src/components/blocks/imagen-wrapper/imagen-client.tsx</code>
+            <span class="badge-desc">Everything you see and touch — and the home of faults 1, 2, 4 and half of 5. Long, honest, and completely readable once you know the stations.</span>
+          </div>
+          <div class="badge-item">
+            <code class="badge-code">src/app/theme.css</code>
+            <span class="badge-desc">The paint chart. Every colour, corner and shadow in the app, defined twice — once for light mode, once for dark.</span>
+          </div>
+        </div>
+
+        <p>Open one of them, scroll slowly, and see how much of it you can now read out loud. That is the whole send-off — no certificate, no new job title. Just a house you can walk through in the dark.</p>
+      </section>
+
+    </div>
+  </div>
+</section>

--- a/courses/image-generator-ui-course/styles.css
+++ b/courses/image-generator-ui-course/styles.css
@@ -1,0 +1,1195 @@
+/* =============================================================
+   CODEBASE-TO-COURSE — COMPLETE DESIGN SYSTEM
+   Copy this file verbatim into the course output directory.
+   Never regenerate it — customize only via :root overrides
+   in _base.html (accent color only).
+   ============================================================= */
+
+/* ── GOOGLE FONTS (loaded via _base.html <head>) ───────────────
+   Bricolage Grotesque · DM Sans · JetBrains Mono
+   ──────────────────────────────────────────────────────────── */
+
+/* ── DESIGN TOKENS ─────────────────────────────────────────── */
+:root {
+  /* BACKGROUNDS */
+  --color-bg:             #FAF7F2;
+  --color-bg-warm:        #F5F0E8;
+  --color-bg-code:        #1E1E2E;
+  --color-text:           #2C2A28;
+  --color-text-secondary: #6B6560;
+  --color-text-muted:     #9E9790;
+  --color-border:         #E5DFD6;
+  --color-border-light:   #EEEBE5;
+  --color-surface:        #FFFFFF;
+  --color-surface-warm:   #FDF9F3;
+
+  /* ACCENT — overridden per course in _base.html */
+  --color-accent:         #D94F30;
+  --color-accent-hover:   #C4432A;
+  --color-accent-light:   #FDEEE9;
+  --color-accent-muted:   #E8836C;
+
+  /* SEMANTIC */
+  --color-success:        #2D8B55;
+  --color-success-light:  #E8F5EE;
+  --color-error:          #C93B3B;
+  --color-error-light:    #FDE8E8;
+  --color-info:           #2A7B9B;
+  --color-info-light:     #E4F2F7;
+
+  /* ACTOR COLORS */
+  --color-actor-1:        #D94F30;
+  --color-actor-2:        #2A7B9B;
+  --color-actor-3:        #7B6DAA;
+  --color-actor-4:        #D4A843;
+  --color-actor-5:        #2D8B55;
+
+  /* FONTS */
+  --font-display: 'Bricolage Grotesque', Georgia, serif;
+  --font-body:    'DM Sans', -apple-system, sans-serif;
+  --font-mono:    'JetBrains Mono', 'Fira Code', 'Consolas', monospace;
+
+  /* TYPE SCALE */
+  --text-xs:   0.75rem;
+  --text-sm:   0.875rem;
+  --text-base: 1rem;
+  --text-lg:   1.125rem;
+  --text-xl:   1.25rem;
+  --text-2xl:  1.5rem;
+  --text-3xl:  1.875rem;
+  --text-4xl:  2.25rem;
+  --text-5xl:  3rem;
+  --text-6xl:  3.75rem;
+
+  /* LINE HEIGHTS */
+  --leading-tight:  1.15;
+  --leading-snug:   1.3;
+  --leading-normal: 1.6;
+  --leading-loose:  1.8;
+
+  /* SPACING */
+  --space-1:  0.25rem;
+  --space-2:  0.5rem;
+  --space-3:  0.75rem;
+  --space-4:  1rem;
+  --space-5:  1.25rem;
+  --space-6:  1.5rem;
+  --space-8:  2rem;
+  --space-10: 2.5rem;
+  --space-12: 3rem;
+  --space-16: 4rem;
+  --space-20: 5rem;
+  --space-24: 6rem;
+
+  /* LAYOUT */
+  --content-width:      800px;
+  --content-width-wide: 1000px;
+  --nav-height:         50px;
+
+  /* RADII */
+  --radius-sm:   8px;
+  --radius-md:   12px;
+  --radius-lg:   16px;
+  --radius-full: 9999px;
+
+  /* SHADOWS (warm-tinted, never pure black) */
+  --shadow-sm: 0 1px 2px rgba(44,42,40,0.05);
+  --shadow-md: 0 4px 12px rgba(44,42,40,0.08);
+  --shadow-lg: 0 8px 24px rgba(44,42,40,0.10);
+  --shadow-xl: 0 16px 48px rgba(44,42,40,0.12);
+
+  /* EASING */
+  --ease-out:    cubic-bezier(0.16,1,0.3,1);
+  --ease-in-out: cubic-bezier(0.65,0,0.35,1);
+
+  /* DURATIONS */
+  --duration-fast:   150ms;
+  --duration-normal: 300ms;
+  --duration-slow:   500ms;
+  --stagger-delay:   120ms;
+}
+
+/* ── RESET & BASE ───────────────────────────────────────────── */
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+html {
+  scroll-snap-type: y proximity;
+  scroll-behavior: smooth;
+}
+
+body {
+  font-family: var(--font-body);
+  font-size: var(--text-base);
+  color: var(--color-text);
+  line-height: var(--leading-normal);
+  background: var(--color-bg);
+  background-image: radial-gradient(
+    ellipse at 20% 50%,
+    rgba(217,79,48,0.03) 0%,
+    transparent 50%
+  );
+}
+
+/* ── SCROLLBAR ──────────────────────────────────────────────── */
+::-webkit-scrollbar { width: 6px; }
+::-webkit-scrollbar-track { background: transparent; }
+::-webkit-scrollbar-thumb {
+  background: var(--color-border);
+  border-radius: var(--radius-full);
+}
+
+/* ── CODE GLOBALS ───────────────────────────────────────────── */
+pre, code {
+  white-space: pre-wrap;
+  word-break: break-word;
+  overflow-x: hidden;
+}
+.translation-code::-webkit-scrollbar,
+pre::-webkit-scrollbar { display: none; }
+
+/* Catppuccin-inspired syntax highlighting */
+.code-keyword  { color: #CBA6F7; }
+.code-string   { color: #A6E3A1; }
+.code-function { color: #89B4FA; }
+.code-comment  { color: #6C7086; }
+.code-number   { color: #FAB387; }
+.code-property { color: #F9E2AF; }
+.code-operator { color: #94E2D5; }
+.code-tag      { color: #F38BA8; }
+.code-attr     { color: #F9E2AF; }
+.code-value    { color: #A6E3A1; }
+.code-line     { display: block; }
+
+/* ── NAV ────────────────────────────────────────────────────── */
+.nav {
+  position: fixed;
+  top: 0; left: 0; right: 0;
+  height: var(--nav-height);
+  z-index: 1000;
+  background: rgba(250,247,242,0.92);
+  backdrop-filter: blur(8px);
+  border-bottom: 1px solid var(--color-border-light);
+}
+
+.progress-bar {
+  position: absolute;
+  bottom: 0; left: 0;
+  height: 2px;
+  width: 0%;
+  background: var(--color-accent);
+  transition: width 100ms linear;
+}
+
+.nav-inner {
+  max-width: var(--content-width-wide);
+  margin: 0 auto;
+  padding: 0 var(--space-6);
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-4);
+}
+
+.nav-title {
+  font-family: var(--font-display);
+  font-size: var(--text-sm);
+  font-weight: 600;
+  color: var(--color-text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 300px;
+}
+
+.nav-dots {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.nav-dot {
+  width: 10px; height: 10px;
+  border-radius: 50%;
+  border: 2px solid var(--color-text-muted);
+  background: transparent;
+  cursor: pointer;
+  transition: all var(--duration-fast);
+  position: relative;
+}
+.nav-dot::after {
+  content: attr(data-tooltip);
+  position: absolute;
+  top: calc(100% + 6px);
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--color-bg-code);
+  color: #CDD6F4;
+  font-family: var(--font-body);
+  font-size: var(--text-xs);
+  white-space: nowrap;
+  padding: var(--space-1) var(--space-3);
+  border-radius: var(--radius-sm);
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity var(--duration-fast);
+}
+.nav-dot:hover::after { opacity: 1; }
+.nav-dot.active {
+  border-color: var(--color-accent);
+  background: var(--color-accent);
+  box-shadow: 0 0 0 3px var(--color-accent-light);
+}
+.nav-dot.visited {
+  border-color: var(--color-accent-muted);
+  background: var(--color-accent-muted);
+}
+
+/* ── MODULE STRUCTURE ───────────────────────────────────────── */
+.module {
+  min-height: 100dvh;
+  min-height: 100vh;
+  scroll-snap-align: start;
+  padding: var(--space-16) var(--space-6);
+  padding-top: calc(var(--nav-height) + var(--space-12));
+}
+
+.module-content {
+  max-width: var(--content-width);
+  margin: 0 auto;
+}
+
+.module-header { margin-bottom: var(--space-12); }
+
+.module-number {
+  display: block;
+  font-family: var(--font-display);
+  font-size: var(--text-6xl);
+  font-weight: 800;
+  color: var(--color-accent);
+  opacity: 0.15;
+  line-height: 1;
+  margin-bottom: var(--space-2);
+}
+
+.module-title {
+  font-family: var(--font-display);
+  font-size: var(--text-4xl);
+  font-weight: 700;
+  line-height: var(--leading-tight);
+  color: var(--color-text);
+}
+
+.module-subtitle {
+  margin-top: var(--space-3);
+  font-size: var(--text-lg);
+  color: var(--color-text-secondary);
+  line-height: var(--leading-snug);
+}
+
+.screen {
+  margin-bottom: var(--space-16);
+}
+
+.screen-heading {
+  font-family: var(--font-display);
+  font-size: var(--text-2xl);
+  font-weight: 600;
+  color: var(--color-text);
+  margin-bottom: var(--space-6);
+  line-height: var(--leading-snug);
+}
+
+p { margin-bottom: var(--space-4); }
+p:last-child { margin-bottom: 0; }
+
+/* ── SCROLL ANIMATIONS ──────────────────────────────────────── */
+.animate-in {
+  opacity: 0;
+  transform: translateY(20px);
+  transition:
+    opacity var(--duration-slow) var(--ease-out),
+    transform var(--duration-slow) var(--ease-out);
+}
+.animate-in.visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+.stagger-children > .animate-in {
+  transition-delay: calc(var(--stagger-index, 0) * var(--stagger-delay));
+}
+
+/* ── TRANSLATION BLOCKS ─────────────────────────────────────── */
+.translation-block {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0;
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  box-shadow: var(--shadow-md);
+  margin: var(--space-8) 0;
+}
+
+.translation-code {
+  background: var(--color-bg-code);
+  color: #CDD6F4;
+  padding: var(--space-6);
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  line-height: 1.7;
+  position: relative;
+  overflow-x: hidden;
+}
+
+.translation-english {
+  background: var(--color-surface-warm);
+  padding: var(--space-6);
+  font-size: var(--text-sm);
+  line-height: 1.7;
+  border-left: 3px solid var(--color-accent);
+}
+
+.translation-label {
+  position: absolute;
+  top: var(--space-2);
+  right: var(--space-3);
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  opacity: 0.5;
+}
+.translation-english .translation-label {
+  position: static;
+  display: block;
+  margin-bottom: var(--space-3);
+  color: var(--color-text-muted);
+}
+
+.translation-lines .tl {
+  padding: var(--space-1) 0;
+  border-bottom: 1px solid var(--color-border-light);
+  color: var(--color-text-secondary);
+}
+.translation-lines .tl:last-child { border-bottom: none; }
+
+/* ── QUIZ ───────────────────────────────────────────────────── */
+.quiz-container {
+  background: var(--color-surface);
+  border-radius: var(--radius-lg);
+  padding: var(--space-8);
+  box-shadow: var(--shadow-md);
+  margin: var(--space-8) 0;
+}
+
+.quiz-question-block { margin-bottom: var(--space-8); }
+.quiz-question-block:last-of-type { margin-bottom: 0; }
+
+.quiz-question {
+  font-family: var(--font-display);
+  font-size: var(--text-lg);
+  font-weight: 600;
+  margin-bottom: var(--space-4);
+  line-height: var(--leading-snug);
+}
+
+.quiz-options {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.quiz-option {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-3) var(--space-4);
+  border: 2px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  background: var(--color-surface);
+  cursor: pointer;
+  width: 100%;
+  text-align: left;
+  font-family: var(--font-body);
+  font-size: var(--text-base);
+  transition: border-color var(--duration-fast), background var(--duration-fast);
+}
+.quiz-option:hover:not(:disabled) { border-color: var(--color-accent-muted); }
+.quiz-option.selected { border-color: var(--color-accent); background: var(--color-accent-light); }
+.quiz-option.correct  { border-color: var(--color-success); background: var(--color-success-light); }
+.quiz-option.incorrect{ border-color: var(--color-error);   background: var(--color-error-light); }
+.quiz-option:disabled { cursor: default; }
+
+.quiz-option-radio {
+  width: 18px; height: 18px;
+  border-radius: 50%;
+  border: 2px solid var(--color-border);
+  flex-shrink: 0;
+  transition: all var(--duration-fast);
+}
+.quiz-option.selected .quiz-option-radio {
+  border-color: var(--color-accent);
+  background: var(--color-accent);
+  box-shadow: inset 0 0 0 3px white;
+}
+.quiz-option.correct .quiz-option-radio  { border-color: var(--color-success); background: var(--color-success); box-shadow: inset 0 0 0 3px white; }
+.quiz-option.incorrect .quiz-option-radio{ border-color: var(--color-error);   background: var(--color-error);   box-shadow: inset 0 0 0 3px white; }
+
+.quiz-feedback {
+  max-height: 0;
+  overflow: hidden;
+  opacity: 0;
+  transition: max-height var(--duration-normal), opacity var(--duration-normal);
+  font-size: var(--text-sm);
+  border-radius: var(--radius-sm);
+}
+.quiz-feedback.show {
+  max-height: 200px;
+  opacity: 1;
+  padding: var(--space-3);
+  margin-top: var(--space-2);
+}
+.quiz-feedback.success { background: var(--color-success-light); color: var(--color-success); }
+.quiz-feedback.error   { background: var(--color-error-light);   color: var(--color-error); }
+.quiz-feedback.warning { background: var(--color-info-light);    color: var(--color-info); }
+
+.quiz-check-btn, .quiz-reset-btn {
+  margin-top: var(--space-6);
+  padding: var(--space-3) var(--space-6);
+  border-radius: var(--radius-sm);
+  font-family: var(--font-body);
+  font-size: var(--text-sm);
+  font-weight: 600;
+  cursor: pointer;
+  border: none;
+  transition: background var(--duration-fast), transform var(--duration-fast);
+}
+.quiz-check-btn {
+  background: var(--color-accent);
+  color: white;
+  margin-right: var(--space-3);
+}
+.quiz-check-btn:hover { background: var(--color-accent-hover); transform: translateY(-1px); }
+.quiz-reset-btn {
+  background: var(--color-surface);
+  color: var(--color-text-secondary);
+  border: 1px solid var(--color-border);
+}
+.quiz-reset-btn:hover { border-color: var(--color-accent-muted); }
+
+/* Scenario block */
+.scenario-block { margin-bottom: var(--space-6); }
+.scenario-context {
+  background: var(--color-info-light);
+  border-left: 3px solid var(--color-info);
+  border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
+  padding: var(--space-4);
+  margin-bottom: var(--space-4);
+}
+.scenario-label {
+  display: inline-block;
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--color-info);
+  margin-bottom: var(--space-2);
+}
+
+/* ── DRAG AND DROP ──────────────────────────────────────────── */
+.dnd-container { margin: var(--space-8) 0; }
+.dnd-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-3);
+  margin-bottom: var(--space-6);
+}
+.dnd-chip {
+  padding: var(--space-2) var(--space-4);
+  background: var(--color-accent);
+  color: white;
+  border-radius: var(--radius-full);
+  font-size: var(--text-sm);
+  font-weight: 600;
+  cursor: grab;
+  user-select: none;
+  transition: opacity var(--duration-fast), transform var(--duration-fast);
+}
+.dnd-chip:active { cursor: grabbing; transform: scale(1.05); }
+.dnd-chip.dragging { opacity: 0.4; }
+.dnd-chip.placed { opacity: 0.3; pointer-events: none; }
+
+.dnd-zones { display: flex; flex-direction: column; gap: var(--space-4); }
+.dnd-zone {
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  padding: var(--space-4);
+  background: var(--color-surface);
+}
+.dnd-zone-label { font-size: var(--text-sm); color: var(--color-text-secondary); margin-bottom: var(--space-3); }
+.dnd-zone-target {
+  min-height: 40px;
+  border: 2px dashed var(--color-border);
+  border-radius: var(--radius-sm);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: var(--text-sm);
+  color: var(--color-text-muted);
+  transition: border-color var(--duration-fast), background var(--duration-fast);
+}
+.dnd-zone-target.drag-over { border-color: var(--color-accent); background: var(--color-accent-light); }
+.dnd-zone-target.correct-placed { border-color: var(--color-success); background: var(--color-success-light); color: var(--color-success); font-weight: 600; }
+.dnd-zone-target.incorrect-placed{ border-color: var(--color-error); background: var(--color-error-light); }
+.touch-ghost {
+  padding: var(--space-2) var(--space-4);
+  background: var(--color-accent);
+  color: white;
+  border-radius: var(--radius-full);
+  font-size: var(--text-sm);
+  font-weight: 600;
+  opacity: 0.85;
+  pointer-events: none;
+}
+
+/* ── GROUP CHAT ─────────────────────────────────────────────── */
+.chat-window {
+  background: var(--color-surface);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-md);
+  overflow: hidden;
+  margin: var(--space-8) 0;
+}
+
+.chat-messages {
+  padding: var(--space-6);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+  min-height: 200px;
+}
+
+.chat-message {
+  display: flex;
+  align-items: flex-end;
+  gap: var(--space-3);
+  animation: fadeSlideUp 0.3s var(--ease-out);
+}
+
+.chat-avatar {
+  width: 36px; height: 36px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: var(--font-display);
+  font-size: var(--text-sm);
+  font-weight: 700;
+  color: white;
+  flex-shrink: 0;
+}
+
+.chat-bubble {
+  max-width: 75%;
+  background: var(--color-bg-warm);
+  border-radius: var(--radius-md) var(--radius-md) var(--radius-md) 4px;
+  padding: var(--space-3) var(--space-4);
+}
+
+.chat-sender {
+  display: block;
+  font-size: var(--text-xs);
+  font-weight: 700;
+  margin-bottom: var(--space-1);
+  font-family: var(--font-mono);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.chat-bubble p {
+  font-size: var(--text-sm);
+  margin: 0;
+  line-height: var(--leading-normal);
+}
+
+.chat-typing {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding: 0 var(--space-6) var(--space-4);
+}
+
+.chat-typing-dots {
+  display: flex;
+  gap: var(--space-1);
+  background: var(--color-bg-warm);
+  padding: var(--space-3) var(--space-4);
+  border-radius: var(--radius-md);
+}
+
+.typing-dot {
+  width: 8px; height: 8px;
+  border-radius: 50%;
+  background: var(--color-text-muted);
+  animation: typingBounce 1.4s infinite;
+}
+.typing-dot:nth-child(2) { animation-delay: 0.2s; }
+.typing-dot:nth-child(3) { animation-delay: 0.4s; }
+
+.chat-controls {
+  padding: var(--space-4) var(--space-6);
+  border-top: 1px solid var(--color-border-light);
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  background: var(--color-surface-warm);
+}
+.chat-progress {
+  margin-left: auto;
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
+  font-family: var(--font-mono);
+}
+
+/* ── FLOW / DATA FLOW ANIMATION ─────────────────────────────── */
+.flow-animation {
+  position: relative;
+  background: var(--color-surface);
+  border-radius: var(--radius-lg);
+  padding: var(--space-8);
+  box-shadow: var(--shadow-md);
+  margin: var(--space-8) 0;
+}
+
+.flow-actors {
+  display: flex;
+  justify-content: space-around;
+  align-items: center;
+  gap: var(--space-4);
+  margin-bottom: var(--space-8);
+  flex-wrap: wrap;
+}
+
+.flow-actor {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-2);
+  transition: all var(--duration-normal) var(--ease-out);
+}
+
+.flow-actor-icon {
+  width: 56px; height: 56px;
+  border-radius: var(--radius-md);
+  background: var(--color-bg-warm);
+  border: 2px solid var(--color-border);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: var(--font-display);
+  font-size: var(--text-xl);
+  font-weight: 700;
+  transition: all var(--duration-normal) var(--ease-out);
+}
+
+.flow-actor span {
+  font-size: var(--text-xs);
+  color: var(--color-text-secondary);
+  font-family: var(--font-mono);
+  text-align: center;
+}
+
+.flow-actor.active .flow-actor-icon {
+  border-color: var(--color-accent);
+  background: var(--color-accent-light);
+  box-shadow: 0 0 0 3px var(--color-accent-light), 0 0 20px rgba(217,79,48,0.15);
+  transform: scale(1.1);
+}
+
+.flow-packet {
+  width: 16px; height: 16px;
+  border-radius: 50%;
+  background: var(--color-accent);
+  position: absolute;
+  pointer-events: none;
+  display: none;
+  box-shadow: 0 0 8px rgba(217,79,48,0.5);
+}
+
+.flow-step-label {
+  text-align: center;
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+  min-height: 2.5em;
+  padding: var(--space-3) var(--space-4);
+  background: var(--color-bg-warm);
+  border-radius: var(--radius-sm);
+  margin-bottom: var(--space-6);
+  line-height: var(--leading-normal);
+}
+
+.flow-controls {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+}
+.flow-progress {
+  margin-left: auto;
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
+  font-family: var(--font-mono);
+}
+
+/* ── ARCHITECTURE DIAGRAM ───────────────────────────────────── */
+.arch-diagram {
+  background: var(--color-surface);
+  border-radius: var(--radius-lg);
+  padding: var(--space-8);
+  box-shadow: var(--shadow-md);
+  margin: var(--space-8) 0;
+}
+.arch-zone {
+  border: 1px dashed var(--color-border);
+  border-radius: var(--radius-md);
+  padding: var(--space-6);
+  margin-bottom: var(--space-4);
+}
+.arch-zone-label {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--color-text-muted);
+  margin-bottom: var(--space-4);
+}
+.arch-component {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-4);
+  background: var(--color-surface-warm);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  margin: var(--space-2);
+  transition: all var(--duration-fast);
+  font-size: var(--text-sm);
+}
+.arch-component:hover, .arch-component.active {
+  border-color: var(--color-accent);
+  background: var(--color-accent-light);
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-sm);
+}
+.arch-icon { font-size: 1.5rem; }
+.arch-description {
+  margin-top: var(--space-4);
+  padding: var(--space-4);
+  background: var(--color-bg-warm);
+  border-radius: var(--radius-sm);
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+  min-height: 2.5em;
+}
+
+/* ── LAYER TOGGLE ───────────────────────────────────────────── */
+.layer-demo { margin: var(--space-8) 0; }
+.layer-tabs {
+  display: flex;
+  gap: var(--space-2);
+  margin-bottom: var(--space-4);
+}
+.layer-tab {
+  padding: var(--space-2) var(--space-5);
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--color-border);
+  background: var(--color-surface);
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  cursor: pointer;
+  transition: all var(--duration-fast);
+}
+.layer-tab.active {
+  background: var(--color-accent);
+  color: white;
+  border-color: var(--color-accent);
+}
+.layer-viewport {
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  border: 1px solid var(--color-border);
+}
+.layer-description {
+  margin-top: var(--space-3);
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+}
+
+/* ── BUG CHALLENGE ──────────────────────────────────────────── */
+.bug-challenge {
+  background: var(--color-surface);
+  border-radius: var(--radius-lg);
+  padding: var(--space-8);
+  box-shadow: var(--shadow-md);
+  margin: var(--space-8) 0;
+}
+.bug-challenge h3 {
+  font-family: var(--font-display);
+  font-size: var(--text-lg);
+  font-weight: 600;
+  margin-bottom: var(--space-4);
+}
+.bug-code {
+  background: var(--color-bg-code);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  margin-bottom: var(--space-4);
+}
+.bug-line {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-2) var(--space-4);
+  cursor: pointer;
+  transition: background var(--duration-fast);
+}
+.bug-line:hover { background: rgba(255,255,255,0.05); }
+.bug-line.correct  { background: rgba(45,139,85,0.2); }
+.bug-line.incorrect{ background: rgba(201,59,59,0.2); }
+.line-num {
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  color: #6C7086;
+  min-width: 1.5em;
+  text-align: right;
+  user-select: none;
+}
+.bug-line code {
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  color: #CDD6F4;
+}
+.bug-feedback {
+  max-height: 0;
+  overflow: hidden;
+  opacity: 0;
+  transition: max-height var(--duration-normal), opacity var(--duration-normal);
+  font-size: var(--text-sm);
+  border-radius: var(--radius-sm);
+}
+.bug-feedback.show {
+  max-height: 200px;
+  opacity: 1;
+  padding: var(--space-3);
+}
+.bug-feedback.success { background: var(--color-success-light); color: var(--color-success); }
+.bug-feedback.error   { background: var(--color-error-light);   color: var(--color-error); }
+
+/* ── CALLOUT BOXES ──────────────────────────────────────────── */
+.callout {
+  display: flex;
+  gap: var(--space-4);
+  padding: var(--space-5);
+  border-radius: var(--radius-md);
+  margin: var(--space-6) 0;
+  border-left: 4px solid;
+}
+.callout-accent  { background: var(--color-accent-light);  border-color: var(--color-accent); }
+.callout-info    { background: var(--color-info-light);    border-color: var(--color-info); }
+.callout-warning { background: var(--color-error-light);   border-color: var(--color-error); }
+
+.callout-icon { font-size: 1.25rem; flex-shrink: 0; margin-top: 2px; }
+.callout-title { display: block; font-weight: 700; margin-bottom: var(--space-1); }
+.callout-content p { font-size: var(--text-sm); margin: 0; color: var(--color-text-secondary); }
+
+/* ── PATTERN / FEATURE CARDS ────────────────────────────────── */
+.pattern-cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: var(--space-4);
+  margin: var(--space-6) 0;
+}
+.pattern-card {
+  background: var(--color-surface);
+  border-radius: var(--radius-md);
+  padding: var(--space-6);
+  box-shadow: var(--shadow-sm);
+  border-top: 3px solid var(--color-accent);
+  transition: transform var(--duration-normal) var(--ease-out), box-shadow var(--duration-normal);
+}
+.pattern-card:hover { transform: translateY(-4px); box-shadow: var(--shadow-md); }
+.pattern-icon {
+  width: 40px; height: 40px;
+  border-radius: var(--radius-sm);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.1rem;
+  margin-bottom: var(--space-3);
+}
+.pattern-title {
+  font-family: var(--font-display);
+  font-size: var(--text-base);
+  font-weight: 700;
+  margin-bottom: var(--space-2);
+}
+.pattern-desc {
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+  line-height: var(--leading-normal);
+  margin: 0;
+}
+
+/* ── FLOW DIAGRAMS (static) ─────────────────────────────────── */
+.flow-steps {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  flex-wrap: wrap;
+  margin: var(--space-6) 0;
+}
+.flow-step {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-2);
+  text-align: center;
+}
+.flow-step-num {
+  width: 40px; height: 40px;
+  border-radius: 50%;
+  background: var(--color-accent);
+  color: white;
+  font-family: var(--font-display);
+  font-weight: 700;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.flow-step p { font-size: var(--text-sm); color: var(--color-text-secondary); max-width: 120px; margin: 0; }
+.flow-arrow {
+  font-size: var(--text-xl);
+  color: var(--color-text-muted);
+  flex-shrink: 0;
+}
+
+/* ── BADGE / CONFIG LIST ────────────────────────────────────── */
+.badge-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  margin: var(--space-6) 0;
+}
+.badge-item {
+  display: flex;
+  align-items: center;
+  gap: var(--space-4);
+  padding: var(--space-3) var(--space-4);
+  border: 1px solid var(--color-border-light);
+  border-radius: var(--radius-sm);
+  background: var(--color-surface);
+  transition: border-color var(--duration-fast);
+}
+.badge-item:hover { border-color: var(--color-accent-muted); }
+.badge-code {
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  background: var(--color-bg-code);
+  color: #CBA6F7;
+  padding: var(--space-1) var(--space-3);
+  border-radius: var(--radius-sm);
+  white-space: nowrap;
+}
+.badge-desc {
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+}
+
+/* ── GLOSSARY TOOLTIPS ──────────────────────────────────────── */
+.term {
+  border-bottom: 1.5px dashed var(--color-accent-muted);
+  cursor: pointer;
+}
+.term:hover, .term.active {
+  border-bottom-color: var(--color-accent);
+  color: var(--color-accent);
+}
+.term-tooltip {
+  position: fixed;
+  background: var(--color-bg-code);
+  color: #CDD6F4;
+  padding: var(--space-3) var(--space-4);
+  border-radius: var(--radius-sm);
+  font-size: var(--text-sm);
+  font-family: var(--font-body);
+  line-height: var(--leading-normal);
+  width: max(200px, min(320px, 80vw));
+  box-shadow: var(--shadow-lg);
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity var(--duration-fast);
+  z-index: 10000;
+}
+.term-tooltip::after {
+  content: '';
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  border: 6px solid transparent;
+  border-top-color: var(--color-bg-code);
+}
+.term-tooltip.visible { opacity: 1; }
+.term-tooltip.flip::after {
+  top: auto;
+  bottom: 100%;
+  border-top-color: transparent;
+  border-bottom-color: var(--color-bg-code);
+}
+
+/* ── VISUAL FILE TREE ───────────────────────────────────────── */
+.file-tree {
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  margin: var(--space-6) 0;
+}
+.ft-folder, .ft-file {
+  padding: var(--space-2) var(--space-3);
+  border-left: 2px solid var(--color-border-light);
+  margin-left: var(--space-4);
+}
+.ft-folder > .ft-name { color: var(--color-accent); font-weight: 600; }
+.ft-folder > .ft-name::before { content: '📁 '; }
+.ft-file > .ft-name::before { content: '📄 '; }
+.ft-desc {
+  color: var(--color-text-secondary);
+  font-family: var(--font-body);
+  margin-left: var(--space-2);
+  font-size: var(--text-xs);
+}
+.ft-children { margin-left: var(--space-4); }
+
+/* ── ICON-LABEL ROWS ────────────────────────────────────────── */
+.icon-rows {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+  margin: var(--space-6) 0;
+}
+.icon-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-4);
+  padding: var(--space-4);
+  background: var(--color-surface);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-sm);
+}
+.icon-row strong { display: block; font-weight: 600; }
+.icon-row p { margin: var(--space-1) 0 0; color: var(--color-text-secondary); font-size: var(--text-sm); }
+.icon-circle {
+  width: 48px; height: 48px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.25rem;
+  flex-shrink: 0;
+}
+
+/* ── NUMBERED STEP CARDS ────────────────────────────────────── */
+.step-cards {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  margin: var(--space-6) 0;
+}
+.step-card {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-4);
+  padding: var(--space-4) var(--space-5);
+  background: var(--color-surface);
+  border-radius: var(--radius-md);
+  border-left: 3px solid var(--color-accent);
+  box-shadow: var(--shadow-sm);
+}
+.step-num {
+  width: 32px; height: 32px;
+  border-radius: 50%;
+  background: var(--color-accent);
+  color: white;
+  font-weight: 700;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: var(--font-display);
+  flex-shrink: 0;
+}
+.step-body strong { display: block; font-weight: 600; margin-bottom: var(--space-1); }
+.step-body p { margin: 0; color: var(--color-text-secondary); font-size: var(--text-sm); }
+
+/* ── SHARED BUTTON STYLE ────────────────────────────────────── */
+.btn {
+  padding: var(--space-2) var(--space-5);
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--color-border);
+  background: var(--color-surface);
+  font-family: var(--font-body);
+  font-size: var(--text-sm);
+  font-weight: 600;
+  cursor: pointer;
+  transition: all var(--duration-fast);
+  color: var(--color-text-secondary);
+}
+.btn:hover { border-color: var(--color-accent-muted); color: var(--color-accent); }
+.btn-primary {
+  background: var(--color-accent);
+  color: white;
+  border-color: var(--color-accent);
+}
+.btn-primary:hover { background: var(--color-accent-hover); border-color: var(--color-accent-hover); color: white; }
+
+/* ── RESPONSIVE ─────────────────────────────────────────────── */
+@media (max-width: 768px) {
+  :root {
+    --text-4xl: 1.875rem;
+    --text-5xl: 2.25rem;
+    --text-6xl: 3rem;
+  }
+  .translation-block { grid-template-columns: 1fr; }
+  .translation-english { border-left: none; border-top: 3px solid var(--color-accent); }
+  .pattern-cards { grid-template-columns: 1fr 1fr; }
+}
+
+@media (max-width: 480px) {
+  :root {
+    --text-4xl: 1.5rem;
+    --text-5xl: 1.875rem;
+    --text-6xl: 2.25rem;
+  }
+  .module { padding: var(--space-8) var(--space-4); }
+  .pattern-cards { grid-template-columns: 1fr; }
+  .flow-steps { flex-direction: column; }
+  .flow-arrow { transform: rotate(90deg); }
+  .nav-title { max-width: 140px; }
+}
+
+/* ── KEYFRAMES ──────────────────────────────────────────────── */
+@keyframes fadeSlideUp {
+  from { opacity: 0; transform: translateY(12px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes typingBounce {
+  0%, 60%, 100% { transform: translateY(0); }
+  30%           { transform: translateY(-6px); }
+}
+
+@keyframes packetMove {
+  from { left: var(--packet-from-x); top: var(--packet-from-y); opacity: 0; }
+  20%  { opacity: 1; }
+  80%  { opacity: 1; }
+  to   { left: var(--packet-to-x);   top: var(--packet-to-y);   opacity: 0; }
+}


### PR DESCRIPTION
Two self-contained, interactive HTML courses generated from this codebase via the `codebase-to-course` skill — open `index.html` in either directory directly in a browser, no build step needed.

## `courses/general-course/` (7 modules)
Full-project walkthrough for non-technical "vibe coder" learners: the click-to-generation flow, the cast of actors, auth, payments/credits, database + external services (includes the Supabase project outage as a real "gotcha" teaching moment), i18n, and debugging.

## `courses/image-generator-ui-course/` (5 modules)
Tightly scoped to the AI image/video generator (`src/aisdk/`, Kling provider, OpenAI wiring) and the UI/design system (Shadcn components, Tailwind, form patterns). Distinct accent color from the general course.

Also adds `._*` (macOS AppleDouble resource-fork files) to `.gitignore`, generated incidentally by the course-writing agents' filesystem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)